### PR TITLE
Normalize in freebayes

### DIFF
--- a/bio/freebayes/wrapper.py
+++ b/bio/freebayes/wrapper.py
@@ -12,7 +12,7 @@ log = snakemake.log_fmt_shell(stdout=False, stderr=True)
 
 params = snakemake.params.get("extra", "")
 norm = snakemake.params.get("normalize", "False")
-assert(norm in ["True", "False"]
+assert norm in ["True", "False"]
 norm = norm == "True"
 
 pipe = ""
@@ -28,8 +28,10 @@ if snakemake.threads == 1:
     freebayes = "freebayes"
 else:
     chunksize = snakemake.params.get("chunksize", 100000)
-    regions = "<(fasta_generate_regions.py {snakemake.input.ref}.fai {chunksize})".format(
-        snakemake=snakemake, chunksize=chunksize
+    regions = (
+        "<(fasta_generate_regions.py {snakemake.input.ref}.fai {chunksize})".format(
+            snakemake=snakemake, chunksize=chunksize
+        )
     )
     if snakemake.input.get("regions", ""):
         regions = (

--- a/bio/freebayes/wrapper.py
+++ b/bio/freebayes/wrapper.py
@@ -11,10 +11,18 @@ shell.executable("bash")
 log = snakemake.log_fmt_shell(stdout=False, stderr=True)
 
 params = snakemake.params.get("extra", "")
+norm = snakemake.params.get("normalize", "False")
+assert(norm in ["True", "False"]
+norm = norm == "True"
 
 pipe = ""
 if snakemake.output[0].endswith(".bcf"):
-    pipe = "| bcftools view -Ob -"
+    if norm:
+        pipe = "| bcftools norm -Ob -"
+    else:
+        pipe = "| bcftools view -Ob -"
+elif norm:
+    pipe = "| bcftools norm -"
 
 if snakemake.threads == 1:
     freebayes = "freebayes"

--- a/bio/freebayes/wrapper.py
+++ b/bio/freebayes/wrapper.py
@@ -28,10 +28,8 @@ if snakemake.threads == 1:
     freebayes = "freebayes"
 else:
     chunksize = snakemake.params.get("chunksize", 100000)
-    regions = (
-        "<(fasta_generate_regions.py {snakemake.input.ref}.fai {chunksize})".format(
-            snakemake=snakemake, chunksize=chunksize
-        )
+    regions = "<(fasta_generate_regions.py {snakemake.input.ref}.fai {chunksize})".format(
+        snakemake=snakemake, chunksize=chunksize
     )
     if snakemake.input.get("regions", ""):
         regions = (


### PR DESCRIPTION
Sometimes freebayes does not normalize indels. This PR adds a flag to perform bcftools norm after calling.