### PR TITLE
Adding containers

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,7 +51,7 @@ jobs:
         uses: textbook/git-checkout-submodule-action@2.0.0
 
       - name: Setup Snakemake environment
-        run: conda create -c bioconda -c conda-forge --quiet --name snakemake snakemake-minimal pytest
+        run: conda create -c bioconda -c conda-forge --quiet --name snakemake snakemake-minimal pytest pyaml
 
       - name: Fetch master
         if: github.ref != 'master'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -65,6 +65,7 @@ jobs:
           # activate conda env
           export PATH="/usr/share/miniconda/bin:$PATH"
           source activate snakemake
-          
           # run tests
           pytest test.py -v
+          # show docker images that were built
+          docker images

--- a/bio/bwa/mem/Dockerfile
+++ b/bio/bwa/mem/Dockerfile
@@ -1,0 +1,9 @@
+FROM snakemake/snakemake
+# docker build -t snakemake-wrappers/bwa/mem
+# How to test from test folder:
+# snakemake --cores 1 mapped/a.bam --use-conda -F -s Snakefile_samtools
+MAINTAINER Johannes Köster <johannes.koester@tu-dortmund.de>
+ADD . /tmp/repo
+WORKDIR /tmp/repo
+RUN /bin/bash -c "source activate snakemake && \
+    conda env update --file /tmp/repo/environment.yaml --prune"

--- a/bio/bwa/mem/meta.yaml
+++ b/bio/bwa/mem/meta.yaml
@@ -1,7 +1,6 @@
 name: "bwa mem"
 description: Map reads using bwa mem, with optional sorting using
   samtools or picard.
-container: "docker://quay.io/snakemake-wrappers/bwa:mem"
 authors:
   - Johannes Köster
   - Julian de Ruiter

--- a/bio/bwa/mem/meta.yaml
+++ b/bio/bwa/mem/meta.yaml
@@ -1,6 +1,7 @@
 name: "bwa mem"
 description: Map reads using bwa mem, with optional sorting using
   samtools or picard.
+container: "docker-daemon://snakemake-wrappers/bwa/mem"
 authors:
   - Johannes Köster
   - Julian de Ruiter

--- a/bio/bwa/mem/meta.yaml
+++ b/bio/bwa/mem/meta.yaml
@@ -1,7 +1,7 @@
 name: "bwa mem"
 description: Map reads using bwa mem, with optional sorting using
   samtools or picard.
-container: "docker-daemon://snakemake-wrappers/bwa/mem"
+container: "docker://quay.io/snakemake-wrappers/bwa:mem"
 authors:
   - Johannes Köster
   - Julian de Ruiter


### PR DESCRIPTION
This is an early test to add a container with a Dockerfile, along with an automated build in the CI. The container I added for bwa/mem would be the one we are testing, and specifically we:

 - require a Dockerfile and environment.yaml (for container naming based on packages and versions) to do a build
 - generate a hash for the container name (the sorted packages) and tag (the same sorted versions for the corresponding packages)
 - build with Docker (will this work on GitHub actions?)

I have a few concerns and questions with respect to having a mono-repo for wrappers, specifically:

 - how will this scale to handle tests and build for hundreds, thousands of wrappers?
 - after merge, how do we build only updated containers?
 - how do we do builds that have each conda package in layers?

I'll post more questions / ideas as the tests run - I refactored the organization so I'm not sure if I broke anything :P 