### PR TITLE
include BAM indexes BAI as freebayes required input

### DIFF
--- a/bio/freebayes/test/Snakefile
+++ b/bio/freebayes/test/Snakefile
@@ -2,7 +2,9 @@ rule freebayes:
     input:
         ref="genome.fasta",
         # you can have a list of samples here
-        samples="mapped/{sample}.bam"
+        samples="mapped/{sample}.bam",
+        # the matching BAI indexes have to present for freebayes
+        indexes="mapped/{sample}.bam.bai"
         # optional BED file specifying chromosomal regions on which freebayes 
         # should run, e.g. all regions that show coverage
         #regions="/path/to/region-file.bed"


### PR DESCRIPTION
In my local pipeline, with BAMs covering only one chromosome, freebayes failed to recompute indexes on the fly. So it seems like the BAI files should be required input alongside the BAM files. As these are easily and quickly generated with another wrapper and aren't very big, it is in any case cleaner to have them generated once and then lying around next to the BAMs---this way, whenever they are needed with an index again (e.g. delly), it's there.