### PR TITLE
DeepVariant fixed

### DIFF
--- a/bio/deepvariant/environment.yaml
+++ b/bio/deepvariant/environment.yaml
@@ -3,4 +3,5 @@ channels:
   - bioconda
 dependencies:
   - deepvariant=0.10.0
-  - unzip
+  - tensorflow-estimator=2.0.0
+  - unzip=6.0

--- a/test.py
+++ b/test.py
@@ -393,6 +393,13 @@ def test_cutadapt_se():
     )
 
 
+def test_deepvariant():
+    run(
+        "bio/deepvariant",
+        ["snakemake", "--cores", "1", "calls/a.vcf.gz", "--use-conda", "-F"],
+    )
+
+
 def test_epic_peaks():
     run(
         "bio/epic/peaks",


### PR DESCRIPTION
DeepVariant's bioconda package installs tensorflow-estimator dependently, but the DeepVariant wrapper now fails to import tensorflow because "the conda-forge tensorflow-estimator" was updated a few days ago. I had to explicitly specify a version of tensorflow-estimator to solve this.