### PR TITLE
Added params extra and adapters for consistentency

### DIFF
--- a/bio/cutadapt/pe/test/Snakefile
+++ b/bio/cutadapt/pe/test/Snakefile
@@ -9,7 +9,7 @@ rule cutadapt:
         # https://cutadapt.readthedocs.io/en/stable/guide.html#adapter-types
         adapters="-a AGAGCACACGTCTGAACTCCAGTCAC -g AGATCGGAAGAGCACACGT -A AGAGCACACGTCTGAACTCCAGTCAC -G AGATCGGAAGAGCACACGT",
         # https://cutadapt.readthedocs.io/en/stable/guide.html#
-        extra = "--minimum-length 1 -q 20"
+        extra="--minimum-length 1 -q 20"
     log:
         "logs/cutadapt/{sample}.log"
     threads: 4 # set desired number of threads here

--- a/bio/cutadapt/pe/test/Snakefile
+++ b/bio/cutadapt/pe/test/Snakefile
@@ -7,7 +7,7 @@ rule cutadapt:
         qc="trimmed/{sample}.qc.txt"
     params:
         # https://cutadapt.readthedocs.io/en/stable/guide.html#adapter-types
-        adapters = "-a AGAGCACACGTCTGAACTCCAGTCAC -g AGATCGGAAGAGCACACGT -A AGAGCACACGTCTGAACTCCAGTCAC -G AGATCGGAAGAGCACACGT",
+        adapters="-a AGAGCACACGTCTGAACTCCAGTCAC -g AGATCGGAAGAGCACACGT -A AGAGCACACGTCTGAACTCCAGTCAC -G AGATCGGAAGAGCACACGT",
         # https://cutadapt.readthedocs.io/en/stable/guide.html#
         extra = "--minimum-length 1 -q 20"
     log:

--- a/bio/cutadapt/pe/test/Snakefile
+++ b/bio/cutadapt/pe/test/Snakefile
@@ -9,7 +9,7 @@ rule cutadapt:
         # https://cutadapt.readthedocs.io/en/stable/guide.html#adapter-types
         adapters = "-a AGAGCACACGTCTGAACTCCAGTCAC -g AGATCGGAAGAGCACACGT -A AGAGCACACGTCTGAACTCCAGTCAC -G AGATCGGAAGAGCACACGT",
         # https://cutadapt.readthedocs.io/en/stable/guide.html#
-        others = "--minimum-length 1 -q 20"
+        extra = "--minimum-length 1 -q 20"
     log:
         "logs/cutadapt/{sample}.log"
     threads: 4 # set desired number of threads here

--- a/bio/cutadapt/pe/wrapper.py
+++ b/bio/cutadapt/pe/wrapper.py
@@ -16,7 +16,9 @@ extra = snakemake.params.get("extra", "")
 adapters = snakemake.params.get("adapters", "")
 log = snakemake.log_fmt_shell(stdout=False, stderr=True)
 
-assert extra != "" or adapters != "", "No options provided to cutadapt. Please use 'params: adapters=' or 'params: extra='."
+assert (
+    extra != "" or adapters != ""
+), "No options provided to cutadapt. Please use 'params: adapters=' or 'params: extra='."
 
 shell(
     "cutadapt"

--- a/bio/cutadapt/pe/wrapper.py
+++ b/bio/cutadapt/pe/wrapper.py
@@ -12,7 +12,11 @@ from snakemake.shell import shell
 n = len(snakemake.input)
 assert n == 2, "Input must contain 2 (paired-end) elements."
 
+extra = snakemake.params.get("extra", "")
+adapters = snakemake.params.get("adapters", "")
 log = snakemake.log_fmt_shell(stdout=False, stderr=True)
+
+assert extra != "" or adapters != "", "No options provided to cutadapt"
 
 shell(
     "cutadapt"

--- a/bio/cutadapt/pe/wrapper.py
+++ b/bio/cutadapt/pe/wrapper.py
@@ -16,7 +16,7 @@ extra = snakemake.params.get("extra", "")
 adapters = snakemake.params.get("adapters", "")
 log = snakemake.log_fmt_shell(stdout=False, stderr=True)
 
-assert extra != "" or adapters != "", "No options provided to cutadapt"
+assert extra != "" or adapters != "", "No options provided to cutadapt. Please use 'params: adapters=' or 'params: extra='."
 
 shell(
     "cutadapt"

--- a/bio/cutadapt/pe/wrapper.py
+++ b/bio/cutadapt/pe/wrapper.py
@@ -17,7 +17,7 @@ log = snakemake.log_fmt_shell(stdout=False, stderr=True)
 shell(
     "cutadapt"
     " {snakemake.params.adapters}"
-    " {snakemake.params.others}"
+    " {snakemake.params.extra}"
     " -o {snakemake.output.fastq1}"
     " -p {snakemake.output.fastq2}"
     " -j {snakemake.threads}"

--- a/bio/cutadapt/se/test/Snakefile
+++ b/bio/cutadapt/se/test/Snakefile
@@ -5,8 +5,8 @@ rule cutadapt:
         fastq="trimmed/{sample}.fastq",
         qc="trimmed/{sample}.qc.txt"
     params:
-        adapters = "-a AGATCGGAAGAGCACACGTCTGAACTCCAGTCAC",
-        extra = "-q 20"
+        adapters="-a AGATCGGAAGAGCACACGTCTGAACTCCAGTCAC",
+        extra="-q 20"
     log:
         "logs/cutadapt/{sample}.log"
     threads: 4 # set desired number of threads here

--- a/bio/cutadapt/se/test/Snakefile
+++ b/bio/cutadapt/se/test/Snakefile
@@ -5,7 +5,8 @@ rule cutadapt:
         fastq="trimmed/{sample}.fastq",
         qc="trimmed/{sample}.qc.txt"
     params:
-        "-a AGATCGGAAGAGCACACGTCTGAACTCCAGTCAC -q 20"
+        adapters = "-a AGATCGGAAGAGCACACGTCTGAACTCCAGTCAC",
+        extra = "-q 20"
     log:
         "logs/cutadapt/{sample}.log"
     threads: 4 # set desired number of threads here

--- a/bio/cutadapt/se/wrapper.py
+++ b/bio/cutadapt/se/wrapper.py
@@ -16,7 +16,9 @@ extra = snakemake.params.get("extra", "")
 adapters = snakemake.params.get("adapters", "")
 log = snakemake.log_fmt_shell(stdout=False, stderr=True)
 
-assert extra != "" or adapters != "", "No options provided to cutadapt"
+assert (
+    extra != "" or adapters != ""
+), "No options provided to cutadapt. Please use 'params: adapters=' or 'params: extra='."
 
 shell(
     "cutadapt"

--- a/bio/cutadapt/se/wrapper.py
+++ b/bio/cutadapt/se/wrapper.py
@@ -12,7 +12,11 @@ from snakemake.shell import shell
 n = len(snakemake.input)
 assert n == 1, "Input must contain 1 (single-end) elements."
 
+extra = snakemake.params.get("extra", "")
+adapters = snakemake.params.get("adapters", "")
 log = snakemake.log_fmt_shell(stdout=False, stderr=True)
+
+assert extra != "" or adapters != "", "No options provided to cutadapt"
 
 shell(
     "cutadapt"

--- a/bio/cutadapt/se/wrapper.py
+++ b/bio/cutadapt/se/wrapper.py
@@ -9,11 +9,15 @@ __license__ = "MIT"
 from snakemake.shell import shell
 
 
+n = len(snakemake.input)
+assert n == 1, "Input must contain 1 (single-end) elements."
+
 log = snakemake.log_fmt_shell(stdout=False, stderr=True)
 
 shell(
     "cutadapt"
-    " {snakemake.params}"
+    " {snakemake.params.adapters}"
+    " {snakemake.params.extra}"
     " -j {snakemake.threads}"
     " -o {snakemake.output.fastq}"
     " {snakemake.input[0]}"

--- a/bio/cutadapt/se/wrapper.py
+++ b/bio/cutadapt/se/wrapper.py
@@ -10,7 +10,7 @@ from snakemake.shell import shell
 
 
 n = len(snakemake.input)
-assert n == 1, "Input must contain 1 (single-end) elements."
+assert n == 1, "Input must contain 1 (single-end) element."
 
 extra = snakemake.params.get("extra", "")
 adapters = snakemake.params.get("adapters", "")

--- a/bio/fastp/test/Snakefile
+++ b/bio/fastp/test/Snakefile
@@ -8,7 +8,7 @@ rule fastp_se:
     log:
         "logs/fastp/se/{sample}.log"
     params:
-        adapters="--adapter_sequence ACGGCTAGCTA"
+        adapters="--adapter_sequence ACGGCTAGCTA",
         extra=""
     threads: 1
     wrapper:
@@ -25,7 +25,7 @@ rule fastp_pe:
     log:
         "logs/fastp/pe/{sample}.log"
     params:
-        adapters="--adapter_sequence ACGGCTAGCTA --adapter_sequence_r2 AGATCGGAAGAGCACACGTCTGAACTCCAGTCAC"
+        adapters="--adapter_sequence ACGGCTAGCTA --adapter_sequence_r2 AGATCGGAAGAGCACACGTCTGAACTCCAGTCAC",
         extra=""
     threads: 2
     wrapper:

--- a/bio/fastp/test/Snakefile
+++ b/bio/fastp/test/Snakefile
@@ -8,6 +8,7 @@ rule fastp_se:
     log:
         "logs/fastp/se/{sample}.log"
     params:
+        adapters="--adapter_sequence ACGGCTAGCTA"
         extra=""
     threads: 1
     wrapper:
@@ -24,6 +25,7 @@ rule fastp_pe:
     log:
         "logs/fastp/pe/{sample}.log"
     params:
+        adapters="--adapter_sequence ACGGCTAGCTA --adapter_sequence_r2 AGATCGGAAGAGCACACGTCTGAACTCCAGTCAC"
         extra=""
     threads: 2
     wrapper:

--- a/bio/fastp/wrapper.py
+++ b/bio/fastp/wrapper.py
@@ -6,6 +6,7 @@ __license__ = "MIT"
 from snakemake.shell import shell
 
 extra = snakemake.params.get("extra", "")
+adapters = snakemake.params.get("adapters", "")
 log = snakemake.log_fmt_shell(stdout=True, stderr=True)
 
 n = len(snakemake.input.sample)
@@ -31,7 +32,9 @@ html = "--html {}".format(snakemake.output.html)
 json = "--json {}".format(snakemake.output.json)
 
 shell(
-    "(fastp --thread {snakemake.threads} {snakemake.params.extra} {snakemake.params.adapters} "
+    "(fastp --thread {snakemake.threads} "
+    "{extra} "
+    "{adapters} "
     "{reads} "
     "{trimmed} "
     "{json} "

--- a/bio/fastp/wrapper.py
+++ b/bio/fastp/wrapper.py
@@ -31,7 +31,7 @@ html = "--html {}".format(snakemake.output.html)
 json = "--json {}".format(snakemake.output.json)
 
 shell(
-    "(fastp --thread {snakemake.threads} {snakemake.params.extra} {snakemake.params.adapters}"
+    "(fastp --thread {snakemake.threads} {snakemake.params.extra} {snakemake.params.adapters} "
     "{reads} "
     "{trimmed} "
     "{json} "

--- a/bio/fastp/wrapper.py
+++ b/bio/fastp/wrapper.py
@@ -31,7 +31,7 @@ html = "--html {}".format(snakemake.output.html)
 json = "--json {}".format(snakemake.output.json)
 
 shell(
-    "(fastp --thread {snakemake.threads} {snakemake.params.extra} "
+    "(fastp --thread {snakemake.threads} {snakemake.params.extra} {snakemake.params.adapters}"
     "{reads} "
     "{trimmed} "
     "{json} "


### PR DESCRIPTION

Some wrappers have `params.extra`, `params.others`, `params.adapters`, or just `params`.

I think it would be nice to have it a bit more consistent across different wrappers, and having `adapters` on a separate `params`  makes it a little easier sometimes (since adapter specification can differ quite a bit between tools).