### PR TITLE
Updated wrapper for pTrimmer v1.3.2

### DIFF
--- a/bio/ptrimmer/environment.yaml
+++ b/bio/ptrimmer/environment.yaml
@@ -2,4 +2,4 @@ channels:
   - bioconda
   - conda-forge
 dependencies:
-  - ptrimmer ==1.3.1
+  - ptrimmer ==1.3.2

--- a/bio/ptrimmer/wrapper.py
+++ b/bio/ptrimmer/wrapper.py
@@ -29,13 +29,13 @@ ptrimmer_params = "-t {mode} {in_reads} -a {primers} {out_reads}".format(
 )
 
 process_r1 = "mv {out_read} {final_output_path}".format(
-    out_read={out_r1}, final_output_path=snakemake.output.r1
+    out_read=out_r1, final_output_path=snakemake.output.r1
 )
 
 process_r2 = ""
 if snakemake.input.get("r2", ""):
     process_r2 = "&& mv {out_read} {final_output_path}".format(
-        out_read={out_r2}, final_output_path=snakemake.output.r2
+        out_read=out_r2, final_output_path=snakemake.output.r2
     )
 
 shell("(ptrimmer {ptrimmer_params} && {process_r1} {process_r2}) {log}")

--- a/bio/ptrimmer/wrapper.py
+++ b/bio/ptrimmer/wrapper.py
@@ -22,7 +22,6 @@ else:
 
 primers = snakemake.params.primers
 
-outdir = Path(snakemake.output[0]).parent.resolve()
 log = snakemake.log_fmt_shell(stdout=True, stderr=True)
 
 ptrimmer_params = "-s {mode} {in_reads} -a {primers} {out_reads}".format(

--- a/bio/ptrimmer/wrapper.py
+++ b/bio/ptrimmer/wrapper.py
@@ -24,7 +24,7 @@ primers = snakemake.params.primers
 
 log = snakemake.log_fmt_shell(stdout=True, stderr=True)
 
-ptrimmer_params = "-s {mode} {in_reads} -a {primers} {out_reads}".format(
+ptrimmer_params = "-s {mode} {in_reads} -t {primers} {out_reads}".format(
     mode=seqmode, in_reads=input_reads, primers=primers, out_reads=output_reads
 )
 

--- a/bio/ptrimmer/wrapper.py
+++ b/bio/ptrimmer/wrapper.py
@@ -16,7 +16,7 @@ if snakemake.input.get("r2", ""):
     seqmode = "pair"
     input_reads = "{reads} -r {r2}".format(reads=input_reads, r2=snakemake.input.r2)
     out_r2 = ntpath.basename(snakemake.output.r2)
-    output_reads = "{reads} -d {o2}".format(o2=out_r2)
+    output_reads = "{reads} -e {o2}".format(o2=out_r2)
 else:
     seqmode = "single"
 

--- a/bio/ptrimmer/wrapper.py
+++ b/bio/ptrimmer/wrapper.py
@@ -7,42 +7,36 @@ from snakemake.shell import shell
 from pathlib import Path
 import ntpath
 
-reads = "-f {r1}".format(r1=snakemake.input.r1)
-read_prefix = ntpath.basename(snakemake.input.r1).split("_R1")[0]
-intermediate_output_r1 = snakemake.output.r1.strip(".gz")
+input_reads = "-f {r1}".format(r1=snakemake.input.r1)
+
+out_r1 = os.path.basename(snakemake.output.r1)
+output_reads = "-d {o1}".format(o1=out_r1)
 
 if snakemake.input.get("r2", ""):
     seqmode = "pair"
-    reads = "{reads} -r {r2}".format(reads=reads, r2=snakemake.input.r2)
-    intermediate_output_r2 = snakemake.output.r2.strip(".gz")
+    input_reads = "{reads} -r {r2}".format(reads=input_reads, r2=snakemake.input.r2)
+    out_r2 = os.path.basename(snakemake.output.r2)
+    output_reads = "{reads} -d {o2}".format(o2=out_r2)
 else:
     seqmode = "single"
 
 primers = snakemake.params.primers
+
 outdir = Path(snakemake.output[0]).parent.resolve()
 log = snakemake.log_fmt_shell(stdout=True, stderr=True)
 
-
-ptrimmer_params = "-s {mode} {reads} -a {primers} -o {out}".format(
-    mode=seqmode, reads=reads, primers=primers, out=outdir
+ptrimmer_params = "-s {mode} {in_reads} -a {primers} {out_reads}".format(
+    mode=seqmode, in_reads=input_reads, primers=primers, out_reads=output_reads 
 )
 
-process_r1 = "mv {outdir}/{prefix}_trim_R1.fq {out}".format(
-    outdir=outdir, prefix=read_prefix, out=intermediate_output_r1
+process_r1 = "mv {out_read} {final_output_path}".format(
+    out_read={out_r1}, final_output_path=snakemake.output.r1
 )
-if snakemake.output.r1.endswith(".gz"):
-    process_r1 = "{process_r1} && gzip -9 {out}".format(
-        process_r1=process_r1, out=intermediate_output_r1
-    )
 
 process_r2 = ""
 if snakemake.input.get("r2", ""):
-    process_r2 = "&& mv {outdir}/{prefix}_trim_R2.fq {out}".format(
-        outdir=outdir, prefix=read_prefix, out=intermediate_output_r2
-    )
-    if snakemake.output.r2.endswith(".gz"):
-        process_r2 = "{process_r2} && gzip -9 {out}".format(
-            process_r2=process_r2, out=intermediate_output_r2
-        )
+    process_r2 = "&& mv {out_read} {final_output_path}".format(
+    out_read={out_r2}, final_output_path=snakemake.output.r2
+)
 
 shell("(ptrimmer {ptrimmer_params} && {process_r1} {process_r2}) {log}")

--- a/bio/ptrimmer/wrapper.py
+++ b/bio/ptrimmer/wrapper.py
@@ -26,7 +26,7 @@ outdir = Path(snakemake.output[0]).parent.resolve()
 log = snakemake.log_fmt_shell(stdout=True, stderr=True)
 
 ptrimmer_params = "-s {mode} {in_reads} -a {primers} {out_reads}".format(
-    mode=seqmode, in_reads=input_reads, primers=primers, out_reads=output_reads 
+    mode=seqmode, in_reads=input_reads, primers=primers, out_reads=output_reads
 )
 
 process_r1 = "mv {out_read} {final_output_path}".format(
@@ -36,7 +36,7 @@ process_r1 = "mv {out_read} {final_output_path}".format(
 process_r2 = ""
 if snakemake.input.get("r2", ""):
     process_r2 = "&& mv {out_read} {final_output_path}".format(
-    out_read={out_r2}, final_output_path=snakemake.output.r2
-)
+        out_read={out_r2}, final_output_path=snakemake.output.r2
+    )
 
 shell("(ptrimmer {ptrimmer_params} && {process_r1} {process_r2}) {log}")

--- a/bio/ptrimmer/wrapper.py
+++ b/bio/ptrimmer/wrapper.py
@@ -24,7 +24,7 @@ primers = snakemake.params.primers
 
 log = snakemake.log_fmt_shell(stdout=True, stderr=True)
 
-ptrimmer_params = "-s {mode} {in_reads} -t {primers} {out_reads}".format(
+ptrimmer_params = "-t {mode} {in_reads} -a {primers} {out_reads}".format(
     mode=seqmode, in_reads=input_reads, primers=primers, out_reads=output_reads
 )
 

--- a/bio/ptrimmer/wrapper.py
+++ b/bio/ptrimmer/wrapper.py
@@ -9,13 +9,13 @@ import ntpath
 
 input_reads = "-f {r1}".format(r1=snakemake.input.r1)
 
-out_r1 = ntpath.path.basename(snakemake.output.r1)
+out_r1 = ntpath.basename(snakemake.output.r1)
 output_reads = "-d {o1}".format(o1=out_r1)
 
 if snakemake.input.get("r2", ""):
     seqmode = "pair"
     input_reads = "{reads} -r {r2}".format(reads=input_reads, r2=snakemake.input.r2)
-    out_r2 = ntpath.path.basename(snakemake.output.r2)
+    out_r2 = ntpath.basename(snakemake.output.r2)
     output_reads = "{reads} -d {o2}".format(o2=out_r2)
 else:
     seqmode = "single"

--- a/bio/ptrimmer/wrapper.py
+++ b/bio/ptrimmer/wrapper.py
@@ -16,7 +16,7 @@ if snakemake.input.get("r2", ""):
     seqmode = "pair"
     input_reads = "{reads} -r {r2}".format(reads=input_reads, r2=snakemake.input.r2)
     out_r2 = ntpath.basename(snakemake.output.r2)
-    output_reads = "{reads} -e {o2}".format(o2=out_r2)
+    output_reads = "{reads} -e {o2}".format(reads=output_reads, o2=out_r2)
 else:
     seqmode = "single"
 

--- a/bio/ptrimmer/wrapper.py
+++ b/bio/ptrimmer/wrapper.py
@@ -5,18 +5,17 @@ __license__ = "MIT"
 
 from snakemake.shell import shell
 from pathlib import Path
-import os
 import ntpath
 
 input_reads = "-f {r1}".format(r1=snakemake.input.r1)
 
-out_r1 = os.path.basename(snakemake.output.r1)
+out_r1 = ntpath.path.basename(snakemake.output.r1)
 output_reads = "-d {o1}".format(o1=out_r1)
 
 if snakemake.input.get("r2", ""):
     seqmode = "pair"
     input_reads = "{reads} -r {r2}".format(reads=input_reads, r2=snakemake.input.r2)
-    out_r2 = os.path.basename(snakemake.output.r2)
+    out_r2 = ntpath.path.basename(snakemake.output.r2)
     output_reads = "{reads} -d {o2}".format(o2=out_r2)
 else:
     seqmode = "single"

--- a/bio/ptrimmer/wrapper.py
+++ b/bio/ptrimmer/wrapper.py
@@ -5,6 +5,7 @@ __license__ = "MIT"
 
 from snakemake.shell import shell
 from pathlib import Path
+import os
 import ntpath
 
 input_reads = "-f {r1}".format(r1=snakemake.input.r1)


### PR DESCRIPTION
This updates the wrapper to pTrimmer 1.3.2.
As the latest version of pTrimmer has replaced the output-folder argument by output file arguments these have been replaced.
Moreover pTrimmer now automatically identifies if the output files contain a gz-extension so creating an archive not required anymore.
Nevertheless, pTrimmer can not handle file-paths for output files. Which is why the wrapper must strip the filename from the output and move the resulting files to the final output directory.