### PR TITLE
Explicitly add sphinx-copybutton dependency (fixes #208)

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -86,7 +86,7 @@ the relevant stdout and stderr messages printed.
 If you also want to test the docs generation locally, create another environment
 and activate it::
 
-  conda create -n test-snakemake-wrapper-docs sphinx sphinx_rtd_theme pyyaml
+  conda create -n test-snakemake-wrapper-docs sphinx sphinx_rtd_theme pyyaml sphinx-copybutton
   conda activate test-snakemake-wrapper-docs
 
 Then, enter the respective directory and build the docs::


### PR DESCRIPTION
Small correction to add the sphinx-copybutton package to build the docs without errors. It fixes #208 
Thanks in advance for the reviews,