### PR TITLE
Automatically detect threads and output format on bcftools

### DIFF
--- a/bio/bcftools/concat/environment.yaml
+++ b/bio/bcftools/concat/environment.yaml
@@ -2,5 +2,5 @@ channels:
   - bioconda
   - conda-forge
 dependencies:
-  - bcftools =1.11
+  - bcftools =1.12
   - snakemake-wrapper-utils ==0.2.0

--- a/bio/bcftools/concat/environment.yaml
+++ b/bio/bcftools/concat/environment.yaml
@@ -3,3 +3,4 @@ channels:
   - conda-forge
 dependencies:
   - bcftools =1.11
+  - snakemake-wrapper-utils ==0.2.0

--- a/bio/bcftools/concat/meta.yaml
+++ b/bio/bcftools/concat/meta.yaml
@@ -2,3 +2,13 @@ name: bcftools concat
 description: Concatenate vcf/bcf files with bcftools. For more information see `BCFtools documentation <https://www.htslib.org/doc/bcftools.html#concat>`_.
 authors:
   - Johannes Köster
+  - Filipe G. Vieira
+input:
+  - vcf files
+output:
+  - Concatenated VCF/BCF file
+notes: |
+  * The `uncompressed_bcf` param allows to specify that a BCF output should be uncompressed (ignored otherwise).
+  * The `bcftools_use_mem` param controls whether to pass the resources.mem_mb to bcftools
+  * The `extra` param alllows for additional program arguments (not `--threads, `-O/--output-type`, `-m/--max-mem`, or `-T/--temp-dir`).
+  * For more information see, https://samtools.github.io/bcftools/bcftools.html

--- a/bio/bcftools/concat/meta.yaml
+++ b/bio/bcftools/concat/meta.yaml
@@ -9,6 +9,5 @@ output:
   - Concatenated VCF/BCF file
 notes: |
   * The `uncompressed_bcf` param allows to specify that a BCF output should be uncompressed (ignored otherwise).
-  * The `bcftools_use_mem` param controls whether to pass the resources.mem_mb to bcftools
   * The `extra` param alllows for additional program arguments (not `--threads, `-O/--output-type`, `-m/--max-mem`, or `-T/--temp-dir`).
   * For more information see, https://samtools.github.io/bcftools/bcftools.html

--- a/bio/bcftools/concat/test/Snakefile
+++ b/bio/bcftools/concat/test/Snakefile
@@ -7,7 +7,6 @@ rule bcftools_concat:
         "logs/all.log"
     params:
         uncompressed_bcf = False,
-        bcftools_use_mem = False,
         extra = ""  # optional parameters for bcftools concat (except -o)
     threads: 4
     resources:

--- a/bio/bcftools/concat/test/Snakefile
+++ b/bio/bcftools/concat/test/Snakefile
@@ -3,6 +3,8 @@ rule bcftools_concat:
         calls=["a.bcf", "b.bcf"]
     output:
         "all.bcf"
+    log:
+        "logs/all.log"
     params:
         uncompressed_bcf = False,
         bcftools_use_mem = False,

--- a/bio/bcftools/concat/test/Snakefile
+++ b/bio/bcftools/concat/test/Snakefile
@@ -1,4 +1,4 @@
-B65;6003;1crule bcftools_concat:
+rule bcftools_concat:
     input:
         calls=["a.bcf", "b.bcf"]
     output:

--- a/bio/bcftools/concat/test/Snakefile
+++ b/bio/bcftools/concat/test/Snakefile
@@ -1,15 +1,15 @@
 rule bcftools_concat:
     input:
-        calls=["a.bcf", "b.bcf"]
+        calls=["a.bcf", "b.bcf"],
     output:
-        "all.bcf"
+        "all.bcf",
     log:
-        "logs/all.log"
+        "logs/all.log",
     params:
-        uncompressed_bcf = False,
-        extra = ""  # optional parameters for bcftools concat (except -o)
+        uncompressed_bcf=False,
+        extra="",  # optional parameters for bcftools concat (except -o)
     threads: 4
     resources:
-        mem_mb = 10,
+        mem_mb=10,
     wrapper:
         "master/bio/bcftools/concat"

--- a/bio/bcftools/concat/test/Snakefile
+++ b/bio/bcftools/concat/test/Snakefile
@@ -1,9 +1,14 @@
-rule bcftools_concat:
+B65;6003;1crule bcftools_concat:
     input:
         calls=["a.bcf", "b.bcf"]
     output:
         "all.bcf"
     params:
-        ""  # optional parameters for bcftools concat (except -o)
+        uncompressed_bcf = False,
+        bcftools_use_mem = False,
+        extra = ""  # optional parameters for bcftools concat (except -o)
+    threads: 4
+    resources:
+        mem_mb = 10,
     wrapper:
         "master/bio/bcftools/concat"

--- a/bio/bcftools/concat/wrapper.py
+++ b/bio/bcftools/concat/wrapper.py
@@ -6,35 +6,15 @@ __license__ = "MIT"
 
 from os import path
 from snakemake.shell import shell
+from snakemake_wrapper_utils.bcftools import get_bcftools_opts
 
+
+bcftools_opts = get_bcftools_opts(snakemake)
 log = snakemake.log_fmt_shell(stdout=True, stderr=True)
-
-threads = "" if snakemake.threads <= 1 else "--threads {}".format(snakemake.threads - 1)
-
-
-uncompressed_bcf = snakemake.params.get("uncompressed_bcf", False)
-
-
-out_name, out_ext = path.splitext(snakemake.output[0])
-if out_ext == ".vcf":
-    out_format = "v"
-elif out_ext == ".bcf":
-    if uncompressed_bcf:
-        out_format = "u"
-    else:
-        out_format = "b"
-elif out_ext == ".gz":
-    out_name, out_ext = path.splitext(out_name)
-    if out_ext == ".vcf":
-        out_format = "z"
-    else:
-        raise ValueError("output file with invalid extension (.vcf, .vcf.gz, .bcf).")
-else:
-    raise ValueError("output file with invalid extension (.vcf, .vcf.gz, .bcf).")
 
 
 shell(
-    "bcftools concat {threads} {snakemake.params} --output-type {out_format} -o {snakemake.output[0]} "
+    "bcftools concat {snakemake.params.extra} {bcftools_opts} -o {snakemake.output[0]} "
     "{snakemake.input.calls} "
     "{log}"
 )

--- a/bio/bcftools/concat/wrapper.py
+++ b/bio/bcftools/concat/wrapper.py
@@ -4,12 +4,37 @@ __email__ = "koester@jimmy.harvard.edu"
 __license__ = "MIT"
 
 
+from os import path
 from snakemake.shell import shell
 
 log = snakemake.log_fmt_shell(stdout=True, stderr=True)
 
+threads = "" if snakemake.threads <= 1 else "--threads {}".format(snakemake.threads - 1)
+
+
+uncompressed_bcf = snakemake.params.get("uncompressed_bcf", False)
+
+
+out_name, out_ext = path.splitext(snakemake.output[0])
+if out_ext == ".vcf":
+    out_format = "v"
+elif out_ext == ".bcf":
+    if uncompressed_bcf:
+        out_format = "u"
+    else:
+        out_format = "b"
+elif out_ext == ".gz":
+    out_name, out_ext = path.splitext(out_name)
+    if out_ext == ".vcf":
+        out_format = "z"
+    else:
+        raise ValueError("output file with invalid extension (.vcf, .vcf.gz, .bcf).")
+else:
+    raise ValueError("output file with invalid extension (.vcf, .vcf.gz, .bcf).")
+
+
 shell(
-    "bcftools concat {snakemake.params} -o {snakemake.output[0]} "
+    "bcftools concat {threads} {snakemake.params} --output-type {out_format} -o {snakemake.output[0]} "
     "{snakemake.input.calls} "
     "{log}"
 )

--- a/bio/bcftools/concat/wrapper.py
+++ b/bio/bcftools/concat/wrapper.py
@@ -9,7 +9,7 @@ from snakemake.shell import shell
 from snakemake_wrapper_utils.bcftools import get_bcftools_opts
 
 
-bcftools_opts = get_bcftools_opts(snakemake)
+bcftools_opts = get_bcftools_opts(snakemake, parse_memory=False)
 log = snakemake.log_fmt_shell(stdout=True, stderr=True)
 
 


### PR DESCRIPTION

These options are quite common across `bcftools` tools (and there might be others, like `tmp_dir` or `max_mem`) so, it might make sense to have them parsed on `snakemake_wrapper_utils`, just like it is currently done for `java`. The same could be done for `samtools`, (e.g.):

- `snakemake_wrapper_utils.bcftools`
- `snakemake_wrapper_utils.samtools`