### PR TITLE
update for macs2 callpeak wrapper for --broad option

### DIFF
--- a/bio/macs2/callpeak/meta.yaml
+++ b/bio/macs2/callpeak/meta.yaml
@@ -17,27 +17,27 @@ description: >
     |                                |                                        |          |                    |
     |                                | peaks                                  |          |                    |
     +--------------------------------+----------------------------------------+----------+--------------------+
-    | NAME_control_lambda.bdg        | local biases estimated for each genomic| bedGraph | --bdg or -B        |
+    | NAME_control_lambda.bdg        | local biases estimated for each genomic| bedGraph | -\-bdg or -B       |
     |                                |                                        |          |                    |
     |                                | location from the control sample       |          |                    |
     +--------------------------------+----------------------------------------+----------+--------------------+
-    | NAME_treat_pileup.bdg          | pileup signals from treatment sample   | bedGraph | --bdg or -B        |
+    | NAME_treat_pileup.bdg          | pileup signals from treatment sample   | bedGraph | -\-bdg or -B       |
     +--------------------------------+----------------------------------------+----------+--------------------+
-    | NAME_peaks.broadPeak           | similar to _peaks.narrowPeak file,     | BED 6+3  | --broad            |
+    | NAME_peaks.broadPeak           | similar to _peaks.narrowPeak file,     | BED 6+3  | -\-broad           |
     |                                |                                        |          |                    |
     |                                | except for missing the annotating peak |          |                    |
     |                                |                                        |          |                    |
     |                                | summits                                |          |                    |
     +--------------------------------+----------------------------------------+----------+--------------------+
-    | NAME_peaks.gappedPeak          | contains the broad region and narrow   | BED 12+3 | --broad            |
+    | NAME_peaks.gappedPeak          | contains the broad region and narrow   | BED 12+3 | -\-broad           |
     |                                |                                        |          |                    |
     |                                | peaks                                  |          |                    |
     +--------------------------------+----------------------------------------+----------+--------------------+
-    | NAME_peaks.narrowPeak          | contains the peak locations, peak      | BED 6+4  | if not set --broad |
+    | NAME_peaks.narrowPeak          | contains the peak locations, peak      | BED 6+4  | if not set -\-broad|
     |                                |                                        |          |                    |
     |                                | summit, p-value and q-value            |          |                    |
     +--------------------------------+----------------------------------------+----------+--------------------+
-    | NAME_summits.bed               | peak summits locations for every peak  | BED      | if not set --broad |
+    | NAME_summits.bed               | peak summits locations for every peak  | BED      | if not set -\-broad|
     +--------------------------------+----------------------------------------+----------+--------------------+
 
 authors:

--- a/bio/macs2/callpeak/test/Snakefile
+++ b/bio/macs2/callpeak/test/Snakefile
@@ -40,6 +40,6 @@ rule callpeak_options:
     log:
         "logs/macs2/callpeak.log"
     params:
-        "-f BAM -g hs --nomodel"
+        "-f BAM -g hs --broad-cutoff 0.1 --nomodel"
     wrapper:
         "master/bio/macs2/callpeak"

--- a/bio/macs2/callpeak/wrapper.py
+++ b/bio/macs2/callpeak/wrapper.py
@@ -44,7 +44,7 @@ if any(out.endswith(("_peaks.narrowPeak", "_summits.bed")) for out in snakemake.
 if any(
     out.endswith(("_peaks.broadPeak", "_peaks.gappedPeak")) for out in snakemake.output
 ):
-    if "--broad" not in params:
+    if "--broad " not in params and not params.endswith("--broad"):
         params += " --broad "
 
 if any(


### PR DESCRIPTION
Update for macs2 callpeak wrapper in case the --broad-cutoff value is set but the --broad option is missing in params.