### PR TITLE
MultiQC: temporary matplotlib dependency

### DIFF
--- a/bio/multiqc/environment.yaml
+++ b/bio/multiqc/environment.yaml
@@ -1,6 +1,7 @@
 channels:
-  - bioconda
   - conda-forge
+  - bioconda
   - defaults
 dependencies:
   - multiqc ==1.9
+  - matplotlib ==3.3.1


### PR DESCRIPTION
Currently MultiQC may have a conflict with the ca-certificate-chain provided by the "certify"-module. Matplotlib requires a relatively recent version of "python-certifi" (>=2020.06.20).
when accessing the local python installations: 

[...]
  File "~/.local/lib/python3.6/site-packages/pkg_resources/__init__.py", line 791, in resolve
    raise VersionConflict(dist, req).with_context(dependent_req)
pkg_resources.ContextualVersionConflict: (certifi 2019.3.9 (~/.local/lib/python3.6/site-packages), Requirement.parse('certifi>=2020.06.20'), {'matplotlib'})

Therefore I suggest to temporarily add matplotlib to the MultiQC environment, so that this dependency can be autoresolved in the conda-environment.