### PR TITLE
MultiQC updated to 1.9

### DIFF
--- a/bio/multiqc/environment.yaml
+++ b/bio/multiqc/environment.yaml
@@ -3,4 +3,4 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - multiqc ==1.8
+  - multiqc ==1.9


### PR DESCRIPTION
Latest MultiQC release is 1.9 (https://github.com/ewels/MultiQC/releases) it includes new features and bug fixes in existing modules, especially proper handling of fastqc reports for empty bam files.