### PR TITLE
Optitype - generalized output directory

### DIFF
--- a/bio/optitype/test/Snakefile
+++ b/bio/optitype/test/Snakefile
@@ -13,6 +13,5 @@ rule optitype:
         config="",
         # additional parameters
         extra=""
-    threads: 4
     wrapper:
         "master/bio/optitype"

--- a/bio/optitype/wrapper.py
+++ b/bio/optitype/wrapper.py
@@ -9,7 +9,7 @@ from snakemake.shell import shell
 
 extra = snakemake.params.get("extra", "")
 log = snakemake.log_fmt_shell(stdout=True, stderr=True)
-outdir = "optitype"  # os.path.dirname(snakemake.output[0])
+outdir = os.path.dirname(snakemake.output[0])
 
 # get sequencing type
 seq_type = snakemake.params.get("sequencing_type", "dna")

--- a/test.py
+++ b/test.py
@@ -77,6 +77,7 @@ def run(wrapper, cmd, check_log=None):
             # go back to original directory
             os.chdir(origdir)
 
+
 def test_shovill():
     run(
         "bio/shovill",
@@ -283,6 +284,8 @@ def test_bwa_index():
         "bio/bwa/index",
         [
             "snakemake",
+            "--cores",
+            "1",
             "genome.amb",
             "genome.ann",
             "genome.bwt",
@@ -405,6 +408,8 @@ def test_fastp_pe():
         "bio/fastp",
         [
             "snakemake",
+            "--cores",
+            "1",
             "trimmed/pe/a.1.fastq",
             "trimmed/pe/a.2.fastq",
             "report/pe/a.html",
@@ -420,6 +425,8 @@ def test_fastp_pe_wo_trimming():
         "bio/fastp",
         [
             "snakemake",
+            "--cores",
+            "1",
             "report/pe_wo_trimming/a.html",
             "report/pe_wo_trimming/a.json",
             "--use-conda",
@@ -433,6 +440,8 @@ def test_fastp_se():
         "bio/fastp",
         [
             "snakemake",
+            "--cores",
+            "1",
             "trimmed/se/a.fastq",
             "report/se/a.html",
             "report/se/a.json",
@@ -468,6 +477,8 @@ def test_fgbio_collectduplexseqmetrics():
         "bio/fgbio/collectduplexseqmetrics",
         [
             "snakemake",
+            "--cores",
+            "1",
             "stats/a.family_sizes.txt",
             "stats/a.duplex_family_sizes.txt",
             "stats/a.duplex_yield_metrics.txt",
@@ -685,6 +696,8 @@ def test_nanosimh():
         "bio/nanosim-h",
         [
             "snakemake",
+            "--cores",
+            "1",
             "test.simulated.fa",
             "test.simulated.log",
             "test.simulated.errors.txt",


### PR DESCRIPTION
Fix for OptiType wrapper to infer the output dir from the path of the output files.