### PR TITLE
Add log to ucsc examples

### DIFF
--- a/bio/ucsc/bedGraphToBigWig/test/Snakefile
+++ b/bio/ucsc/bedGraphToBigWig/test/Snakefile
@@ -5,7 +5,7 @@ rule bedGraphToBigWig:
     output:
         "{sample}.bw"
     log:
-        "{sample}.bed-graph_to_big-wig.log"
+        "logs/{sample}.bed-graph_to_big-wig.log"
     params:
         "" # optional params string
     wrapper:

--- a/bio/ucsc/bedGraphToBigWig/test/Snakefile
+++ b/bio/ucsc/bedGraphToBigWig/test/Snakefile
@@ -4,6 +4,8 @@ rule bedGraphToBigWig:
         chromsizes="genome.chrom.sizes"
     output:
         "{sample}.bw"
+    log:
+        "{sample}.bed-graph_to_big-wig.log"
     params:
         "" # optional params string
     wrapper:

--- a/bio/ucsc/faToTwoBit/test/Snakefile
+++ b/bio/ucsc/faToTwoBit/test/Snakefile
@@ -5,7 +5,7 @@ rule faToTwoBit_fa:
     output:
         "{sample}.2bit"
     log:
-        "{sample}.fa_to_2bit.log"
+        "logs/{sample}.fa_to_2bit.log"
     params:
         "" # optional params string
     wrapper:
@@ -18,7 +18,7 @@ rule faToTwoBit_fa_gz:
     output:
         "{sample}.2bit"
     log:
-        "{sample}.fa-gz_to_2bit.log"
+        "logs/{sample}.fa-gz_to_2bit.log"
     params:
         "" # optional params string
     wrapper:

--- a/bio/ucsc/faToTwoBit/test/Snakefile
+++ b/bio/ucsc/faToTwoBit/test/Snakefile
@@ -4,6 +4,8 @@ rule faToTwoBit_fa:
         "{sample}.fa"
     output:
         "{sample}.2bit"
+    log:
+        "{sample}.fa_to_2bit.log"
     params:
         "" # optional params string
     wrapper:
@@ -15,6 +17,8 @@ rule faToTwoBit_fa_gz:
         "{sample}.fa.gz"
     output:
         "{sample}.2bit"
+    log:
+        "{sample}.fa-gz_to_2bit.log"
     params:
         "" # optional params string
     wrapper:

--- a/bio/ucsc/twoBitInfo/test/Snakefile
+++ b/bio/ucsc/twoBitInfo/test/Snakefile
@@ -4,7 +4,7 @@ rule twoBitInfo:
     output:
         "{sample}.chrom.sizes"
     log:
-        "{sample}.chrom.sizes.log"
+        "logs/{sample}.chrom.sizes.log"
     params:
         "" # optional params string
     wrapper:

--- a/bio/ucsc/twoBitInfo/test/Snakefile
+++ b/bio/ucsc/twoBitInfo/test/Snakefile
@@ -3,6 +3,8 @@ rule twoBitInfo:
         "{sample}.2bit"
     output:
         "{sample}.chrom.sizes"
+    log:
+        "{sample}.chrom.sizes.log"
     params:
         "" # optional params string
     wrapper:

--- a/bio/ucsc/twoBitToFa/test/Snakefile
+++ b/bio/ucsc/twoBitToFa/test/Snakefile
@@ -3,6 +3,8 @@ rule twoBitToFa:
         "{sample}.2bit"
     output:
         "{sample}.fa"
+    log:
+        "{sample}.2bit_to_fa.log"
     params:
         "" # optional params string
     wrapper:

--- a/bio/ucsc/twoBitToFa/test/Snakefile
+++ b/bio/ucsc/twoBitToFa/test/Snakefile
@@ -4,7 +4,7 @@ rule twoBitToFa:
     output:
         "{sample}.fa"
     log:
-        "{sample}.2bit_to_fa.log"
+        "logs/{sample}.2bit_to_fa.log"
     params:
         "" # optional params string
     wrapper:


### PR DESCRIPTION
The ucsc wrappers already handle logging output, but the example `Snakefile`s did not contain a `log:` entry. This PR adds this.