### PR TITLE
fix gdc api token reading

### DIFF
--- a/bio/gdc-api/bam-slicing/wrapper.py
+++ b/bio/gdc-api/bam-slicing/wrapper.py
@@ -17,7 +17,7 @@ if token_file == "":
     raise ValueError(
         "You need to provide a GDC data access token file via the 'token' in 'params'."
     )
-token=""
+token = ""
 with open(token_file) as tf:
     token = tf.read()
 os.environ["CURL_HEADER_TOKEN"] = "'X-Auth-Token: {}'".format(token)

--- a/bio/gdc-api/bam-slicing/wrapper.py
+++ b/bio/gdc-api/bam-slicing/wrapper.py
@@ -4,7 +4,7 @@ __email__ = "david.laehnemann@uni-due.de"
 __license__ = "MIT"
 
 from snakemake.shell import shell
-import os.path as path
+import os
 
 log = snakemake.log_fmt_shell(stdout=True, stderr=True)
 
@@ -17,8 +17,10 @@ if token_file == "":
     raise ValueError(
         "You need to provide a GDC data access token file via the 'token' in 'params'."
     )
+token=""
 with open(token_file) as tf:
     token = tf.read()
+os.environ["CURL_HEADER_TOKEN"] = "'X-Auth-Token: {}'".format(token)
 
 slices = snakemake.params.get("slices", "")
 if slices == "":
@@ -30,13 +32,13 @@ extra = snakemake.params.get("extra", "")
 
 shell(
     "curl --silent"
-    " --header 'X-Auth-Token: {token}'"
+    " --header $CURL_HEADER_TOKEN"
     " 'https://api.gdc.cancer.gov/slicing/view/{uuid}?{slices}'"
     " {extra}"
     " --output {snakemake.output.bam} {log}"
 )
 
-if path.getsize(snakemake.output.bam) < 100000:
+if os.path.getsize(snakemake.output.bam) < 100000:
     with open(snakemake.output.bam) as f:
         if "error" in f.read():
             shell("cat {snakemake.output.bam} {log}")

--- a/bio/gdc-api/bam-slicing/wrapper.py
+++ b/bio/gdc-api/bam-slicing/wrapper.py
@@ -18,7 +18,7 @@ if token_file == "":
         "You need to provide a GDC data access token file via the 'token' in 'params'."
     )
 with open(token_file) as tf:
-    token=tf.read()
+    token = tf.read()
 
 slices = snakemake.params.get("slices", "")
 if slices == "":

--- a/bio/gdc-api/bam-slicing/wrapper.py
+++ b/bio/gdc-api/bam-slicing/wrapper.py
@@ -12,11 +12,13 @@ uuid = snakemake.params.get("uuid", "")
 if uuid == "":
     raise ValueError("You need to provide a GDC UUID via the 'uuid' in 'params'.")
 
-token = snakemake.params.get("gdc_token", "")
-if token == "":
+token_file = snakemake.params.get("gdc_token", "")
+if token_file == "":
     raise ValueError(
-        "You need to provide a GDC data access token via the 'token' in 'params'."
+        "You need to provide a GDC data access token file via the 'token' in 'params'."
     )
+with open(token_file) as tf:
+    token=tf.read()
 
 slices = snakemake.params.get("slices", "")
 if slices == "":


### PR DESCRIPTION
With not being able to use a genuine token, the test didn't catch this -- the token has to pasted verbatim into the API request being made.
But as far as I can see, this does not pose the risk of exposing the token via snakemake logs, as the exact command being run is hidden behind the temporary `wrapper.py` in the `.snakemake/log` files. But @johanneskoester, if you see any possibility of the token being put somewhere where users might (accidentally) make it publicly available, please do say! We definitely don't want this as a side-effect, also not in any future versions of snakemake (e.g. if there are any plans of putting the temporary wrapper.py contents in the log eventually).