### PR TITLE
Implemented running MarkDuplicates on multiple bams.

### DIFF
--- a/bio/picard/markduplicates/meta.yaml
+++ b/bio/picard/markduplicates/meta.yaml
@@ -4,6 +4,6 @@ description: |
 authors:
   - Johannes Köster
 input:
-  - bam file
+  - bam file(s)
 output:
   - bam file with marked or removed duplicates

--- a/bio/picard/markduplicates/test/Snakefile
+++ b/bio/picard/markduplicates/test/Snakefile
@@ -1,6 +1,9 @@
 rule mark_duplicates:
     input:
         "mapped/{sample}.bam"
+	# optional to specify a list of BAMs; this has the same effect
+	# of marking duplicates on separate read groups for a sample
+	# and then merging
     output:
         bam="dedup/{sample}.bam",
         metrics="dedup/{sample}.metrics.txt"

--- a/bio/picard/markduplicates/wrapper.py
+++ b/bio/picard/markduplicates/wrapper.py
@@ -11,12 +11,16 @@ log = snakemake.log_fmt_shell(stdout=True, stderr=True)
 
 extra = snakemake.params
 java_opts = get_java_opts(snakemake)
+bams = snakemake.input
+if isinstance(bams, str):
+    bams = [bams]
+bams = list(map("-I {}".format, bams))
 
 shell(
     "picard MarkDuplicates "  # Tool and its subcommand
     "{java_opts} "  # Automatic java option
     "{extra} "  # User defined parmeters
-    "INPUT={snakemake.input} "  # Input file
+    "{bams} "  # Input bam(s)
     "OUTPUT={snakemake.output.bam} "  # Output bam
     "METRICS_FILE={snakemake.output.metrics} "  # Output metrics
     "{log}"  # Logging

--- a/bio/picard/markduplicates/wrapper.py
+++ b/bio/picard/markduplicates/wrapper.py
@@ -14,7 +14,7 @@ java_opts = get_java_opts(snakemake)
 bams = snakemake.input
 if isinstance(bams, str):
     bams = [bams]
-bams = list(map("-I {}".format, bams))
+bams = list(map("--INPUT {}".format, bams))
 
 shell(
     "picard MarkDuplicates "  # Tool and its subcommand

--- a/bio/picard/markduplicates/wrapper.py
+++ b/bio/picard/markduplicates/wrapper.py
@@ -14,7 +14,7 @@ java_opts = get_java_opts(snakemake)
 bams = snakemake.input
 if isinstance(bams, str):
     bams = [bams]
-bams = list(map("--INPUT {}".format, bams))
+bams = list(map("INPUT={}".format, bams))
 
 shell(
     "picard MarkDuplicates "  # Tool and its subcommand

--- a/bio/picard/markduplicates/wrapper.py
+++ b/bio/picard/markduplicates/wrapper.py
@@ -9,7 +9,7 @@ from snakemake_wrapper_utils.java import get_java_opts
 
 log = snakemake.log_fmt_shell(stdout=True, stderr=True)
 
-extra = snakemake.params
+extra = snakemake.params.get("extra", "")
 java_opts = get_java_opts(snakemake)
 bams = snakemake.input
 if isinstance(bams, str):


### PR DESCRIPTION
As noted in https://gatk.broadinstitute.org/hc/en-us/articles/360035889471-How-should-I-pre-process-data-from-multiplexed-sequencing-and-multi-library-designs- :

> 2. Merge read groups and mark duplicates per sample (aggregation + dedup)
> 
> Once you have pre-processed each read group individually, you merge read groups belonging to the same sample into a single BAM file. You can do this as a standalone step, bur for the sake of efficiency we combine this with the per-sample duplicate marking step (it's simply a matter of passing the multiple inputs to MarkDuplicates in a single command).