### PR TITLE
Ensure pigz dependency is installed

### DIFF
--- a/bio/seqtk/subsample/pe/environment.yaml
+++ b/bio/seqtk/subsample/pe/environment.yaml
@@ -3,3 +3,4 @@ channels:
   - conda-forge
 dependencies:
   - seqtk ==1.3
+  - pigz ==2.3.4

--- a/bio/seqtk/subsample/pe/environment.yaml
+++ b/bio/seqtk/subsample/pe/environment.yaml
@@ -3,4 +3,4 @@ channels:
   - conda-forge
 dependencies:
   - seqtk ==1.3
-  - pigz ==2.3.4
+  - pigz ==2.3

--- a/bio/seqtk/subsample/pe/environment.yaml
+++ b/bio/seqtk/subsample/pe/environment.yaml
@@ -3,4 +3,4 @@ channels:
   - conda-forge
 dependencies:
   - seqtk ==1.3
-  - pigz ==2.3
+  - pigz =2.3

--- a/bio/seqtk/subsample/se/environment.yaml
+++ b/bio/seqtk/subsample/se/environment.yaml
@@ -3,3 +3,4 @@ channels:
   - conda-forge
 dependencies:
   - seqtk ==1.3
+  - pigz ==2.3.4

--- a/bio/seqtk/subsample/se/environment.yaml
+++ b/bio/seqtk/subsample/se/environment.yaml
@@ -3,4 +3,4 @@ channels:
   - conda-forge
 dependencies:
   - seqtk ==1.3
-  - pigz ==2.3.4
+  - pigz ==2.3

--- a/bio/seqtk/subsample/se/environment.yaml
+++ b/bio/seqtk/subsample/se/environment.yaml
@@ -3,4 +3,4 @@ channels:
   - conda-forge
 dependencies:
   - seqtk ==1.3
-  - pigz ==2.3
+  - pigz =2.3


### PR DESCRIPTION
The `seqtk/subsample` wrapper didn't work for me because I didn't have pigz installed in my environment. This PR updates the corresponding env files to make sure this doesn't happen.