### PR TITLE
Update pTrimmer

### DIFF
--- a/bio/ptrimmer/environment.yaml
+++ b/bio/ptrimmer/environment.yaml
@@ -2,4 +2,4 @@ channels:
   - bioconda
   - conda-forge
 dependencies:
-  - ptrimmer ==1.3.2
+  - ptrimmer ==1.3.3

--- a/bio/ptrimmer/test/Snakefile
+++ b/bio/ptrimmer/test/Snakefile
@@ -1,12 +1,11 @@
 rule ptrimmer_pe:
     input:
         r1="resources/a.lane1_R1.fastq.gz",
-        r2="resources/a.lane1_R2.fastq.gz"
+        r2="resources/a.lane1_R2.fastq.gz",
+        primers="resources/primers.txt"
     output:
         r1="results/a.lane1_R1.fq.gz",
         r2="results/a.lane1_R2.fq.gz"
-    params:
-        primers="resources/primers.txt"
     log:
         "logs/ptrimmer/a.lane.log"
     wrapper:
@@ -15,10 +14,9 @@ rule ptrimmer_pe:
 rule ptrimmer_se:
     input:
         r1="resources/a.lane1_R1.fastq.gz",
+        primers="resources/primers.txt"
     output:
         r1="results/a.lane1_R1.fq",
-    params:
-        primers="resources/primers.txt"
     log:
         "logs/ptrimmer/a.lane1.log"
     wrapper:

--- a/bio/ptrimmer/wrapper.py
+++ b/bio/ptrimmer/wrapper.py
@@ -20,7 +20,7 @@ if snakemake.input.get("r2", ""):
 else:
     seqmode = "single"
 
-primers = snakemake.params.primers
+primers = snakemake.input.primers
 
 log = snakemake.log_fmt_shell(stdout=True, stderr=True)
 


### PR DESCRIPTION
Just pushes pTrimmer to version 1.3.3 enabling macOS support.
Additionally primers are moved to input as this may be required by some workflows.