### PR TITLE
GTAK baserecalibrator dependency openjdk=8

### DIFF
--- a/bio/gatk/baserecalibrator/environment.yaml
+++ b/bio/gatk/baserecalibrator/environment.yaml
@@ -4,3 +4,4 @@ channels:
   - defaults
 dependencies:
   - gatk4 ==4.1.4.1
+  - openjdk =8


### PR DESCRIPTION
GATK baserecalibrator runs into a nullpointer-exception for java = 11. It is recommended to run GATK on java = 8