### PR TITLE
VEP cache with fully specified output folder with wildcards

### DIFF
--- a/bio/vep/cache/meta.yaml
+++ b/bio/vep/cache/meta.yaml
@@ -2,3 +2,4 @@ name: vep download cache
 description: Download VEP cache for given species, build and release.
 authors:
   - Johannes Köster
+  - Filipe G. Vieira

--- a/bio/vep/cache/test/Snakefile
+++ b/bio/vep/cache/test/Snakefile
@@ -1,12 +1,8 @@
 rule get_vep_cache:
     output:
-        directory("resources/vep/cache")
-    params:
-        species="saccharomyces_cerevisiae",
-        build="R64-1-1",
-        release="98"
+        directory("resources/vep/cache/{species}/{release}_{build}")
     log:
-        "logs/vep/cache.log"
+        "logs/vep/cache/{species}/{release}_{build}.log"
     cache: True  # save space and time with between workflow caching (see docs)
     wrapper:
         "master/bio/vep/cache"

--- a/bio/vep/cache/wrapper.py
+++ b/bio/vep/cache/wrapper.py
@@ -9,7 +9,8 @@ from snakemake.shell import shell
 out_parts = Path(snakemake.output[0]).parts
 # Check if output folder follows Ensembl path structure
 assert (
-    str(Path(*out_parts[-2:])) == f"{snakemake.wildcards.species}/{snakemake.wildcards.release}_{snakemake.wildcards.build}"
+    str(Path(*out_parts[-2:]))
+    == f"{snakemake.wildcards.species}/{snakemake.wildcards.release}_{snakemake.wildcards.build}"
 ), "output folder must end in '{species}/{release}_{build}'"
 # Extract CACHE_DIR
 cache_dir = str(Path(*out_parts[:-2]))

--- a/bio/vep/cache/wrapper.py
+++ b/bio/vep/cache/wrapper.py
@@ -6,15 +6,23 @@ __license__ = "MIT"
 from pathlib import Path
 from snakemake.shell import shell
 
+out_parts = Path(snakemake.output[0]).parts
+# Check if output folder follows Ensembl path structure
+assert (
+    str(Path(*out_parts[-2:])) == f"{snakemake.wildcards.species}/{snakemake.wildcards.release}_{snakemake.wildcards.build}"
+), "output folder must end in '{species}/{release}_{build}'"
+# Extract CACHE_DIR
+cache_dir = str(Path(*out_parts[:-2]))
+
 extra = snakemake.params.get("extra", "")
 log = snakemake.log_fmt_shell(stdout=True, stderr=True)
 
 shell(
     "vep_install --AUTO cf "
-    "--SPECIES {snakemake.params.species} "
-    "--ASSEMBLY {snakemake.params.build} "
-    "--CACHE_VERSION {snakemake.params.release} "
-    "--CACHEDIR {snakemake.output} "
+    "--SPECIES {snakemake.wildcards.species} "
+    "--ASSEMBLY {snakemake.wildcards.build} "
+    "--CACHE_VERSION {snakemake.wildcards.release} "
+    "--CACHEDIR {cache_dir} "
     "--CONVERT "
     "--NO_UPDATE "
     "{extra} {log}"

--- a/test.py
+++ b/test.py
@@ -2611,7 +2611,7 @@ def test_ptrimmer_pe():
 def test_vep_cache():
     run(
         "bio/vep/cache",
-        ["snakemake", "--cores", "1", "resources/vep/cache", "--use-conda", "-F"],
+        ["snakemake", "--cores", "1", "resources/vep/cache/saccharomyces_cerevisiae/98_R64-1-1", "--use-conda", "-F"],
     )
 
 


### PR DESCRIPTION

Implementation of #236, where the output folder has to be fully specified (including the part that is added by the ensembl script),  so that the outptut can be checked by the rule if it exists or not.

This way, we can specify the specific cache for a given species/build/release and check if it exists.