### PR TITLE
update run_busco command to busco

### DIFF
--- a/bio/busco/environment.yaml
+++ b/bio/busco/environment.yaml
@@ -3,6 +3,6 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - python ==3.6
-  - busco
+  - python==3.6
+  - busco==5.0.0
 

--- a/bio/busco/wrapper.py
+++ b/bio/busco/wrapper.py
@@ -25,7 +25,7 @@ else:
 # note: --force allows snakemake to handle rewriting files as necessary
 # without needing to specify *all* busco outputs as snakemake outputs
 shell(
-    "run_busco --in {snakemake.input} --out {out_name} --force "
+    "busco --in {snakemake.input} --out {out_name} --force "
     " --cpu {snakemake.threads} --mode {mode} --lineage {lineage} "
     " {extra} {log}"
 )


### PR DESCRIPTION
As of version 4.0.0 on onwards, the command to run busco is no longer run_busco as it used to be, and is now simply 'busco'. This breaks the wrapper. I have edited it to the correct 'busco'