### PR TITLE
Fix variation download wrapper

### DIFF
--- a/bio/reference/ensembl-variation/test/Snakefile
+++ b/bio/reference/ensembl-variation/test/Snakefile
@@ -1,7 +1,8 @@
 rule get_variation:
     output:
         vcf="refs/variation.vcf.gz"
-        # optional: add fai to get VCF with annotated contig lengths (as required by GATK)
+        # Optional: add fai to get VCF with annotated contig lengths (as required by GATK)
+        # and properly sorted VCFs.
         # fai="refs/genome.fasta.fai"
     params:
         species="saccharomyces_cerevisiae",

--- a/bio/reference/ensembl-variation/wrapper.py
+++ b/bio/reference/ensembl-variation/wrapper.py
@@ -74,11 +74,13 @@ try:
         if snakemake.input.get("fai"):
             # reheader, adding sequence lenghts
             shell(
-                "bcftools reheader --fai {snakemake.input.fai} {tmpdir}/out.vcf.gz > {snakemake.output} 2>> {log}"
+                "(bcftools reheader --fai {snakemake.input.fai} {tmpdir}/out.vcf.gz | bcftools sort -Oz - > {snakemake.output}) 2>> {log}"
             )
         else:
             # just move to final place
-            shell("mv {tmpdir}/out.vcf.gz {snakemake.output}")
+            shell(
+                "bcftools sort -Oz {tmpdir}/out.vcf.gz > {snakemake.output} 2>> {log}"
+            )
 except subprocess.CalledProcessError as e:
     if snakemake.log:
         sys.stderr = open(snakemake.log[0], "a")

--- a/bio/reference/ensembl-variation/wrapper.py
+++ b/bio/reference/ensembl-variation/wrapper.py
@@ -72,12 +72,12 @@ try:
             shell("(cd {tmpdir} && bcftools view -Oz {names} > out.vcf.gz) 2>> {log}")
 
         if snakemake.input.get("fai"):
-            # reheader, adding sequence lenghts
+            # reheader, adding sequence lenghts and sort
             shell(
                 "(bcftools reheader --fai {snakemake.input.fai} {tmpdir}/out.vcf.gz | bcftools sort -Oz - > {snakemake.output}) 2>> {log}"
             )
         else:
-            # just move to final place
+            # just sort into final place
             shell(
                 "bcftools sort -Oz {tmpdir}/out.vcf.gz > {snakemake.output} 2>> {log}"
             )

--- a/bio/reference/ensembl-variation/wrapper.py
+++ b/bio/reference/ensembl-variation/wrapper.py
@@ -6,6 +6,7 @@ __license__ = "MIT"
 import tempfile
 import subprocess
 import sys
+import os
 from snakemake.shell import shell
 from snakemake.exceptions import WorkflowError
 

--- a/bio/reference/ensembl-variation/wrapper.py
+++ b/bio/reference/ensembl-variation/wrapper.py
@@ -77,10 +77,8 @@ try:
                 "(bcftools reheader --fai {snakemake.input.fai} {tmpdir}/out.vcf.gz | bcftools sort -Oz - > {snakemake.output}) 2>> {log}"
             )
         else:
-            # just sort into final place
-            shell(
-                "bcftools sort -Oz {tmpdir}/out.vcf.gz > {snakemake.output} 2>> {log}"
-            )
+            # just move into final place
+            shell("mv {tmpdir}/out.vcf.gz {snakemake.output}")
 except subprocess.CalledProcessError as e:
     if snakemake.log:
         sys.stderr = open(snakemake.log[0], "a")

--- a/bio/reference/ensembl-variation/wrapper.py
+++ b/bio/reference/ensembl-variation/wrapper.py
@@ -69,10 +69,12 @@ try:
         else:
             # recompress with bgzip
             shell("(cd {tmpdir} && bcftools view -Oz {names} > out.vcf.gz) 2>> {log}")
-        
+
         if snakemake.input.get("fai"):
             # reheader, adding sequence lenghts
-            shell("bcftools reheader --fai {snakemake.input.fai} {tmpdir}/out.vcf.gz > {snakemake.output} 2>> {log}")
+            shell(
+                "bcftools reheader --fai {snakemake.input.fai} {tmpdir}/out.vcf.gz > {snakemake.output} 2>> {log}"
+            )
         else:
             # just move to final place
             shell("mv {tmpdir}/out.vcf.gz {snakemake.output}")


### PR DESCRIPTION
Apartently both b(g)zip format as well as tabix indices in ensembl archives can be problematic, at least with older releases. These changes try to work around the issues, by explicitly downloading and recompressing vcf files.