### PR TITLE
Implemented ability to run picard MarkDuplicates on multiple BAMs.

### DIFF
--- a/bio/gatk/genotypegvcfs/test/Snakefile
+++ b/bio/gatk/genotypegvcfs/test/Snakefile
@@ -1,6 +1,8 @@
 rule genotype_gvcfs:
     input:
         gvcf="calls/all.g.vcf",  # combined gvcf over multiple samples
+	# N.B. gvcf or genomicsdb must be specified
+	# in the latter case, this is a GenomicsDB data store
         ref="genome.fasta"
     output:
         vcf="calls/all.vcf",

--- a/bio/gatk/genotypegvcfs/wrapper.py
+++ b/bio/gatk/genotypegvcfs/wrapper.py
@@ -21,7 +21,7 @@ if dbsnp:
 
 # Allow for either an input gvcf or GenomicsDB
 gvcf = snakemake.input.get("gvcf", "")
-genomicsdb = snakemake.input.get("genomicsdb")
+genomicsdb = snakemake.input.get("genomicsdb", "")
 if gvcf:
     if genomicsdb:
         raise Exception("Only input.gvcf or input.genomicsdb expected, got both.")

--- a/bio/gatk/genotypegvcfs/wrapper.py
+++ b/bio/gatk/genotypegvcfs/wrapper.py
@@ -12,11 +12,36 @@ from snakemake_wrapper_utils.java import get_java_opts
 
 extra = snakemake.params.get("extra", "")
 java_opts = get_java_opts(snakemake)
+interval_file = snakemake.input.get("interval_file", "")
+if interval_file:
+    interval_file = "-L {}".format(interval_file)
+dbsnp = snakemake.input.get("known", "")
+if dbsnp:
+    dbsnp = "-D {}".format(dbsnp)
+
+# Allow for either an input gvcf or GenomicsDB
+gvcf = snakemake.input.get("gvcf", "")
+genomicsdb = snakemake.input.get("genomicsdb")
+if gvcf:
+    if genomicsdb:
+        raise Exception("Only input.gvcf or input.genomicsdb expected, got both.")
+    input_string = gvcf
+else:
+    if genomicsdb:
+        input_string = "gendb://{}".format(genomicsdb)
+    else:
+        raise Exception("Expected input.gvcf or input.genomicsdb.")
+tmp_dir = snakemake.params.get("tmp_dir", "")
+if tmp_dir:
+    tmp_dir = "--tmp-dir={}".format(tmp_dir)
 
 log = snakemake.log_fmt_shell(stdout=True, stderr=True)
 shell(
     "gatk --java-options '{java_opts}' GenotypeGVCFs {extra} "
-    "-V {snakemake.input.gvcf} "
+    "-V {input_string} "
     "-R {snakemake.input.ref} "
+    "{dbsnp} "
+    "{interval_file} "
+    "{tmp_dir} "
     "-O {snakemake.output.vcf} {log}"
 )

--- a/bio/picard/markduplicates/meta.yaml
+++ b/bio/picard/markduplicates/meta.yaml
@@ -4,6 +4,6 @@ description: |
 authors:
   - Johannes Köster
 input:
-  - bam file
+  - bam file(s)
 output:
   - bam file with marked or removed duplicates

--- a/bio/picard/markduplicates/test/Snakefile
+++ b/bio/picard/markduplicates/test/Snakefile
@@ -1,6 +1,9 @@
 rule mark_duplicates:
     input:
         "mapped/{sample}.bam"
+	# multiple BAMs may be entered as a list; this has the effect of merging
+	# multiple read groups from one sample into a single BAM while retaining
+	# the read group information
     output:
         bam="dedup/{sample}.bam",
         metrics="dedup/{sample}.metrics.txt"


### PR DESCRIPTION
As noted here (https://gatk.broadinstitute.org/hc/en-us/articles/360035889471-How-should-I-pre-process-data-from-multiplexed-sequencing-and-multi-library-designs-):

> 2. Merge read groups and mark duplicates per sample (aggregation + dedup)
> 
> Once you have pre-processed each read group individually, you merge read groups belonging to the same sample into a single BAM file. You can do this as a standalone step, bur for the sake of efficiency we combine this with the per-sample duplicate marking step (it's simply a matter of passing the multiple inputs to MarkDuplicates in a single command).