### PR TITLE
Bump OptiType version to 1.3.5

### DIFF
--- a/bio/optitype/environment.yaml
+++ b/bio/optitype/environment.yaml
@@ -3,4 +3,4 @@ channels:
   - bioconda
   - defaults
 dependencies:
-  - optitype ==1.3.4
+  - optitype ==1.3.5


### PR DESCRIPTION
Until version 1.3.4, OptiType writes temporary BAM files and names them after the current date and time. In combination with a workflow engine that potentially spawns multiple optitype instances within one second, this causes name collisions.

This was fixed in 1.3.5, the temporary BAM file names now take `--prefix` into account.