### PR TITLE
CACHE_VERSION to VERSION

### DIFF
--- a/bio/vep/cache/wrapper.py
+++ b/bio/vep/cache/wrapper.py
@@ -13,7 +13,7 @@ shell(
     "vep_install --AUTO cf "
     "--SPECIES {snakemake.params.species} "
     "--ASSEMBLY {snakemake.params.build} "
-    "--CACHE_VERSION {snakemake.params.release} "
+    "--VERSION {snakemake.params.release} "
     "--CACHEDIR {snakemake.output} "
     "--CONVERT "
     "--NO_UPDATE "


### PR DESCRIPTION
In newer interations of ensembl-vep and `vep_install` the `--CACHE_VERSION` flag is now `--VERSION`, and this throws an error (this is now the default with `conda` installing ensembl-vep.