### PR TITLE
Add checksum verification for ENSEMBL sequence and annotation wrappers

### DIFF
--- a/bio/reference/ensembl-annotation/meta.yaml
+++ b/bio/reference/ensembl-annotation/meta.yaml
@@ -1,4 +1,5 @@
 name: ensembl-annotation
-description: Download annotation of genomic sites (e.g. transcripts) from ENSEMBL FTP servers, and store them in a single .gtf or .gff3 file.
+description: Download annotation of genomic sites (e.g. transcripts) from ENSEMBL FTP servers, and store them in a single .gtf or .gff3 file. After download compare checksums with ENSEMBL FTP 'CHECKSUMS' file.
 authors:
   - Johannes Köster
+  - Fritjof Lammers

--- a/bio/reference/ensembl-annotation/test/Snakefile
+++ b/bio/reference/ensembl-annotation/test/Snakefile
@@ -1,6 +1,6 @@
 rule get_annotation:
     output:
-        "refs/annotation.gtf"
+        "refs/annotation.gtf.gz"
     params:
         species="homo_sapiens",
         release="98",

--- a/bio/reference/ensembl-annotation/wrapper.py
+++ b/bio/reference/ensembl-annotation/wrapper.py
@@ -2,6 +2,7 @@ __author__ = "Johannes Köster"
 __copyright__ = "Copyright 2019, Johannes Köster"
 __email__ = "johannes.koester@uni-due.de"
 __license__ = "MIT"
+__contributor__= "Johannes Köster, Fritjof Lammers"
 
 from ftplib import FTP
 from io import StringIO

--- a/bio/reference/ensembl-annotation/wrapper.py
+++ b/bio/reference/ensembl-annotation/wrapper.py
@@ -4,11 +4,26 @@ __email__ = "johannes.koester@uni-due.de"
 __license__ = "MIT"
 
 from ftplib import FTP
+from io import StringIO
+from subprocess import run
+from os.path import basename
 
 species = snakemake.params.species.lower()
 release = snakemake.params.release
 fmt = snakemake.params.fmt
 build = snakemake.params.build
+
+
+def parse_checksums():
+    lines = r.getvalue().strip().split("\n")
+    for line in lines:
+        fields = line.split()
+        yield {
+            "cksum": int(fields[0]),
+            "blksize": int(fields[1]),
+            "filename": fields[2]
+        }
+
 
 suffix = ""
 if fmt == "gtf":
@@ -16,8 +31,17 @@ if fmt == "gtf":
 elif fmt == "gff3":
     suffix = "gff3.gz"
 
+r = StringIO()
 
 with FTP("ftp.ensembl.org") as ftp, open(snakemake.output[0], "wb") as out:
+    print("starting download: pub/release-{release}/{fmt}/{species}/{species_cap}.{build}.{release}.{suffix}".format(
+        release=release,
+        build=build,
+        species=species,
+        fmt=fmt,
+        species_cap=species.capitalize(),
+        suffix=suffix,
+    ))
     ftp.login()
     ftp.retrbinary(
         "RETR pub/release-{release}/{fmt}/{species}/{species_cap}.{build}.{release}.{suffix}".format(
@@ -30,3 +54,31 @@ with FTP("ftp.ensembl.org") as ftp, open(snakemake.output[0], "wb") as out:
         ),
         out.write,
     )
+    ftp.retrlines(
+        "RETR pub/release-{release}/{fmt}/{species}/CHECKSUMS".format(
+            release=release,
+            build=build,
+            species=species,
+            fmt=fmt,
+            species_cap=species.capitalize(),
+            suffix=suffix,
+        ),
+        lambda s, w=r.write: w(s + '\n'),
+        # use StringIO instance for callback, add "\n" because ftplib.retrlines omits newlines
+    )
+
+for elem in parse_checksums():
+    if elem["filename"] == basename(snakemake.output[0]):
+        cksum_remote = elem["cksum"]
+        cksum_local = int(run(["sum", snakemake.output[0]], capture_output=True).stdout.strip().split()[0])
+        print(cksum_remote)
+        print(cksum_local)
+        if cksum_local == cksum_remote:
+            print("CHECKSUM OK: %s" % snakemake.output[0])
+            exit(0)
+        else:
+            print("CHECKSUM FAILED: %s" % snakemake.output[0])
+            exit(1)
+    else:
+        print("No matching file for CHECKSUM test found")
+        continue

--- a/bio/reference/ensembl-sequence/test/Snakefile
+++ b/bio/reference/ensembl-sequence/test/Snakefile
@@ -1,6 +1,6 @@
 rule get_sequence:
     output:
-        "refs/genome.fasta"
+        "refs/genome.fasta.gz"
     params:
         species="drosophila_melanogaster",
         datatype="dna",

--- a/bio/reference/ensembl-sequence/wrapper.py
+++ b/bio/reference/ensembl-sequence/wrapper.py
@@ -4,6 +4,9 @@ __email__ = "johannes.koester@uni-due.de"
 __license__ = "MIT"
 
 from ftplib import FTP
+from io import StringIO
+from subprocess import run
+from os.path import basename
 
 species = snakemake.params.species.lower()
 release = snakemake.params.release
@@ -11,6 +14,27 @@ build = snakemake.params.build
 
 suffixes = ""
 datatype = snakemake.params.get("datatype", "")
+
+
+def checksum():
+    lines = r.getvalue().strip().split("\n")
+    for line in lines:
+        fields = line.strip().split()
+        cksum = int(fields[0])
+        filename = fields[2]
+        if filename == basename(snakemake.output[0]):
+            cksum_local = int(run(["sum", snakemake.output[0]], capture_output=True).stdout.strip().split()[0])
+            if cksum_local == cksum:
+                print("CHECKSUM OK: %s" % snakemake.output[0])
+                exit(0)
+            else:
+                print("CHECKSUM FAILED: %s" % snakemake.output[0])
+                exit(1)
+        else:
+            # print("No matching file for CHECKSUM test found")
+            continue
+
+
 if datatype == "dna":
     suffixes = ["dna.primary_assembly.fa.gz", "dna.toplevel.fa.gz"]
 elif datatype == "cdna":
@@ -43,6 +67,19 @@ with FTP("ftp.ensembl.org") as ftp, open(snakemake.output[0], "wb") as out:
 
         ftp.retrbinary("RETR " + url, out.write)
         success = True
+        # retrieve CHECKSUMS file
+        r = StringIO()
+        ftp.retrlines(
+            "RETR pub/release-{release}/fasta/{species}/{datatype}/CHECKSUMS".format(
+                release=release,
+                species=species,
+                datatype=datatype
+            ),
+            lambda s, w=r.write: w(s + '\n'),
+        )
+        # use StringIO instance for callback, add "\n" because ftplib.retrlines omits newlines
+
+    checksum()
 
 if not success:
     raise ValueError(


### PR DESCRIPTION
- I've added a routine to compare checksums for downloaded files.  
- Output files in the test snakefiles are now ending with ".gz" to reflect the downloaded fileformat correctly. 

Ideally, the checksum() method I've added would be stored separately to avoid redundancy, but I believe this would break the ability of each wrapper to function stand-alone. If there is a way to import common libraries, please let me know. 