### PR TITLE
Specified input call to bam field

### DIFF
--- a/bio/homer/makeTagDirectory/wrapper.py
+++ b/bio/homer/makeTagDirectory/wrapper.py
@@ -11,5 +11,9 @@ extra = snakemake.params.get("extra", "")
 log = snakemake.log_fmt_shell(stdout=True, stderr=True)
 
 shell(
-    "(makeTagDirectory" " {snakemake.output}" " {extra}" " {snakemake.input})" " {log}"
+    "(makeTagDirectory"
+    " {snakemake.output}"
+    " {extra}"
+    " {snakemake.input.bam})"
+    " {log}"
 )


### PR DESCRIPTION
Use the desired input field ("bam") in the shell command instead of the compete `{snakemake.input}`.