### PR TITLE
Automated detection of BAI file, memory, and temp dir

### DIFF
--- a/bio/gatk3/indelrealigner/meta.yaml
+++ b/bio/gatk3/indelrealigner/meta.yaml
@@ -5,10 +5,11 @@ authors:
   - Patrik Smeds
   - Filipe G. Vieira
 input:
-  - input bam file (indexed)
-  - vcf files of known variation (indexed)
+  - bam file
+  - vcf files
   - reference genome
   - target intervals to realign
+  - bed file (optional)
 output:
   - indel realigned bam file
   - indel realigned bai file (optional)

--- a/bio/gatk3/indelrealigner/meta.yaml
+++ b/bio/gatk3/indelrealigner/meta.yaml
@@ -3,15 +3,18 @@ description: |
   Run gatk3 IndelRealigner
 authors:
   - Patrik Smeds
+  - Filipe G. Vieira
 input:
-  - bam file
-  - vcf files
-  - reference genome
-  - target intervals
+  - `bam`: input bam file (indexed)
+  - `known`: vcf files of known variation (indexed)
+  - `ref`: reference genome
+  - `target_intervals`: target intervals to realign
 output:
-  - indel realigned bam file
+  - `bam`: indel realigned bam file
+  - `bai`: indel realigned bai file (optional)
+  - `java_temp`: temp dir (optional)
 notes: |
-  * The `java_opts` param allows for additional arguments to be passed to the java compiler, e.g. "-Xmx4G" for one, and "-Xmx4G -XX:ParallelGCThreads=10" for two options.
+  * The `java_opts` param allows for additional arguments to be passed to the java compiler, e.g. "-XX:ParallelGCThreads=10" (memory is automatically inferred from `resources` and temp dir from `output.java_temp`.
   * The `extra` param alllows for additional program arguments.
   * For more inforamtion see, https://software.broadinstitute.org/gatk/documentation/article?id=11050
   * Gatk3.jar is not included in the bioconda package, i.e it need to be added to the conda environment manually.

--- a/bio/gatk3/indelrealigner/meta.yaml
+++ b/bio/gatk3/indelrealigner/meta.yaml
@@ -5,14 +5,14 @@ authors:
   - Patrik Smeds
   - Filipe G. Vieira
 input:
-  - `bam`: input bam file (indexed)
-  - `known`: vcf files of known variation (indexed)
-  - `ref`: reference genome
-  - `target_intervals`: target intervals to realign
+  - input bam file (indexed)
+  - vcf files of known variation (indexed)
+  - reference genome
+  - target intervals to realign
 output:
-  - `bam`: indel realigned bam file
-  - `bai`: indel realigned bai file (optional)
-  - `java_temp`: temp dir (optional)
+  - indel realigned bam file
+  - indel realigned bai file (optional)
+  - temp dir (optional)
 notes: |
   * The `java_opts` param allows for additional arguments to be passed to the java compiler, e.g. "-XX:ParallelGCThreads=10" (memory is automatically inferred from `resources` and temp dir from `output.java_temp`.
   * The `extra` param alllows for additional program arguments.

--- a/bio/gatk3/indelrealigner/test/Snakefile
+++ b/bio/gatk3/indelrealigner/test/Snakefile
@@ -1,11 +1,13 @@
 rule indelrealigner:
     input:
-        bam="mapped/{sample}.bam",
+        bam="mapped/{sample}.bam",              # input bam file (indexed)
         ref="genome.fasta",
-        known="dbsnp.vcf.gz",
+        known="dbsnp.vcf.gz",                   # vcf files of known variation (indexed)
         target_intervals="{sample}.intervals"
     output:
-        bam="realigned/{sample}.bam"
+        bam="realigned/{sample}.bam",
+        bai="realigned/{sample}.bai",
+        java_temp=temp(directory("/tmp/gatk3_indelrealigner/{sample}")),
     log:
         "logs/gatk3/indelrealigner/{sample}.log"
     params:
@@ -13,5 +15,7 @@ rule indelrealigner:
     resources:
         mem_mb = 1024
     threads: 16
+    resources:
+        mem_mb = 10240
     wrapper:
         "bio/gatk/indelrealigner"

--- a/bio/gatk3/indelrealigner/test/Snakefile
+++ b/bio/gatk3/indelrealigner/test/Snakefile
@@ -1,15 +1,15 @@
 rule indelrealigner:
     input:
         bam="mapped/{sample}.bam",
-	bai="mapped/{sample}.bai",
+        bai="mapped/{sample}.bai",
         ref="genome.fasta",
         known="dbsnp.vcf.gz",
-	known_idx="dbsnp.vcf.gz.tbi",
+        known_idx="dbsnp.vcf.gz.tbi",
         target_intervals="{sample}.intervals"
     output:
         bam="realigned/{sample}.bam",
         bai="realigned/{sample}.bai",
-	java_temp=temp(directory("/tmp/gatk3_indelrealigner/{sample}")),
+        java_temp=temp(directory("/tmp/gatk3_indelrealigner/{sample}")),
     log:
         "logs/gatk3/indelrealigner/{sample}.log"
     params:

--- a/bio/gatk3/indelrealigner/test/Snakefile
+++ b/bio/gatk3/indelrealigner/test/Snakefile
@@ -1,21 +1,21 @@
 rule indelrealigner:
     input:
-        bam="mapped/{sample}.bam",              # input bam file (indexed)
+        bam="mapped/{sample}.bam",
+	bai="mapped/{sample}.bai",
         ref="genome.fasta",
-        known="dbsnp.vcf.gz",                   # vcf files of known variation (indexed)
+        known="dbsnp.vcf.gz",
+	known_idx="dbsnp.vcf.gz.tbi",
         target_intervals="{sample}.intervals"
     output:
         bam="realigned/{sample}.bam",
         bai="realigned/{sample}.bai",
-        java_temp=temp(directory("/tmp/gatk3_indelrealigner/{sample}")),
+	java_temp=temp(directory("/tmp/gatk3_indelrealigner/{sample}")),
     log:
         "logs/gatk3/indelrealigner/{sample}.log"
     params:
         extra=""  # optional
-    resources:
-        mem_mb = 1024
     threads: 16
     resources:
-        mem_mb = 10240
+        mem_mb = 1024
     wrapper:
         "bio/gatk/indelrealigner"

--- a/bio/gatk3/indelrealigner/wrapper.py
+++ b/bio/gatk3/indelrealigner/wrapper.py
@@ -8,30 +8,10 @@ import os
 from snakemake.shell import shell
 from snakemake_wrapper_utils.java import get_java_opts
 
+input_known = snakemake.input.known
 extra = snakemake.params.get("extra", "")
 java_opts = get_java_opts(snakemake)
 
-input_bam = snakemake.input.bam
-input_known = snakemake.input.known
-input_ref = snakemake.input.ref
-input_target_intervals = snakemake.input.target_intervals
-output_bam = snakemake.output.bam
-
-# Getting memory in megabytes, if java opts is not filled with -Xmx parameter
-# By doing so, backward compatibility is preserved
-if "mem_mb" in snakemake.resources.keys() and not "-Xmx" in java_opts:
-    java_opts += " -Xmx{}M".format(snakemake.resources["mem_mb"])
-
-# Getting memory in gigabytes, for user convenience. Please prefer the use
-# of mem_mb over mem_gb as advised in documentation.
-elif "mem_gb" in snakemake.resources.keys() and not "-Xmx" in java_opts:
-    java_opts += " -Xmx{}G".format(snakemake.resources["mem_gb"])
-
-# Getting java temp directory from output files list, if -Djava.io.tmpdir
-# is not provided in java parameters. By doing so, backward compatibility is
-# not broken.
-if "java_temp" in snakemake.output.keys() and not "-Djava.io.tmpdir" in java_opts:
-    java_opts += " -Djava.io.tmpdir={}".format(snakemake.output["java_temp"])
 
 bed = snakemake.input.get("bed", None)
 if bed is not None:
@@ -39,24 +19,28 @@ if bed is not None:
 else:
     bed = ""
 
+
 input_known_string = ""
 for known in input_known:
     input_known_string = input_known_string + " -known {}".format(known)
+
 
 output_bai = snakemake.output.get("bai", None)
 if output_bai is None:
     extra += " --disable_bam_indexing"
 
+
 log = snakemake.log_fmt_shell(stdout=True, stderr=True)
+
 
 shell(
     "gatk3 {java_opts} -T IndelRealigner"
     " {extra}"
-    " -I {input_bam}"
-    " -R {input_ref}"
+    " -I {snakemake.input.bam}"
+    " -R {snakemake.input.ref}"
     " {input_known_string}"
     " {bed}"
-    " --targetIntervals {input_target_intervals}"
+    " --targetIntervals {snakemake.input.target_intervals}"
     " -o {snakemake.output.bam}"
     " {log}"
 )

--- a/bio/gatk3/indelrealigner/wrapper.py
+++ b/bio/gatk3/indelrealigner/wrapper.py
@@ -15,6 +15,23 @@ input_bam = snakemake.input.bam
 input_known = snakemake.input.known
 input_ref = snakemake.input.ref
 input_target_intervals = snakemake.input.target_intervals
+output_bam = snakemake.output.bam
+
+# Getting memory in megabytes, if java opts is not filled with -Xmx parameter
+# By doing so, backward compatibility is preserved
+if "mem_mb" in snakemake.resources.keys() and not "-Xmx" in java_opts:
+    java_opts += " -Xmx{}M".format(snakemake.resources["mem_mb"])
+
+# Getting memory in gigabytes, for user convenience. Please prefer the use
+# of mem_mb over mem_gb as advised in documentation.
+elif "mem_gb" in snakemake.resources.keys() and not "-Xmx" in java_opts:
+    java_opts += " -Xmx{}G".format(snakemake.resources["mem_gb"])
+
+# Getting java temp directory from output files list, if -Djava.io.tmpdir
+# is not provided in java parameters. By doing so, backward compatibility is
+# not broken.
+if "java_temp" in snakemake.output.keys() and not "-Djava.io.tmpdir" in java_opts:
+    java_opts += " -Djava.io.tmpdir={}".format(snakemake.output["java_temp"])
 
 bed = snakemake.params.get("bed", None)
 if bed is not None:
@@ -26,6 +43,10 @@ input_known_string = ""
 for known in input_known:
     input_known_string = input_known_string + " -known {}".format(known)
 
+output_bai = snakemake.output.get("bai", None)
+if output_bai is None:
+    extra += "--disable_bam_indexing"
+
 log = snakemake.log_fmt_shell(stdout=True, stderr=True)
 
 shell(
@@ -36,6 +57,6 @@ shell(
     " {input_known_string}"
     " {bed}"
     " --targetIntervals {input_target_intervals}"
-    " -o {snakemake.output}"
+    " -o {output_bam}"
     " {log}"
 )

--- a/bio/gatk3/indelrealigner/wrapper.py
+++ b/bio/gatk3/indelrealigner/wrapper.py
@@ -41,7 +41,7 @@ else:
 
 input_known_string = ""
 for known in input_known:
-    input_known_string = input_known_string + " --known {}".format(known)
+    input_known_string = input_known_string + " -known {}".format(known)
 
 output_bai = snakemake.output.get("bai", None)
 if output_bai is None:

--- a/bio/gatk3/indelrealigner/wrapper.py
+++ b/bio/gatk3/indelrealigner/wrapper.py
@@ -57,6 +57,6 @@ shell(
     " {input_known_string}"
     " {bed}"
     " --targetIntervals {input_target_intervals}"
-    " -o {output_bam}"
+    " -o {snakemake.output.bam}"
     " {log}"
 )

--- a/bio/gatk3/indelrealigner/wrapper.py
+++ b/bio/gatk3/indelrealigner/wrapper.py
@@ -33,7 +33,7 @@ elif "mem_gb" in snakemake.resources.keys() and not "-Xmx" in java_opts:
 if "java_temp" in snakemake.output.keys() and not "-Djava.io.tmpdir" in java_opts:
     java_opts += " -Djava.io.tmpdir={}".format(snakemake.output["java_temp"])
 
-bed = snakemake.params.get("bed", None)
+bed = snakemake.input.get("bed", None)
 if bed is not None:
     bed = "-L " + bed
 else:
@@ -41,7 +41,7 @@ else:
 
 input_known_string = ""
 for known in input_known:
-    input_known_string = input_known_string + " -known {}".format(known)
+    input_known_string = input_known_string + " --known {}".format(known)
 
 output_bai = snakemake.output.get("bai", None)
 if output_bai is None:

--- a/bio/gatk3/indelrealigner/wrapper.py
+++ b/bio/gatk3/indelrealigner/wrapper.py
@@ -45,7 +45,7 @@ for known in input_known:
 
 output_bai = snakemake.output.get("bai", None)
 if output_bai is None:
-    extra += "--disable_bam_indexing"
+    extra += " --disable_bam_indexing"
 
 log = snakemake.log_fmt_shell(stdout=True, stderr=True)
 

--- a/bio/gatk3/realignertargetcreator/meta.yaml
+++ b/bio/gatk3/realignertargetcreator/meta.yaml
@@ -3,14 +3,17 @@ description: |
   Run gatk3 RealignerTargetCreator
 authors:
   - Patrik Smeds
+  - Filipe G. Vieira
 input:
   - bam file
   - vcf files
   - reference genome
+  - bed file (optional)
 output:
   - target intervals
+  - temp dir (optional)
 notes: |
-  * The `java_opts` param allows for additional arguments to be passed to the java compiler, e.g. "-Xmx4G" for one, and "-Xmx4G -XX:ParallelGCThreads=10" for two options.
+  * The `java_opts` param allows for additional arguments to be passed to the java compiler, e.g. "-XX:ParallelGCThreads=10" (memory is automatically inferred from `resources` and temp dir from `output.java_temp`.
   * The `extra` param alllows for additional program arguments.
   * For more inforamtion see, https://software.broadinstitute.org/gatk/documentation/article?id=11050
   * Gatk3.jar is not included in the bioconda package, i.e it need to be added to the conda environment manually.

--- a/bio/gatk3/realignertargetcreator/test/Snakefile
+++ b/bio/gatk3/realignertargetcreator/test/Snakefile
@@ -4,7 +4,8 @@ rule realignertargetcreator:
         ref="genome.fasta",
         known="dbsnp.vcf.gz"
     output:
-        "{sample}.intervals"
+        intervals="{sample}.intervals",
+	java_temp=temp(directory("/tmp/gatk3_indelrealigner/{sample}")),
     log:
         "logs/gatk/realignertargetcreator/{sample}.log"
     params:

--- a/bio/gatk3/realignertargetcreator/test/Snakefile
+++ b/bio/gatk3/realignertargetcreator/test/Snakefile
@@ -5,7 +5,7 @@ rule realignertargetcreator:
         known="dbsnp.vcf.gz"
     output:
         intervals="{sample}.intervals",
-	java_temp=temp(directory("/tmp/gatk3_indelrealigner/{sample}")),
+        java_temp=temp(directory("/tmp/gatk3_indelrealigner/{sample}")),
     log:
         "logs/gatk/realignertargetcreator/{sample}.log"
     params:

--- a/bio/gatk3/realignertargetcreator/wrapper.py
+++ b/bio/gatk3/realignertargetcreator/wrapper.py
@@ -14,7 +14,24 @@ java_opts = get_java_opts(snakemake)
 input_bam = snakemake.input.bam
 input_known = snakemake.input.known
 input_ref = snakemake.input.ref
-bed = snakemake.params.get("bed", None)
+
+# Getting memory in megabytes, if java opts is not filled with -Xmx parameter
+# By doing so, backward compatibility is preserved
+if "mem_mb" in snakemake.resources.keys() and not "-Xmx" in java_opts:
+    java_opts += " -Xmx{}M".format(snakemake.resources["mem_mb"])
+
+# Getting memory in gigabytes, for user convenience. Please prefer the use
+# of mem_mb over mem_gb as advised in documentation.
+elif "mem_gb" in snakemake.resources.keys() and not "-Xmx" in java_opts:
+    java_opts += " -Xmx{}G".format(snakemake.resources["mem_gb"])
+
+# Getting java temp directory from output files list, if -Djava.io.tmpdir
+# is not provided in java parameters. By doing so, backward compatibility is
+# not broken.
+if "java_temp" in snakemake.output.keys() and not "-Djava.io.tmpdir" in java_opts:
+    java_opts += " -Djava.io.tmpdir={}".format(snakemake.output["java_temp"])
+
+bed = snakemake.input.get("bed", None)
 if bed is not None:
     bed = "-L " + bed
 else:

--- a/bio/gatk3/realignertargetcreator/wrapper.py
+++ b/bio/gatk3/realignertargetcreator/wrapper.py
@@ -39,7 +39,7 @@ else:
 
 input_known_string = ""
 for known in input_known:
-    input_known_string = input_known_string + " --known {}".format(known)
+    input_known_string = input_known_string + " -known {}".format(known)
 
 log = snakemake.log_fmt_shell(stdout=True, stderr=True)
 

--- a/bio/gatk3/realignertargetcreator/wrapper.py
+++ b/bio/gatk3/realignertargetcreator/wrapper.py
@@ -8,28 +8,10 @@ import os
 from snakemake.shell import shell
 from snakemake_wrapper_utils.java import get_java_opts
 
+input_known = snakemake.input.known
 extra = snakemake.params.get("extra", "")
 java_opts = get_java_opts(snakemake)
 
-input_bam = snakemake.input.bam
-input_known = snakemake.input.known
-input_ref = snakemake.input.ref
-
-# Getting memory in megabytes, if java opts is not filled with -Xmx parameter
-# By doing so, backward compatibility is preserved
-if "mem_mb" in snakemake.resources.keys() and not "-Xmx" in java_opts:
-    java_opts += " -Xmx{}M".format(snakemake.resources["mem_mb"])
-
-# Getting memory in gigabytes, for user convenience. Please prefer the use
-# of mem_mb over mem_gb as advised in documentation.
-elif "mem_gb" in snakemake.resources.keys() and not "-Xmx" in java_opts:
-    java_opts += " -Xmx{}G".format(snakemake.resources["mem_gb"])
-
-# Getting java temp directory from output files list, if -Djava.io.tmpdir
-# is not provided in java parameters. By doing so, backward compatibility is
-# not broken.
-if "java_temp" in snakemake.output.keys() and not "-Djava.io.tmpdir" in java_opts:
-    java_opts += " -Djava.io.tmpdir={}".format(snakemake.output["java_temp"])
 
 bed = snakemake.input.get("bed", None)
 if bed is not None:
@@ -37,9 +19,11 @@ if bed is not None:
 else:
     bed = ""
 
+
 input_known_string = ""
 for known in input_known:
     input_known_string = input_known_string + " -known {}".format(known)
+
 
 log = snakemake.log_fmt_shell(stdout=True, stderr=True)
 
@@ -48,10 +32,10 @@ shell(
     "gatk3 {java_opts} -T RealignerTargetCreator"
     " -nt {snakemake.threads}"
     " {extra}"
-    " -I {input_bam}"
-    " -R {input_ref}"
+    " -I {snakemake.input.bam}"
+    " -R {snakemake.input.ref}"
     " {input_known_string}"
     " {bed}"
-    " -o {snakemake.output}"
+    " -o {snakemake.output.intervals}"
     " {log}"
 )


### PR DESCRIPTION
Added automated detection of BAI file (generated by default), memory, and temp dir.
Set BED file as an input file and not a parameter.