### PR TITLE
Update for Wrapper Picard CollectMultipleMetrics

### DIFF
--- a/bio/picard/collectmultiplemetrics/meta.yaml
+++ b/bio/picard/collectmultiplemetrics/meta.yaml
@@ -4,8 +4,11 @@ description: >
   For usage information about CollectMultipleMetrics, please see  ``picard``'s `documentation <https://broadinstitute.github.io/picard/command-line-overview.html#CollectMultipleMetrics>`_.
   For more information about ``picard``, also see the `source code <https://github.com/broadinstitute/picard>`_.
 
+
+  You can select which tool(s) to run by adding the respective extension(s) (see table below) to the requested output of the wrapper invocation (see example Snakemake rule below).
+
     +-----------------------------------+-----------------------------------------+
-    |               Tools               |     Extensions for the output files     |
+    |               Tool                |    Extension(s) for the output files    |
     +===================================+=========================================+
     | CollectAlignmentSummaryMetrics    | ".alignment_summary_metrics"            |
     +-----------------------------------+-----------------------------------------+

--- a/bio/picard/collectmultiplemetrics/meta.yaml
+++ b/bio/picard/collectmultiplemetrics/meta.yaml
@@ -3,6 +3,37 @@ description: >
   A ``picard`` meta-metrics tool that collects multiple classes of metrics.
   For usage information about CollectMultipleMetrics, please see  ``picard``'s `documentation <https://broadinstitute.github.io/picard/command-line-overview.html#CollectMultipleMetrics>`_.
   For more information about ``picard``, also see the `source code <https://github.com/broadinstitute/picard>`_.
+  +-----------------------------------+-----------------------------------------+
+  |               tools               |     extensions for the output files     |
+  +===================================+=========================================+
+  | CollectAlignmentSummaryMetrics    | ".alignment_summary_metrics"            |
+  +-----------------------------------+-----------------------------------------+
+  | CollectInsertSizeMetrics          | ".insert_size_metrics",                 |
+  |                                   | ".insert_size_histogram.pdf"            |
+  +-----------------------------------+-----------------------------------------+
+  | QualityScoreDistribution          | ".quality_distribution_metrics",        |
+  |                                   | ".quality_distribution.pdf"             |
+  +-----------------------------------+-----------------------------------------+
+  | MeanQualityByCycle                | ".quality_by_cycle_metrics",            |
+  |                                   | ".quality_by_cycle.pdf"                 |
+  +-----------------------------------+-----------------------------------------+
+  | CollectBaseDistributionByCycle    | ".base_distribution_by_cycle_metrics",  |
+  |                                   | ".base_distribution_by_cycle.pdf"       |
+  +-----------------------------------+-----------------------------------------+
+  |                                   | ".gc_bias.detail_metrics",              |
+  | CollectGcBiasMetrics              | ".gc_bias.summary_metrics",              |
+  |                                   | ".gc_bias.pdf"                          |
+  +-----------------------------------+-----------------------------------------+
+  | RnaSeqMetrics                     | ".rna_metrics"                          |
+  +-----------------------------------+-----------------------------------------+
+  |                                   | ".bait_bias_detail_metrics",            |
+  |                                   | ".bait_bias_summary_metrics",           |
+  | CollectSequencingArtifactMetrics  | ".error_summary_metrics",               |
+  |                                   | ".pre_adapter_detail_metrics",          |
+  |                                   | ".pre_adapter_summary_metrics"          |
+  +-----------------------------------+-----------------------------------------+
+  | CollectQualityYieldMetrics        | ".quality_yield_metrics"                |
+  +-----------------------------------+-----------------------------------------+
 authors:
   - David Laehnemann
   - Antonie Vietor
@@ -13,34 +44,3 @@ output:
   - multiple metrics text files (_metrics) AND
   - multiple metrics pdf files (.pdf)
   - the appropriate extensions for the output files must be used depending on the desired tools
-    +-----------------------------------+-----------------------------------------+
-    |               tools               |     extensions for the output files     |
-    +===================================+=========================================+
-    | CollectAlignmentSummaryMetrics    | ".alignment_summary_metrics"            |
-    +-----------------------------------+-----------------------------------------+
-    | CollectInsertSizeMetrics          | ".insert_size_metrics",                 |
-    |                                   | ".insert_size_histogram.pdf"            |
-    +-----------------------------------+-----------------------------------------+
-    | QualityScoreDistribution          | ".quality_distribution_metrics",        |
-    |                                   | ".quality_distribution.pdf"             |
-    +-----------------------------------+-----------------------------------------+
-    | MeanQualityByCycle                | ".quality_by_cycle_metrics",            |
-    |                                   | ".quality_by_cycle.pdf"                 |
-    +-----------------------------------+-----------------------------------------+
-    | CollectBaseDistributionByCycle    | ".base_distribution_by_cycle_metrics",  |
-    |                                   | ".base_distribution_by_cycle.pdf"       |
-    +-----------------------------------+-----------------------------------------+
-    |                                   | ".gc_bias.detail_metrics",              |
-    | CollectGcBiasMetrics              | ".gc_bias.summary_metrics"              |
-    |                                   | ".gc_bias.pdf"                          |
-    +-----------------------------------+-----------------------------------------+
-    | RnaSeqMetrics                     | ".rna_metrics"                          |
-    +-----------------------------------+-----------------------------------------+
-    |                                   | ".bait_bias_detail_metrics",            |
-    |                                   | ".bait_bias_summary_metrics",           |
-    | CollectSequencingArtifactMetrics  | ".error_summary_metrics",               |
-    |                                   | ".pre_adapter_detail_metrics",          |
-    |                                   | ".pre_adapter_summary_metrics"          |
-    +-----------------------------------+-----------------------------------------+
-    | CollectQualityYieldMetrics        | ".quality_yield_metrics"                |
-    +-----------------------------------+-----------------------------------------+

--- a/bio/picard/collectmultiplemetrics/meta.yaml
+++ b/bio/picard/collectmultiplemetrics/meta.yaml
@@ -3,37 +3,49 @@ description: >
   A ``picard`` meta-metrics tool that collects multiple classes of metrics.
   For usage information about CollectMultipleMetrics, please see  ``picard``'s `documentation <https://broadinstitute.github.io/picard/command-line-overview.html#CollectMultipleMetrics>`_.
   For more information about ``picard``, also see the `source code <https://github.com/broadinstitute/picard>`_.
-  +-----------------------------------+-----------------------------------------+
-  |               tools               |     extensions for the output files     |
-  +===================================+=========================================+
-  | CollectAlignmentSummaryMetrics    | ".alignment_summary_metrics"            |
-  +-----------------------------------+-----------------------------------------+
-  | CollectInsertSizeMetrics          | ".insert_size_metrics",                 |
-  |                                   | ".insert_size_histogram.pdf"            |
-  +-----------------------------------+-----------------------------------------+
-  | QualityScoreDistribution          | ".quality_distribution_metrics",        |
-  |                                   | ".quality_distribution.pdf"             |
-  +-----------------------------------+-----------------------------------------+
-  | MeanQualityByCycle                | ".quality_by_cycle_metrics",            |
-  |                                   | ".quality_by_cycle.pdf"                 |
-  +-----------------------------------+-----------------------------------------+
-  | CollectBaseDistributionByCycle    | ".base_distribution_by_cycle_metrics",  |
-  |                                   | ".base_distribution_by_cycle.pdf"       |
-  +-----------------------------------+-----------------------------------------+
-  |                                   | ".gc_bias.detail_metrics",              |
-  | CollectGcBiasMetrics              | ".gc_bias.summary_metrics",              |
-  |                                   | ".gc_bias.pdf"                          |
-  +-----------------------------------+-----------------------------------------+
-  | RnaSeqMetrics                     | ".rna_metrics"                          |
-  +-----------------------------------+-----------------------------------------+
-  |                                   | ".bait_bias_detail_metrics",            |
-  |                                   | ".bait_bias_summary_metrics",           |
-  | CollectSequencingArtifactMetrics  | ".error_summary_metrics",               |
-  |                                   | ".pre_adapter_detail_metrics",          |
-  |                                   | ".pre_adapter_summary_metrics"          |
-  +-----------------------------------+-----------------------------------------+
-  | CollectQualityYieldMetrics        | ".quality_yield_metrics"                |
-  +-----------------------------------+-----------------------------------------+
+
+    +-----------------------------------+-----------------------------------------+
+    |               Tools               |     Extensions for the output files     |
+    +===================================+=========================================+
+    | CollectAlignmentSummaryMetrics    | ".alignment_summary_metrics"            |
+    +-----------------------------------+-----------------------------------------+
+    | CollectInsertSizeMetrics          | ".insert_size_metrics",                 |
+    |                                   |                                         |
+    |                                   | ".insert_size_histogram.pdf"            |
+    +-----------------------------------+-----------------------------------------+
+    | QualityScoreDistribution          | ".quality_distribution_metrics",        |
+    |                                   |                                         |
+    |                                   | ".quality_distribution.pdf"             |
+    +-----------------------------------+-----------------------------------------+
+    | MeanQualityByCycle                | ".quality_by_cycle_metrics",            |
+    |                                   |                                         |
+    |                                   | ".quality_by_cycle.pdf"                 |
+    +-----------------------------------+-----------------------------------------+
+    | CollectBaseDistributionByCycle    | ".base_distribution_by_cycle_metrics",  |
+    |                                   |                                         |
+    |                                   | ".base_distribution_by_cycle.pdf"       |
+    +-----------------------------------+-----------------------------------------+
+    | CollectGcBiasMetrics              | ".gc_bias.detail_metrics",              |
+    |                                   |                                         |
+    |                                   | ".gc_bias.summary_metrics",             |
+    |                                   |                                         |
+    |                                   | ".gc_bias.pdf"                          |
+    +-----------------------------------+-----------------------------------------+
+    | RnaSeqMetrics                     | ".rna_metrics"                          |
+    +-----------------------------------+-----------------------------------------+
+    | CollectSequencingArtifactMetrics  | ".bait_bias_detail_metrics",            |
+    |                                   |                                         |
+    |                                   | ".bait_bias_summary_metrics",           |
+    |                                   |                                         |
+    |                                   | ".error_summary_metrics",               |
+    |                                   |                                         |
+    |                                   | ".pre_adapter_detail_metrics",          |
+    |                                   |                                         |
+    |                                   | ".pre_adapter_summary_metrics"          |
+    +-----------------------------------+-----------------------------------------+
+    | CollectQualityYieldMetrics        | ".quality_yield_metrics"                |
+    +-----------------------------------+-----------------------------------------+
+
 authors:
   - David Laehnemann
   - Antonie Vietor

--- a/bio/picard/collectmultiplemetrics/wrapper.py
+++ b/bio/picard/collectmultiplemetrics/wrapper.py
@@ -12,56 +12,45 @@ res = snakemake.resources.get("mem_gb", "3")
 if not res or res is None:
     res = 3
 
+exts_to_prog = {
+    ".alignment_summary_metrics": "CollectAlignmentSummaryMetrics",
+    ".insert_size_metrics": "CollectInsertSizeMetrics",
+    ".insert_size_histogram.pdf": "CollectInsertSizeMetrics",
+    ".quality_distribution_metrics": "QualityScoreDistribution",
+    ".quality_distribution.pdf": "QualityScoreDistribution",
+    ".quality_by_cycle_metrics": "MeanQualityByCycle",
+    ".quality_by_cycle.pdf": "MeanQualityByCycle",
+    ".base_distribution_by_cycle_metrics": "CollectBaseDistributionByCycle",
+    ".base_distribution_by_cycle.pdf": "CollectBaseDistributionByCycle",
+    ".gc_bias.detail_metrics": "CollectGcBiasMetrics",
+    ".gc_bias.summary_metrics": "CollectGcBiasMetrics",
+    ".gc_bias.pdf": "CollectGcBiasMetrics",
+    ".rna_metrics": "RnaSeqMetrics",
+    ".bait_bias_detail_metrics": "CollectSequencingArtifactMetrics",
+    ".bait_bias_summary_metrics": "CollectSequencingArtifactMetrics",
+    ".error_summary_metrics": "CollectSequencingArtifactMetrics",
+    ".pre_adapter_detail_metrics": "CollectSequencingArtifactMetrics",
+    ".pre_adapter_summary_metrics": "CollectSequencingArtifactMetrics",
+    ".quality_yield_metrics": "CollectQualityYieldMetrics",
+}
 progs = set()
-extensions = set()
 
 for file in snakemake.output:
-    if "alignment_summary" in file:
-        progs.add("CollectAlignmentSummaryMetrics ")
-        extensions.add(".alignment_summary_metrics")
-    elif "insert_size" in file:
-        progs.add("CollectInsertSizeMetrics ")
-        extensions.add(".insert_size_metrics")
-        extensions.add(".insert_size_histogram.pdf")
-    elif "quality_distribution" in file:
-        progs.add("QualityScoreDistribution ")
-        extensions.add(".quality_distribution_metrics")
-        extensions.add(".quality_distribution.pdf")
-    elif "quality_by_cycle" in file:
-        progs.add("MeanQualityByCycle ")
-        extensions.add(".quality_by_cycle_metrics")
-        extensions.add(".quality_by_cycle.pdf")
-    elif "base_distribution_by_cycle" in file:
-        progs.add("CollectBaseDistributionByCycle ")
-        extensions.add(".base_distribution_by_cycle_metrics")
-        extensions.add(".base_distribution_by_cycle.pdf")
-    elif "gc_bias" in file:
-        progs.add("CollectGcBiasMetrics ")
-        extensions.add(".gc_bias.detail_metrics")
-        extensions.add(".gc_bias.summary_metrics")
-        extensions.add(".gc_bias.pdf")
-    elif "rna_metrics" in file:
-        progs.add("RnaSeqMetrics ")
-        extensions.add(".rna_metrics")
-    elif "bait_bias" in file or "error_summary" in file or "pre_adapter" in file:
-        progs.add("CollectSequencingArtifactMetrics ")
-        extensions.add(".bait_bias_detail_metrics")
-        extensions.add(".bait_bias_summary_metrics")
-        extensions.add(".error_summary_metrics")
-        extensions.add(".pre_adapter_detail_metrics")
-        extensions.add(".pre_adapter_summary_metrics")
-    elif "quality_yield" in file:
-        progs.add("CollectQualityYieldMetrics ")
-        extensions.add(".quality_yield_metrics")
-    else:
+    matched = False
+    for ext in exts_to_prog:
+        if file.endswith(ext):
+            progs.add(exts_to_prog[ext])
+            matched = True
+    if not matched:
         sys.exit(
             "Unknown type of metrics file requested, for possible metrics files, see https://snakemake-wrappers.readthedocs.io/en/stable/wrappers/picard/collectmultiplemetrics.html"
         )
-programs = " PROGRAM=" + "PROGRAM=".join(progs)
+
+programs = " PROGRAM=" + " PROGRAM=".join(progs)
 
 out = str(snakemake.wildcards.sample)  # as default
 output_file = str(snakemake.output[0])
-for ext in extensions:
+for ext in exts_to_prog:
     if ext in output_file:
         if output_file.endswith(ext):
             out = output_file[: -len(ext)]

--- a/bio/picard/collectmultiplemetrics/wrapper.py
+++ b/bio/picard/collectmultiplemetrics/wrapper.py
@@ -51,10 +51,9 @@ programs = " PROGRAM=" + " PROGRAM=".join(progs)
 out = str(snakemake.wildcards.sample)  # as default
 output_file = str(snakemake.output[0])
 for ext in exts_to_prog:
-    if ext in output_file:
-        if output_file.endswith(ext):
-            out = output_file[: -len(ext)]
-            break
+    if output_file.endswith(ext):
+        out = output_file[: -len(ext)]
+        break
 
 shell(
     "(picard -Xmx{res}g CollectMultipleMetrics "


### PR DESCRIPTION
@dlaehnemann : An update for picard's CollectMultipleMetrics wrapper. As you suggested the extensions were created as dict in the wrapper and now match to the full extension at the end of a path. The table for assigning tools to their extensions moved to description in meta.yaml file and has received some design changes.