### PR TITLE
Add min version and threads for fasterq-dump

### DIFF
--- a/bio/sra-tools/fasterq-dump/environment.yaml
+++ b/bio/sra-tools/fasterq-dump/environment.yaml
@@ -2,4 +2,4 @@ channels:
   - bioconda
   - conda-forge
 dependencies:
-  - sra-tools =2.*
+  - sra-tools >2.9.1

--- a/bio/sra-tools/fasterq-dump/meta.yaml
+++ b/bio/sra-tools/fasterq-dump/meta.yaml
@@ -2,3 +2,4 @@ name: sra-tools fasterq-dump
 description: Download FASTQ files from SRA.
 authors:
   - Johannes Köster
+  - Derek Croote

--- a/bio/sra-tools/fasterq-dump/test/Snakefile
+++ b/bio/sra-tools/fasterq-dump/test/Snakefile
@@ -6,6 +6,7 @@ rule get_fastq_pe:
     params:
         # optional extra arguments
         extra=""
+    threads: 6  # defaults to 6
     wrapper:
         "master/bio/sra-tools/fasterq-dump"
 
@@ -15,5 +16,6 @@ rule get_fastq_se:
         "data/{accession}.fastq"
     params:
         extra=""
+    threads: 6
     wrapper:
         "master/bio/sra-tools/fasterq-dump"

--- a/bio/sra-tools/fasterq-dump/wrapper.py
+++ b/bio/sra-tools/fasterq-dump/wrapper.py
@@ -1,4 +1,4 @@
-__author__ = "Johannes Köster"
+__author__ = "Johannes Köster, Derek Croote"
 __copyright__ = "Copyright 2020, Johannes Köster"
 __email__ = "johannes.koester@uni-due.de"
 __license__ = "MIT"
@@ -17,5 +17,6 @@ extra = snakemake.params.get("extra", "")
 
 with tempfile.TemporaryDirectory() as tmp:
     shell(
-        "fasterq-dump --temp {tmp} {extra} {outdir} {snakemake.wildcards.accession} {log}"
+        "fasterq-dump --temp {tmp} --threads {snakemake.threads} "
+        "{extra} {outdir} {snakemake.wildcards.accession} {log}"
     )


### PR DESCRIPTION
This PR:

1. Adds a `sra-tools` minimum version to guarantee `fasterq-dump` is included in the bioconda install.
2. Adds `--threads` to `fasterq-dump`