### PR TITLE
Added bcftools-norm wrapper

### DIFF
--- a/bio/bcftools/norm/environment.yaml
+++ b/bio/bcftools/norm/environment.yaml
@@ -1,0 +1,6 @@
+channels:
+  - bioconda
+  - conda-forge
+  - defaults
+dependencies:
+  - bcftools ==1.9

--- a/bio/bcftools/norm/meta.yaml
+++ b/bio/bcftools/norm/meta.yaml
@@ -1,0 +1,4 @@
+name: bcftools norm
+description: Left-align and normalize indels, check if REF alleles match the reference, split multiallelic sites into multiple rows; recover multiallelics from multiple rows.
+authors:
+  - Dayne Filer

--- a/bio/bcftools/norm/test/Snakefile
+++ b/bio/bcftools/norm/test/Snakefile
@@ -1,0 +1,9 @@
+rule norm_vcf:
+    input:
+        "{prefix}.vcf"
+    output:
+        "{prefix}.vcf"
+    params:
+        ""  # optional parameters for bcftools norm (except -o)
+    wrapper:
+        "master/bio/bcftools/norm"

--- a/bio/bcftools/norm/wrapper.py
+++ b/bio/bcftools/norm/wrapper.py
@@ -1,0 +1,12 @@
+__author__ = "Dayne Filer"
+__copyright__ = "Copyright 2019, Dayne Filer"
+__email__ = "dayne.filer@gmail.com"
+__license__ = "MIT"
+
+
+from snakemake.shell import shell
+
+
+shell(
+    "bcftools norm {snakemake.params} {snakemake.input[0]} " "-o {snakemake.output[0]}"
+)


### PR DESCRIPTION
Simply copied structure from existing bcftools-view. For future development, it might be nice to auto-detect the output format from 'output' and set the `-O` parameter accordingly. 