### PR TITLE
fasterq-dump: Allow setting the temporary directory via params

### DIFF
--- a/bio/sra-tools/fasterq-dump/wrapper.py
+++ b/bio/sra-tools/fasterq-dump/wrapper.py
@@ -20,4 +20,3 @@ with tempfile.TemporaryDirectory(dir=tmpdir) as tmp:
     shell(
         "fasterq-dump --temp {tmp} {extra} {outdir} {snakemake.wildcards.accession} {log}"
     )
-

--- a/bio/sra-tools/fasterq-dump/wrapper.py
+++ b/bio/sra-tools/fasterq-dump/wrapper.py
@@ -13,9 +13,11 @@ outdir = os.path.dirname(snakemake.output[0])
 if outdir:
     outdir = "--outdir {}".format(outdir)
 
+tmpdir = snakemake.params.get("tmpdir", None)
 extra = snakemake.params.get("extra", "")
 
-with tempfile.TemporaryDirectory() as tmp:
+with tempfile.TemporaryDirectory(dir=tmpdir) as tmp:
     shell(
         "fasterq-dump --temp {tmp} {extra} {outdir} {snakemake.wildcards.accession} {log}"
     )
+


### PR DESCRIPTION
Since downloaded files may be rather large and the default temporary directory location may not be large enough to contain them, it may sometimes be useful to be able to set a custom tempdir.