### PR TITLE
Improved exclusion handling

### DIFF
--- a/bio/delly/wrapper.py
+++ b/bio/delly/wrapper.py
@@ -7,7 +7,9 @@ __license__ = "MIT"
 from snakemake.shell import shell
 
 
-exclude = "-x {}".format(snakemake.input.exlude) if snakemake.input.get("exlude", "") else ""
+exclude = (
+    "-x {}".format(snakemake.input.exlude) if snakemake.input.get("exlude", "") else ""
+)
 
 extra = snakemake.params.get("extra", "")
 log = snakemake.log_fmt_shell(stdout=True, stderr=True)

--- a/bio/delly/wrapper.py
+++ b/bio/delly/wrapper.py
@@ -7,11 +7,7 @@ __license__ = "MIT"
 from snakemake.shell import shell
 
 
-try:
-    exclude = "-x " + snakemake.input.exclude
-except AttributeError:
-    exclude = ""
-
+exclude = "-x {}".format(snakemake.input.exlude) if snakemake.input.get("exlude", "") else ""
 
 extra = snakemake.params.get("extra", "")
 log = snakemake.log_fmt_shell(stdout=True, stderr=True)


### PR DESCRIPTION
Previously, the keyword `exclude` must not be part of the input if no region should be excluded.
Now the keyword can existing, containing an empty string in which case still no region gets excluded.