### PR TITLE
Refinement of sed call for freebayes

### DIFF
--- a/bio/freebayes/environment.yaml
+++ b/bio/freebayes/environment.yaml
@@ -6,3 +6,4 @@ dependencies:
   - bcftools ==1.10
   - parallel ==20190522
   - bedtools >=2.29
+  - sed ==4.7

--- a/bio/freebayes/test/Snakefile_bed
+++ b/bio/freebayes/test/Snakefile_bed
@@ -15,4 +15,4 @@ rule freebayes:
         chunksize=100000  # reference genome chunk size for parallelization (default: 100000)
     threads: 2
     wrapper:
-        "master/bio/freebayes"
+        "file:../"

--- a/bio/freebayes/test/Snakefile_bed
+++ b/bio/freebayes/test/Snakefile_bed
@@ -15,4 +15,4 @@ rule freebayes:
         chunksize=100000  # reference genome chunk size for parallelization (default: 100000)
     threads: 2
     wrapper:
-        "file:../"
+        "master/bio/freebayes"

--- a/bio/freebayes/wrapper.py
+++ b/bio/freebayes/wrapper.py
@@ -27,9 +27,9 @@ else:
     if snakemake.input.get("regions", ""):
         regions = (
             "<(bedtools intersect -a "
-            "<(sed 's/:\([0-9]*\)-\([0-9]*\)$/\\t\\1\\t\\2/g' "
+            r"<(sed 's/:\([0-9]*\)-\([0-9]*\)$/\t\1\t\2/g' "
             "{regions}) -b {snakemake.input.regions} | "
-            'sed "s/\\t\([0-9]*\)\\t\([0-9]*\)$/:\\1-\\2/g")'
+            r"sed 's/\t\([0-9]*\)\t\([0-9]*\)$/:\1-\2/g')"
         ).format(regions=regions, snakemake=snakemake)
     freebayes = ("freebayes-parallel {regions} {snakemake.threads}").format(
         snakemake=snakemake, regions=regions

--- a/bio/freebayes/wrapper.py
+++ b/bio/freebayes/wrapper.py
@@ -23,7 +23,6 @@ else:
     regions = "<(fasta_generate_regions.py {snakemake.input.ref}.fai {chunksize})".format(
         snakemake=snakemake, chunksize=chunksize
     )
-    # sed command needs to be improved
     if snakemake.input.get("regions", ""):
         regions = (
             "<(bedtools intersect -a "

--- a/bio/freebayes/wrapper.py
+++ b/bio/freebayes/wrapper.py
@@ -27,9 +27,9 @@ else:
     if snakemake.input.get("regions", ""):
         regions = (
             "<(bedtools intersect -a "
-            r"<(sed 's/:\([0-9]*\)-\([0-9]*\)$/\t\1\t\2/g' "
+            r"<(sed 's/:\([0-9]*\)-\([0-9]*\)$/\t\1\t\2/' "
             "{regions}) -b {snakemake.input.regions} | "
-            r"sed 's/\t\([0-9]*\)\t\([0-9]*\)$/:\1-\2/g')"
+            r"sed 's/\t\([0-9]*\)\t\([0-9]*\)$/:\1-\2/')"
         ).format(regions=regions, snakemake=snakemake)
     freebayes = ("freebayes-parallel {regions} {snakemake.threads}").format(
         snakemake=snakemake, regions=regions

--- a/bio/freebayes/wrapper.py
+++ b/bio/freebayes/wrapper.py
@@ -27,9 +27,9 @@ else:
     if snakemake.input.get("regions", ""):
         regions = (
             "<(bedtools intersect -a "
-            "<(sed \"s/:\([0-9]*\)-\([0-9]*\)$/$(printf '\\t')\\1$(printf '\\t')\\2/g\" "
+            "<(sed 's/:\([0-9]*\)-\([0-9]*\)$/\\t\\1\\t\\2/g' "
             "{regions}) -b {snakemake.input.regions} | "
-            "sed \"s/$(printf '\\t')\([0-9]*\)$(printf '\\t')\([0-9]*\)$/:\\1-\\2/g\")"
+            'sed "s/\\t\([0-9]*\)\\t\([0-9]*\)$/:\\1-\\2/g")'
         ).format(regions=regions, snakemake=snakemake)
     freebayes = ("freebayes-parallel {regions} {snakemake.threads}").format(
         snakemake=snakemake, regions=regions

--- a/bio/freebayes/wrapper.py
+++ b/bio/freebayes/wrapper.py
@@ -23,6 +23,7 @@ else:
     regions = "<(fasta_generate_regions.py {snakemake.input.ref}.fai {chunksize})".format(
         snakemake=snakemake, chunksize=chunksize
     )
+    # sed command needs to be improved
     if snakemake.input.get("regions", ""):
         regions = (
             "<(bedtools intersect -a "


### PR DESCRIPTION
As the current freebayes wrapper builds a not-so-nice sed command this PR aims for refactoring.

The main difficulty is not parsing the command by python but to replace the regex by a valid one being correctly interpreted by sed.

The current sed comment for replacing colons and hyphens by tabs looks as following (without separating the chromosome name):
`sed "s/:\([0-9]*\)-\([0-9]*\)$/$(printf '\t')\1$(printf '\t')\2/g"`

For testing I propose the minimal example:
`echo "MT0:1-AB:10-100" | sed "s/:\([0-9]*\)-\([0-9]*\)$/$(printf '\t')\1$(printf '\t')\2/g"`
The result should be `MT0:1-AB	10	100`