### PR TITLE
Modified snpeff call

### DIFF
--- a/bio/snpeff/wrapper.py
+++ b/bio/snpeff/wrapper.py
@@ -37,7 +37,7 @@ csvstats_opt = "" if not csvstats else "-csvStats {}".format(csvstats)
 stats_opt = "-noStats" if not stats else "-stats {}".format(stats)
 
 shell(
-    "{incalls} | snpEff {data_dir} {stats_opt} {csvstats_opt} {extra} "
-    "{snakemake.params.reference} "
+    "snpEff {data_dir} {stats_opt} {csvstats_opt} {extra} "
+    "{snakemake.params.reference} < {incalls} "
     "{outprefix} > {outcalls} {log}"
 )

--- a/bio/snpeff/wrapper.py
+++ b/bio/snpeff/wrapper.py
@@ -21,7 +21,7 @@ else:
 
 incalls = snakemake.input[0]
 if incalls.endswith(".bcf"):
-    incalls = "<(bcftools view {})".format(incalls)
+    incalls = "< <(bcftools view {})".format(incalls)
 
 log = snakemake.log_fmt_shell(stdout=False, stderr=True)
 
@@ -38,6 +38,6 @@ stats_opt = "-noStats" if not stats else "-stats {}".format(stats)
 
 shell(
     "snpEff {data_dir} {stats_opt} {csvstats_opt} {extra} "
-    "{snakemake.params.reference} < {incalls} "
+    "{snakemake.params.reference} {incalls} "
     "{outprefix} > {outcalls} {log}"
 )

--- a/bio/snpeff/wrapper.py
+++ b/bio/snpeff/wrapper.py
@@ -37,7 +37,7 @@ csvstats_opt = "" if not csvstats else "-csvStats {}".format(csvstats)
 stats_opt = "-noStats" if not stats else "-stats {}".format(stats)
 
 shell(
-    "snpEff {data_dir} {stats_opt} {csvstats_opt} {extra} "
-    "{snakemake.params.reference} {incalls} "
+    "{incalls} | snpEff {data_dir} {stats_opt} {csvstats_opt} {extra} "
+    "{snakemake.params.reference} "
     "{outprefix} > {outcalls} {log}"
 )


### PR DESCRIPTION
This PR fixes an error where snpeff fails with the following input error: `Error:  Cannot read input file '/dev/fd/63'`.
This is resolved by adding a directed-pipe.