### PR TITLE
Cleaning dada2 wrappers

### DIFF
--- a/bio/dada2/add-species/meta.yaml
+++ b/bio/dada2/add-species/meta.yaml
@@ -1,13 +1,13 @@
 name: dada2_add_species
 description: |
   `DADA2 <https://benjjneb.github.io/dada2/index.html>`_
-  Adding species-level annotation using dada2 assignTaxonomy function. Optional parameters are documented in the `manual <https://www.bioconductor.org/packages/release/bioc/manuals/dada2/man/dada2.pdf>`_.
+  Adding species-level annotation using dada2 ``addSpecies`` function. Optional parameters are documented in the `manual <https://www.bioconductor.org/packages/release/bioc/manuals/dada2/man/dada2.pdf#addSpecies>`_ and the function is introduced in the dedicated tutorial `section <https://benjjneb.github.io/dada2/assign.html#species-assignment>`_.
 authors:
   - Charlie Pauvert
 input:
   - taxa: RDS file containing the taxonomic assignments
   - refFasta: A string with the path to the FASTA reference database
 params:
-  - optional arguments for addSpecies(), please provide them as python key=value pairs
+  - optional arguments for ``addSpecies()``, please provide them as python ``key=value`` pairs
 output:
   - The input RDS file augmented by the species-level annotation

--- a/bio/dada2/add-species/test/Snakefile
+++ b/bio/dada2/add-species/test/Snakefile
@@ -2,6 +2,8 @@ rule dada2_add_species:
     input:
         taxtab="results/dada2/taxa.RDS", # Taxonomic assignments
         refFasta="resources/example_species_assignment.fa.gz" # Reference FASTA 
+    output:
+        "results/dada2/taxa-sp.RDS", # Taxonomic + Species assignments
     # Even though this is an R wrapper, use named arguments in Python syntax
     # here, to specify extra parameters. Python booleans (`arg1=True`, `arg2=False`)
     # and lists (`list_arg=[]`) are automatically converted to R.
@@ -9,8 +11,6 @@ rule dada2_add_species:
     #   (`named_list={name1=arg1}`).
     #params:
     #    verbose=True
-    output:
-        "results/dada2/taxa-sp.RDS", # Taxonomic + Species assignments
     log:
         "logs/dada2/add-species/add-species.log"
     threads: 1 # set desired number of threads here

--- a/bio/dada2/assign-taxonomy/meta.yaml
+++ b/bio/dada2/assign-taxonomy/meta.yaml
@@ -1,13 +1,13 @@
 name: dada2_assign_taxonomy
 description: |
   `DADA2 <https://benjjneb.github.io/dada2/index.html>`_
-  Classifying sequences against a reference database using dada2 assignTaxonomy function. Optional parameters are documented in the `manual <https://www.bioconductor.org/packages/release/bioc/manuals/dada2/man/dada2.pdf>`_.
+  Classifying sequences against a reference database using dada2 ``assignTaxonomy`` function. Optional parameters are documented in the `manual <https://www.bioconductor.org/packages/release/bioc/manuals/dada2/man/dada2.pdf#assignTaxonomy>`_ and the function is introduced in the dedicated tutorial `section <https://benjjneb.github.io/dada2/tutorial.html#assign-taxonomy>`_.
 authors:
   - Charlie Pauvert
 input:
   - seqs: RDS file with the chimera-free sequence table
   - refFasta: A string with the path to the FASTA reference database
 params:
-  - optional arguments for assignTaxonomy(), please provide them as python key=value pairs 
+  - optional arguments for ``assignTaxonomy()``, please provide them as python ``key=value`` pairs 
 output:
   - RDS file containing the taxonomic assignments

--- a/bio/dada2/assign-taxonomy/test/Snakefile
+++ b/bio/dada2/assign-taxonomy/test/Snakefile
@@ -7,8 +7,8 @@ rule dada2_assign_taxonomy:
     # and lists (`list_arg=[]`) are automatically converted to R.
     # For a named list as an extra named argument, use a python dict
     #   (`named_list={name1=arg1}`).
-    params:
-        verbose=True
+    #params:
+    #    verbose=True
     output:
         "results/dada2/taxa.RDS" # Taxonomic assignments
     log:

--- a/bio/dada2/assign-taxonomy/test/Snakefile
+++ b/bio/dada2/assign-taxonomy/test/Snakefile
@@ -2,6 +2,8 @@ rule dada2_assign_taxonomy:
     input:
         seqs="results/dada2/seqTab.nochim.RDS", # Chimera-free sequence table
         refFasta="resources/example_train_set.fa.gz" # Reference FASTA for taxonomy
+    output:
+        "results/dada2/taxa.RDS" # Taxonomic assignments
     # Even though this is an R wrapper, use named arguments in Python syntax
     # here, to specify extra parameters. Python booleans (`arg1=True`, `arg2=False`)
     # and lists (`list_arg=[]`) are automatically converted to R.
@@ -9,8 +11,6 @@ rule dada2_assign_taxonomy:
     #   (`named_list={name1=arg1}`).
     #params:
     #    verbose=True
-    output:
-        "results/dada2/taxa.RDS" # Taxonomic assignments
     log:
         "logs/dada2/assign-taxonomy/assign-taxonomy.log"
     threads: 1 # set desired number of threads here

--- a/bio/dada2/dereplicate-fastq/meta.yaml
+++ b/bio/dada2/dereplicate-fastq/meta.yaml
@@ -1,11 +1,13 @@
 name: dada2_dereplicate_fastq
 description: |
   `DADA2 <https://benjjneb.github.io/dada2/index.html>`_
-  Dereplication of FASTQ files using dada2 derepFastq function. Optional parameters are documented in the `manual <https://www.bioconductor.org/packages/release/bioc/manuals/dada2/man/dada2.pdf>`_.
+  Dereplication of FASTQ files using dada2 ``derepFastq`` function. Optional parameters are documented in the `manual <https://www.bioconductor.org/packages/release/bioc/manuals/dada2/man/dada2.pdf#derepFastq>`_ and though the function is not introduced explicitly in the tutorial it is used in under the hood in the `learnErrors` `section <https://benjjneb.github.io/dada2/tutorial.html#learn-the-error-rates>`_.
 authors:
   - Charlie Pauvert
-input: a FASTQ file
+input: 
+  - a FASTQ file
 params:
-  - optional arguments for derepFastq(), please provide them as python key=value pairs
-output: RDS file containing a `derep-class` object
+  - optional arguments for ``derepFastq()``, please provide them as python ``key=value`` pairs
+output: 
+  - RDS file containing a ``derep-class`` object
 

--- a/bio/dada2/filter-trim/meta.yaml
+++ b/bio/dada2/filter-trim/meta.yaml
@@ -1,7 +1,7 @@
 name: dada2_filter_trim
 description: |
   `DADA2 <https://benjjneb.github.io/dada2/index.html>`_
-  Quality filtering of single or paired-end reads using dada2 filterAndTrim function. Optional parameters are documented in the `manual <https://www.bioconductor.org/packages/release/bioc/manuals/dada2/man/dada2.pdf>`_.
+  Quality filtering of single or paired-end reads using dada2 ``filterAndTrim`` function. Optional parameters are documented in the `manual <https://www.bioconductor.org/packages/release/bioc/manuals/dada2/man/dada2.pdf#filterAndTrim>`_ and the function is introduced in the dedicated tutorial `section <https://benjjneb.github.io/dada2/tutorial.html#filter-and-trim>`_.
 authors:
   - Charlie Pauvert
 input:
@@ -12,4 +12,4 @@ output:
   - filt_rev: an (optional) compressed filtered reverse FASTQ file
   - stats: a .tsv file with the number of processed and filtered reads per sample
 params:
-  - optional arguments for filterAndTrim(), please provide them as python key=value pairs
+  - optional arguments for ``filterAndTrim()``, please provide them as python ``key=value`` pairs

--- a/bio/dada2/filter-trim/test/Snakefile
+++ b/bio/dada2/filter-trim/test/Snakefile
@@ -5,20 +5,20 @@ rule dada2_filter_trim_se:
     output:
         filt="filtered-se/{sample}.1.fastq.gz",
         stats="reports/dada2/filter-trim-se/{sample}.tsv"
-    log:
-        "logs/dada2/filter-trim-se/{sample}.log"
     # Even though this is an R wrapper, use named arguments in Python syntax
     # here, to specify extra parameters. Python booleans (`arg1=True`, `arg2=False`)
     # and lists (`list_arg=[]`) are automatically converted to R.
     # For a named list as an extra named argument, use a python dict
     #   (`named_list={name1=arg1}`).
     params:
-	# Set the maximum expected errors tolerated in filtered reads
+        # Set the maximum expected errors tolerated in filtered reads
         maxEE=1,
         # Set the number of kept bases to 7 for the toy example
         truncLen=7,
         # Set minLen to 1 for the toy example but default is 20
         minLen=1
+    log:
+        "logs/dada2/filter-trim-se/{sample}.log"
     threads: 1 # set desired number of threads here
     wrapper:
         "master/bio/dada2/filter-trim"
@@ -32,21 +32,21 @@ rule dada2_filter_trim_pe:
         filt="filtered-pe/{sample}.1.fastq.gz",
         filt_rev="filtered-pe/{sample}.2.fastq.gz",
         stats="reports/dada2/filter-trim-pe/{sample}.tsv"
-    log:
-        "logs/dada2/filter-trim-pe/{sample}.log"
     # Even though this is an R wrapper, use named arguments in Python syntax
     # here, to specify extra parameters. Python booleans (`arg1=True`, `arg2=False`)
     # and lists (`list_arg=[]`) are automatically converted to R.
     # For a named list as an extra named argument, use a python dict
     #   (`named_list={name1=arg1}`).
     params:
-	# Set the maximum expected errors tolerated in filtered reads
+        # Set the maximum expected errors tolerated in filtered reads
         maxEE=1,
         # Set the number of kept bases in forward and reverse reads
-	# respectively to 7 for the toy example
+        # respectively to 7 for the toy example
         truncLen=[7,6],
         # Set minLen to 1 for the toy example but default is 20
         minLen=1
+    log:
+        "logs/dada2/filter-trim-pe/{sample}.log"
     threads: 1 # set desired number of threads here
     wrapper:
         "master/bio/dada2/filter-trim"

--- a/bio/dada2/learn-errors/meta.yaml
+++ b/bio/dada2/learn-errors/meta.yaml
@@ -1,14 +1,13 @@
 name: dada2_learn_errors
 description: |
   `DADA2 <https://benjjneb.github.io/dada2/index.html>`_
-  Learning error rates separately on paired-end data using dada2 learnErrors function.
-  Optional parameters are documented in the `manual <https://www.bioconductor.org/packages/release/bioc/manuals/dada2/man/dada2.pdf>`_.
+  Learning error rates separately on paired-end data using dada2 ``learnErrors`` function. Optional parameters are documented in the `manual <https://www.bioconductor.org/packages/release/bioc/manuals/dada2/man/dada2.pdf#learnErrors>`_ and the function is introduced in the dedicated tutorial `section <https://benjjneb.github.io/dada2/tutorial.html#learn-the-error-rates>`_.
 authors:
   - Charlie Pauvert
 input:
   - A list of quality filtered and trimmed forward FASTQ files (potentially compressed)
 params:
-  - optional arguments for learnErrors(), please provide them as python key=value pairs
+  - optional arguments for ``learnErrors()``, please provide them as python ``key=value`` pairs
 output:
-  - model: RDS file with the stored error model
+  - err: RDS file with the stored error model
   - plot: plot observed vs estimated errors rates

--- a/bio/dada2/learn-errors/test/Snakefile
+++ b/bio/dada2/learn-errors/test/Snakefile
@@ -6,6 +6,9 @@ rule dada2_learn_errors:
     input:
     # Quality filtered and trimmed forward FASTQ files (potentially compressed) 
         expand("filtered/{sample}.{{orientation}}.fastq.gz", sample=["a","b"])
+    output:
+        err="results/dada2/model_{orientation}.RDS",# save the error model
+        plot="reports/dada2/errors_{orientation}.png",# plot observed and estimated rates
     # Even though this is an R wrapper, use named arguments in Python syntax
     # here, to specify extra parameters. Python booleans (`arg1=True`, `arg2=False`)
     # and lists (`list_arg=[]`) are automatically converted to R.
@@ -13,9 +16,6 @@ rule dada2_learn_errors:
     #   (`named_list={name1=arg1}`).
     #params:
     #    randomize=True
-    output:
-        err="results/dada2/model_{orientation}.RDS",# save the error model
-        plot="reports/dada2/errors_{orientation}.png",# plot observed and estimated rates
     log:
         "logs/dada2/learn-errors/learn-errors_{orientation}.log"
     threads: 1 # set desired number of threads here

--- a/bio/dada2/learn-errors/test/Snakefile
+++ b/bio/dada2/learn-errors/test/Snakefile
@@ -11,10 +11,10 @@ rule dada2_learn_errors:
     # and lists (`list_arg=[]`) are automatically converted to R.
     # For a named list as an extra named argument, use a python dict
     #   (`named_list={name1=arg1}`).
-    params:
-        randomize=True
+    #params:
+    #    randomize=True
     output:
-        model="results/dada2/model_{orientation}.RDS",# save the error model
+        err="results/dada2/model_{orientation}.RDS",# save the error model
         plot="reports/dada2/errors_{orientation}.png",# plot observed and estimated rates
     log:
         "logs/dada2/learn-errors/learn-errors_{orientation}.log"

--- a/bio/dada2/learn-errors/wrapper.R
+++ b/bio/dada2/learn-errors/wrapper.R
@@ -39,7 +39,7 @@ library(ggplot2)
 ggsave(snakemake@output[["plot"]], perr, width = 8, height = 8, dpi = 300)
 
 # Store the estimated errors as RDS files
-saveRDS(err, snakemake@output[["model"]],compress = T)
+saveRDS(err, snakemake@output[["err"]],compress = T)
 
 # Proper syntax to close the connection for the log file
 # but could be optional for Snakemake wrapper

--- a/bio/dada2/make-table/meta.yaml
+++ b/bio/dada2/make-table/meta.yaml
@@ -1,13 +1,13 @@
 name: dada2_make_table
 description: |
   `DADA2 <https://benjjneb.github.io/dada2/index.html>`_
-  Build a sequence - sample table from denoised samples using dada2 makeSequenceTable function. Optional parameters are documented in the `manual <https://www.bioconductor.org/packages/release/bioc/manuals/dada2/man/dada2.pdf>`_.
+  Build a sequence - sample table from denoised samples using dada2 ``makeSequenceTable`` function. Optional parameters are documented in the `manual <https://www.bioconductor.org/packages/release/bioc/manuals/dada2/man/dada2.pdf#makeSequenceTable>`_ and the function is introduced in the dedicated tutorial `section <https://benjjneb.github.io/dada2/tutorial.html#construct-sequence-table>`_.
 authors:
   - Charlie Pauvert
 input:
   - A list of RDS files with denoised samples (se), or denoised and merged samples (pe)
 params: 
   - names: A list of sample names instead of paths
-  - params: Any other optional arguments for makeSequenceTable(), please provide them as python key=value pairs
+  - params: Any other optional arguments for ``makeSequenceTable()``, please provide them as python ``key=value`` pairs
 output:
   - RDS file with the table

--- a/bio/dada2/make-table/test/Snakefile
+++ b/bio/dada2/make-table/test/Snakefile
@@ -2,6 +2,8 @@ rule dada2_make_table_se:
     input:
     # Inferred composition 
         expand("denoised/{sample}.1.RDS", sample=['a','b']) 
+    output:
+        "results/dada2/seqTab-se.RDS"
     # Even though this is an R wrapper, use named arguments in Python syntax
     # here, to specify extra parameters. Python booleans (`arg1=True`, `arg2=False`)
     # and lists (`list_arg=[]`) are automatically converted to R.
@@ -9,8 +11,6 @@ rule dada2_make_table_se:
     #   (`named_list={name1=arg1}`).
     params:
         names=['a','b'] # Sample names instead of paths
-    output:
-        "results/dada2/seqTab-se.RDS"
     log:
         "logs/dada2/make-table/make-table-se.log"
     threads: 1 # set desired number of threads here
@@ -21,6 +21,8 @@ rule dada2_make_table_pe:
     input:
     # Merged composition
         expand("merged/{sample}.RDS", sample=['a','b'])
+    output:
+        "results/dada2/seqTab-pe.RDS"
     # Even though this is an R wrapper, use named arguments in Python syntax
     # here, to specify extra parameters. Python booleans (`arg1=True`, `arg2=False`)
     # and lists (`list_arg=[]`) are automatically converted to R.
@@ -29,8 +31,6 @@ rule dada2_make_table_pe:
     params:
         names=['a','b'], # Sample names instead of paths
         orderBy="nsamples" # Change the ordering of samples
-    output:
-        "results/dada2/seqTab-pe.RDS"
     log:
         "logs/dada2/make-table/make-table-pe.log"
     threads: 1 # set desired number of threads here

--- a/bio/dada2/merge-pairs/meta.yaml
+++ b/bio/dada2/merge-pairs/meta.yaml
@@ -1,7 +1,7 @@
 name: dada2_merge_pairs
 description: |
   `DADA2 <https://benjjneb.github.io/dada2/index.html>`_
-  Merging denoised forward and reverse reads using dada2 mergePairs function. Optional parameters are documented in the `manual <https://www.bioconductor.org/packages/release/bioc/manuals/dada2/man/dada2.pdf>`_.
+  Merging denoised forward and reverse reads using dada2 ``mergePairs`` function. Optional parameters are documented in the `manual <https://www.bioconductor.org/packages/release/bioc/manuals/dada2/man/dada2.pdf#mergePairs>`_  and the function is introduced in the dedicated tutorial `section <https://benjjneb.github.io/dada2/tutorial.html#merge-paired-reads>`_.
 authors:
   - Charlie Pauvert
 input:
@@ -10,6 +10,6 @@ input:
   - derepF: RDS file with the dereplicated forward reads
   - derepR:                                reverse      
 params:
-  - optional arguments for mergePairs(), please provide them as python key=value pairs
+  - optional arguments for ``mergePairs()``, please provide them as python ``key=value`` pairs
 output:
   - RDS file with the merged pairs 

--- a/bio/dada2/merge-pairs/test/Snakefile
+++ b/bio/dada2/merge-pairs/test/Snakefile
@@ -4,6 +4,8 @@ rule dada2_merge_pairs:
       dadaR="denoised/{sample}.2.RDS",
       derepF="uniques/{sample}.1.RDS",# Dereplicated sequences
       derepR="uniques/{sample}.2.RDS"
+    output:
+        "merged/{sample}.RDS"
     # Even though this is an R wrapper, use named arguments in Python syntax
     # here, to specify extra parameters. Python booleans (`arg1=True`, `arg2=False`)
     # and lists (`list_arg=[]`) are automatically converted to R.
@@ -11,8 +13,6 @@ rule dada2_merge_pairs:
     #   (`named_list={name1=arg1}`).
     #params:
     #    verbose=True
-    output:
-        "merged/{sample}.RDS"
     log:
         "logs/dada2/merge-pairs/{sample}.log"
     threads: 1 # set desired number of threads here

--- a/bio/dada2/quality-profile/meta.yaml
+++ b/bio/dada2/quality-profile/meta.yaml
@@ -1,7 +1,7 @@
 name: dada2_quality_profiles
 description: |
   `DADA2 <https://benjjneb.github.io/dada2/index.html>`_
-  Plotting the quality profile of reads using dada2 plotQualityProfile function.
+  Plotting the quality profile of reads using dada2 ``plotQualityProfile`` function. The function is introduced in the dedicated tutorial `section <https://benjjneb.github.io/dada2/tutorial.html#inspect-read-quality-profiles>`_.
 authors:
   - Charlie Pauvert
 input:

--- a/bio/dada2/remove-chimeras/meta.yaml
+++ b/bio/dada2/remove-chimeras/meta.yaml
@@ -1,12 +1,12 @@
 name: dada2_remove_chimeras
 description: |
   `DADA2 <https://benjjneb.github.io/dada2/index.html>`_
-  Remove chimera sequences from the sequence table data using dada2 removeBimeraDenovo function. Optional parameters are documented in the `manual <https://www.bioconductor.org/packages/release/bioc/manuals/dada2/man/dada2.pdf>`_.
+  Remove chimera sequences from the sequence table data using dada2 ``removeBimeraDenovo`` function. Optional parameters are documented in the `manual <https://www.bioconductor.org/packages/release/bioc/manuals/dada2/man/dada2.pdf#removeBimeraDenovo>`_  and the function is introduced in the dedicated tutorial `section <https://benjjneb.github.io/dada2/tutorial.html#remove-chimeras>`_.
 authors:
   - Charlie Pauvert
 input:
   - RDS file with the sequence table
 params:
-  - optional arguments for removeBimeraDenovo(), please provide them as python key=value pairs
+  - optional arguments for ``removeBimeraDenovo()``, please provide them as python ``key=value`` pairs
 output:
   - RDS file with the chimera-free sequence table

--- a/bio/dada2/remove-chimeras/test/Snakefile
+++ b/bio/dada2/remove-chimeras/test/Snakefile
@@ -6,8 +6,8 @@ rule dada2_remove_chimeras:
     # and lists (`list_arg=[]`) are automatically converted to R.
     # For a named list as an extra named argument, use a python dict
     #   (`named_list={name1=arg1}`).
-    params:
-        verbose=True
+    #params:
+    #    verbose=True
     output:
         "results/dada2/seqTab.nochim.RDS" # Chimera-free sequence table
     log:

--- a/bio/dada2/remove-chimeras/test/Snakefile
+++ b/bio/dada2/remove-chimeras/test/Snakefile
@@ -1,6 +1,8 @@
 rule dada2_remove_chimeras:
     input:
         "results/dada2/seqTab.RDS" # Sequence table
+    output:
+        "results/dada2/seqTab.nochim.RDS" # Chimera-free sequence table
     # Even though this is an R wrapper, use named arguments in Python syntax
     # here, to specify extra parameters. Python booleans (`arg1=True`, `arg2=False`)
     # and lists (`list_arg=[]`) are automatically converted to R.
@@ -8,8 +10,6 @@ rule dada2_remove_chimeras:
     #   (`named_list={name1=arg1}`).
     #params:
     #    verbose=True
-    output:
-        "results/dada2/seqTab.nochim.RDS" # Chimera-free sequence table
     log:
         "logs/dada2/remove-chimeras/remove-chimeras.log"
     threads: 1 # set desired number of threads here

--- a/bio/dada2/sample-inference/meta.yaml
+++ b/bio/dada2/sample-inference/meta.yaml
@@ -1,7 +1,7 @@
 name: dada2_sample_inference
 description: |
   `DADA2 <https://benjjneb.github.io/dada2/index.html>`_
-  Inferring sample composition using dada2 dada function. Optional parameters are documented in the `manual <https://www.bioconductor.org/packages/release/bioc/manuals/dada2/man/dada2.pdf>`_.
+  Inferring sample composition using dada2 ``dada`` function. Optional parameters are documented in the `manual <https://www.bioconductor.org/packages/release/bioc/manuals/dada2/man/dada2.pdf#dada>`_  and the function is introduced in the dedicated tutorial `section <https://benjjneb.github.io/dada2/tutorial.html#sample-inference>`_.
 authors:
   - Charlie Pauvert
 input:
@@ -10,4 +10,4 @@ input:
 output:
   -  RDS file with the stored inferred sample composition
 params:
-  - optional arguments for dada(), please provide them as python key=value pairs
+  - optional arguments for ``dada()``, please provide them as python ``key=value`` pairs

--- a/bio/dada2/sample-inference/test/Snakefile
+++ b/bio/dada2/sample-inference/test/Snakefile
@@ -3,6 +3,8 @@ rule dada2_sample_inference:
     # Dereplicated (aka unique) sequences of the sample
         derep="uniques/{fastq}.RDS",
         err="results/dada2/model_1.RDS" # Error model
+    output:
+        "denoised/{fastq}.RDS" # Inferred sample composition
     # Even though this is an R wrapper, use named arguments in Python syntax
     # here, to specify extra parameters. Python booleans (`arg1=True`, `arg2=False`)
     # and lists (`list_arg=[]`) are automatically converted to R.
@@ -10,8 +12,6 @@ rule dada2_sample_inference:
     #   (`named_list={name1=arg1}`).
     #params:
     #    verbose=True
-    output:
-        "denoised/{fastq}.RDS" # Inferred sample composition
     log:
         "logs/dada2/sample-inference/{fastq}.log"
     threads: 1 # set desired number of threads here

--- a/test.py
+++ b/test.py
@@ -95,18 +95,6 @@ def run(wrapper, cmd, check_log=None):
             # go back to original directory
             os.chdir(origdir)
 
-def test_dada2_sample_inference():
-    run(
-        "bio/dada2/sample-inference",
-        ["snakemake", "--cores", "1", "--use-conda", "denoised/a.1.RDS"],
-    )
-
-def test_dada2_merge_pairs():
-    run(
-        "bio/dada2/merge-pairs",
-        ["snakemake", "--cores", "1", "--use-conda", "merged/a.RDS", "-F"],
-    )
-
 
 def test_mapdamage2():
     run(
@@ -119,75 +107,192 @@ def test_mapdamage2():
             "results/a/Runtime_log.txt",
         ],
     )
-    
-def test_dada2_add_species():
+
+
+def test_dada2_quality_profile_se():
     run(
-        "bio/dada2/add-species",
-        ["snakemake", "--cores", "1", "--use-conda", "results/dada2/taxa-sp.RDS"],
+        "bio/dada2/quality-profile",
+        [
+            "snakemake",
+            "--cores",
+            "1",
+            "reports/dada2/quality-profile/a-quality-profile.png",
+            "--use-conda",
+            "-F"
+            ]
     )
 
-def test_dada2_remove_chimeras():
+
+def test_dada2_quality_profile_pe():
     run(
-        "bio/dada2/remove-chimeras",
-        ["snakemake", "--cores", "1", "--use-conda", "results/dada2/seqTab.nochim.RDS"],
-    )
-    
-def test_dada2_assign_taxonomy():
-    run(
-        "bio/dada2/assign-taxonomy",
-        ["snakemake", "--cores", "1", "--use-conda", "results/dada2/taxa.RDS"],
+        "bio/dada2/quality-profile",
+        [
+            "snakemake",
+            "--cores",
+            "1",
+            "reports/dada2/quality-profile/a.1-quality-profile.png",
+            "--use-conda",
+            "-F"
+        ]
     )
 
-def test_dada2_make_table_se():
-    run(
-        "bio/dada2/make-table",
-        ["snakemake", "--cores", "1", "--use-conda", "results/dada2/seqTab-se.RDS"],
-    )
-    
-def test_dada2_make_table_pe():
-    run(
-        "bio/dada2/make-table",
-        ["snakemake", "--cores", "1", "--use-conda", "results/dada2/seqTab-pe.RDS"],
-    )
-  
-def test_dada2_dereplicate_fastq():
-    run(
-        "bio/dada2/dereplicate-fastq",
-        ["snakemake", "--cores", "1", "--use-conda", "uniques/a.1.RDS"],
-    )
-
-def test_dada2_learn_errors():
-    run(
-        "bio/dada2/learn-errors",
-        ["snakemake", "--cores", "1", "--use-conda", "results/dada2/model_1.RDS"],
-    )
 
 def test_dada2_filter_trim_se():
     run(
         "bio/dada2/filter-trim",
-        ["snakemake", "--cores", "1", "filtered-se/a.1.fastq.gz", "--use-conda", "-F"]
+        [
+            "snakemake",
+            "--cores",
+            "1",
+            "filtered-se/a.1.fastq.gz",
+            "--use-conda",
+            "-F"
+        ]
     )
+
 
 def test_dada2_filter_trim_pe():
     run(
         "bio/dada2/filter-trim",
-        ["snakemake", "--cores", "1", "filtered-pe/a.1.fastq.gz", "--use-conda", "-F"],
+        [
+            "snakemake",
+            "--cores",
+            "1",
+            "filtered-pe/a.1.fastq.gz",
+            "--use-conda",
+            "-F"
+         ]
+        )
+
+
+def test_dada2_dereplicate_fastq():
+    run(
+        "bio/dada2/dereplicate-fastq",
+        [
+            "snakemake",
+            "--cores",
+            "1",
+            "--use-conda",
+            "uniques/a.1.RDS"
+        ]
     )
 
-def test_dada2_quality_profile_pe():
-    run("bio/dada2/quality-profile",
-        ["snakemake", "--cores", "1", "reports/dada2/quality-profile/a.1-quality-profile.png", "--use-conda", "-F"],
+
+def test_dada2_learn_errors():
+    run(
+        "bio/dada2/learn-errors",
+        [
+            "snakemake",
+            "--cores",
+            "1",
+            "--use-conda",
+            "results/dada2/model_1.RDS"
+         ]
+        )
+
+
+def test_dada2_sample_inference():
+    run(
+        "bio/dada2/sample-inference",
+        [
+            "snakemake",
+            "--cores",
+            "1",
+            "--use-conda",
+            "denoised/a.1.RDS"
+        ]
     )
-    
-def test_dada2_quality_profile_se():
-    run("bio/dada2/quality-profile",
-        ["snakemake", "--cores", "1", "reports/dada2/quality-profile/a-quality-profile.png", "--use-conda", "-F"],
+
+
+def test_dada2_merge_pairs():
+    run(
+        "bio/dada2/merge-pairs",
+        [
+            "snakemake",
+            "--cores",
+            "1",
+            "--use-conda",
+            "merged/a.RDS",
+            "-F"
+        ]
     )
+
+
+def test_dada2_make_table_se():
+    run(
+        "bio/dada2/make-table",
+        [
+            "snakemake",
+            "--cores",
+            "1",
+            "--use-conda",
+            "results/dada2/seqTab-se.RDS"
+         ]
+    )
+
+
+def test_dada2_make_table_pe():
+    run(
+            "bio/dada2/make-table",
+        [
+            "snakemake",
+            "--cores",
+            "1",
+            "--use-conda",
+            "results/dada2/seqTab-pe.RDS"
+        ]
+    )
+
+
+def test_dada2_remove_chimeras():
+    run(
+        "bio/dada2/remove-chimeras",
+        [
+            "snakemake",
+            "--cores",
+            "1",
+            "--use-conda",
+            "results/dada2/seqTab.nochim.RDS"
+        ]
+    )
+
+
+def test_dada2_assign_taxonomy():
+    run(
+        "bio/dada2/assign-taxonomy",
+        [
+            "snakemake",
+            "--cores",
+            "1",
+            "--use-conda",
+            "results/dada2/taxa.RDS"
+        ]
+    )
+
+
+def test_dada2_add_species():
+    run(
+        "bio/dada2/add-species",
+        [
+            "snakemake",
+            "--cores",
+            "1",
+            "--use-conda",
+            "results/dada2/taxa-sp.RDS"
+        ]
+    )
+
 
 def test_arriba_star_meta():
     run(
         "meta/bio/star_arriba",
-        ["snakemake", "--cores", "1", "--use-conda", "results/arriba/a.fusions.tsv"],
+        [
+            "snakemake",
+            "--cores",
+            "1",
+            "--use-conda",
+            "results/arriba/a.fusions.tsv"
+        ]
     )
 
 


### PR DESCRIPTION
Hi,
Here are a final PR to clean up the recently added `dada2` wrappers (thanks to @dlaehnemann).

* Add links to tutorial sections
* Fix typos
* Format nicely function names for the docs
* Reorder the test in `test.py`
* Wrap lines for dada2 tests.

The `make html` for the docs ran smoothly.

If you spot something else, do not hesitate!
Best, 
Charlie