### PR TITLE
Fix normal bam accession in wrapper

### DIFF
--- a/bio/strelka/somatic/wrapper.py
+++ b/bio/strelka/somatic/wrapper.py
@@ -20,7 +20,7 @@ run_extra = snakemake.params.get("run_extra", "")
 # tests on file existance.
 normal = (
     "--normalBam {}".format(snakemake.input["normal"])
-    if "normalBam" in snakemake.input.keys()
+    if "normal" in snakemake.input.keys()
     else ""
 )
 


### PR DESCRIPTION
See title. Wrapper looked for "normalBam" in `snakemake.input.keys()`, but the key is called "normal".