### PR TITLE
Fix a typo in docstring.

### DIFF
--- a/bio/cutadapt/se/wrapper.py
+++ b/bio/cutadapt/se/wrapper.py
@@ -1,4 +1,4 @@
-"""Snakemake wrapper for trimming paired-end reads using cutadapt."""
+"""Snakemake wrapper for trimming single-end reads using cutadapt."""
 
 __author__ = "Julian de Ruiter"
 __copyright__ = "Copyright 2017, Julian de Ruiter"


### PR DESCRIPTION
Before: "paired-end"
After: "single-end"