### PR TITLE
Java (picard) -Xmx parameter

### DIFF
--- a/bio/picard/markduplicates/wrapper.py
+++ b/bio/picard/markduplicates/wrapper.py
@@ -8,8 +8,16 @@ from snakemake.shell import shell
 
 log = snakemake.log_fmt_shell(stdout=True, stderr=True)
 
+memory = ""
+if "mem_mb" in snakemake.resources.keys():
+    memory = "-Xmx{}M".format(str(snakemake.resources["mem_mb"]))
+
 shell(
-    "picard MarkDuplicates {snakemake.params} INPUT={snakemake.input} "
-    "OUTPUT={snakemake.output.bam} METRICS_FILE={snakemake.output.metrics} "
-    "{log}"
+    "picard MarkDuplicates "  # Tool and its subcommand
+    "{memory} "  # Automatic Xmx java option
+    "{snakemake.params} "  # User defined parmeters
+    "INPUT={snakemake.input} "  # Input file
+    "OUTPUT={snakemake.output.bam} "  # Output bam
+    "METRICS_FILE={snakemake.output.metrics} "  # Output metrics
+    "{log}"  # Logging
 )

--- a/docs/generate_docs.py
+++ b/docs/generate_docs.py
@@ -34,10 +34,10 @@ with open(os.path.join(BASE_DIR, "_templates", "tool.rst")) as f:
     TOOL_TEMPLATE = Template(f.read())
 
 with open(os.path.join(BASE_DIR, "_templates", "wrapper.rst")) as f:
-    TEMPLATE = Template(f.read())
+    TEMPLATE_WRAPPER = Template(f.read())
 
 with open(os.path.join(BASE_DIR, "_templates", "meta_wrapper.rst")) as f:
-    TEMPLATE = Template(f.read())
+    TEMPLATE_META = Template(f.read())
 
 
 def get_tool_dir(tool):
@@ -88,7 +88,7 @@ def render_wrapper(path, target):
     name = meta["name"].replace(" ", "_") + ".rst"
     os.makedirs(os.path.dirname(target), exist_ok=True)
     with open(target, "w") as readme:
-        rst = TEMPLATE.render(
+        rst = TEMPLATE_WRAPPER.render(
             snakefile=snakefile,
             wrapper=wrapper,
             wrapper_lang=wrapper_lang,
@@ -113,7 +113,7 @@ def render_meta(path, target):
 
     with open(os.path.join(path, "test", "Snakefile")) as snakefile:
         snakefile = textwrap.indent(snakefile.read(), "    ").replace("master", TAG)
-        
+
     wrappers = []
     for uw in used_wrappers:
         wrapper = os.path.join(WRAPPER_DIR, uw, "wrapper.py")
@@ -124,11 +124,11 @@ def render_meta(path, target):
         with open(wrapper) as wrapper:
             wrapper = textwrap.indent(wrapper.read(), "    ")
             wrappers.append((wrapper, wrapper_lang, uw))
-            
+
     name = meta["name"].replace(" ", "_") + ".rst"
     os.makedirs(os.path.dirname(target), exist_ok=True)
     with open(target, "w") as readme:
-        rst = TEMPLATE.render(
+        rst = TEMPLATE_META.render(
             snakefile=snakefile,
             wrappers=wrappers,
             usedwrappers=used_wrappers,


### PR DESCRIPTION
Hi,

I was wondering if this is a good idea or not: based on the `resources` parameter in snakemake rules, then build `-Xmx` parameter automatically for any java tool that allow this kind of parameters.

Here, the conda wrapper of almost any picard subcommands handles `-Xm*`, and `-D*` options, so `Xmx` is handled.

If you agree with this, I am willing to do the same in Picard, SnpSift, SnpEff, GATK and Trinity (max_memory). If you see any other tool that would need such changes, please tell me and I'll be happy to make the changes.

Thanks in advance for your reviews.

PS: The modifications in `generate_docs.py` come from a PR i did this morning. I don't know how to hide it since it has been already accepted.