### PR TITLE
add bcftools mpileup wrapper

### DIFF
--- a/bio/bcftools/mpileup/environment.yaml
+++ b/bio/bcftools/mpileup/environment.yaml
@@ -1,0 +1,5 @@
+channels:
+  - bioconda
+  - conda-forge
+dependencies:
+  - bcftools ==1.10

--- a/bio/bcftools/mpileup/meta.yaml
+++ b/bio/bcftools/mpileup/meta.yaml
@@ -1,0 +1,4 @@
+name: bcftools mpileup
+description: Generate VCF or BCF containing genotype likelihoods for one or multiple alignment (BAM or CRAM) files with `bcftools mpileup <https://samtools.github.io/bcftools/bcftools.html#mpileup>`_.
+authors:
+  - Michael Hall

--- a/bio/bcftools/mpileup/test/Snakefile
+++ b/bio/bcftools/mpileup/test/Snakefile
@@ -1,0 +1,13 @@
+rule bcftools_mpileup:
+    input:
+        index="genome.fasta.fai",
+        ref="genome.fasta", # this can be left out if --no-reference is in options
+        alignments="mapped/{sample}.bam",
+    output:
+        pileup="pileups/{sample}.pileup.bcf",
+    params:
+        options="--max-depth 100 --min-BQ 15",
+    log:
+        "logs/bcftools_mpileup/{sample}.log",
+    wrapper:
+        "master/bio/bcftools/mpileup"

--- a/bio/bcftools/mpileup/test/genome.fasta
+++ b/bio/bcftools/mpileup/test/genome.fasta
@@ -1,0 +1,1 @@
+../../../samtools/mpileup/test/genome.fasta

--- a/bio/bcftools/mpileup/test/genome.fasta.fai
+++ b/bio/bcftools/mpileup/test/genome.fasta.fai
@@ -1,0 +1,1 @@
+../../../samtools/mpileup/test/genome.fasta.fai

--- a/bio/bcftools/mpileup/test/mapped
+++ b/bio/bcftools/mpileup/test/mapped
@@ -1,0 +1,1 @@
+../../../samtools/mpileup/test/mapped

--- a/bio/bcftools/mpileup/wrapper.py
+++ b/bio/bcftools/mpileup/wrapper.py
@@ -23,9 +23,8 @@ if "--no-reference" not in options:
         )
     options += " --fasta-ref {}".format(ref)
 
-options += " --threads {}".format(snakemake.threads)
-
 shell(
-    "bcftools mpileup {options} --output {snakemake.output.pileup} "
+    "bcftools mpileup {options} --threads {snakemake.threads} "
+    "--output {snakemake.output.pileup} "
     "{snakemake.input.alignments} 2> {snakemake.log}"
 )

--- a/bio/bcftools/mpileup/wrapper.py
+++ b/bio/bcftools/mpileup/wrapper.py
@@ -1,0 +1,31 @@
+__author__ = "Michael Hall"
+__copyright__ = "Copyright 2020, Michael Hall"
+__email__ = "michael@mbh.sh"
+__license__ = "MIT"
+
+
+from snakemake.shell import shell
+
+
+class MissingReferenceError(Exception):
+    pass
+
+
+options = snakemake.params.get("options", "")
+
+# determine if a fasta reference is provided or not and add to options
+if "--no-reference" not in options:
+    ref = snakemake.input.get("ref", "")
+    if not ref:
+        raise MissingReferenceError(
+            "The --no-reference option was not given, but no fasta reference was "
+            "provided."
+        )
+    options += " --fasta-ref {}".format(ref)
+
+options += " --threads {}".format(snakemake.threads)
+
+shell(
+    "bcftools mpileup {options} --output {snakemake.output.pileup} "
+    "{snakemake.input.alignments} 2> {snakemake.log}"
+)

--- a/test.py
+++ b/test.py
@@ -77,7 +77,6 @@ def run(wrapper, cmd, check_log=None):
             # go back to original directory
             os.chdir(origdir)
 
-
 def test_shovill():
     run(
         "bio/shovill",
@@ -163,6 +162,12 @@ def test_bcftools_merge():
     run(
         "bio/bcftools/merge",
         ["snakemake", "--cores", "1", "all.bcf", "--use-conda", "-F"],
+    )
+
+def test_bcftools_mpileup():
+    run(
+        "bio/bcftools/mpileup",
+        ["snakemake", "--cores", "1", "pileups/a.pileup.bcf", "--use-conda", "-F"],
     )
 
 


### PR DESCRIPTION
In addition to adding this wrapper, I would also like to suggest changing the `bcftools call` wrapper to stop using `samtools mpileup` (which is deprecated) and instead only make that wrapper run `bcftools call`. I know the bcftools docs give the example of piping the output of `mpileup` into `call`, but `mpileup` can take a long time to run so I prefer having it run separately so I have that intermediate file on hand in case `call` needs to be rerun. If others don't want to keep that `mpileup` file lying around they can just tag it with [`temp()`](https://snakemake.readthedocs.io/en/stable/snakefiles/rules.html#protected-and-temporary-files) obviously.