### PR TITLE
Quote input/output files in fastqc wrapper

### DIFF
--- a/bio/fastqc/wrapper.py
+++ b/bio/fastqc/wrapper.py
@@ -30,8 +30,8 @@ def basename_without_ext(file_path):
 with TemporaryDirectory() as tempdir:
     shell(
         "fastqc {snakemake.params} --quiet -t {snakemake.threads} "
-        "--outdir {tempdir} {snakemake.input[0]}"
-        " {log}"
+        "--outdir {tempdir:q} {snakemake.input[0]:q}"
+        " {log:q}"
     )
 
     # Move outputs into proper position.
@@ -40,7 +40,7 @@ with TemporaryDirectory() as tempdir:
     zip_path = path.join(tempdir, output_base + "_fastqc.zip")
 
     if snakemake.output.html != html_path:
-        shell("mv {html_path} {snakemake.output.html}")
+        shell("mv {html_path:q} {snakemake.output.html:q}")
 
     if snakemake.output.zip != zip_path:
-        shell("mv {zip_path} {snakemake.output.zip}")
+        shell("mv {zip_path:q} {snakemake.output.zip:q}")


### PR DESCRIPTION
Quote input and output files to ensure the wrapper works when used with
files that contain spaces in the name