### PR TITLE
chm_eval: remove symlink to chm_eval_kit output that does not exist in repo

### DIFF
--- a/bio/benchmark/chm-eval/test/Snakefile
+++ b/bio/benchmark/chm-eval/test/Snakefile
@@ -8,7 +8,7 @@ rule chm_eval_kit:                           # [hide]
         "logs/chm-eval-kit.log"              # [hide]
     cache: True                              # [hide]
     wrapper:                                 # [hide]
-        "0.67.0/bio/benchmark/chm-eval-kit"  # [hide]
+        "master/bio/benchmark/chm-eval-kit"  # [hide]
                                              # [hide]
 
 

--- a/bio/benchmark/chm-eval/test/resources
+++ b/bio/benchmark/chm-eval/test/resources
@@ -1,1 +1,0 @@
-../../chm-eval-kit/test/resources/


### PR DESCRIPTION
This seems like the current reason for tests still failing on the master branch.