### PR TITLE
Deepvariant 1.0

### DIFF
--- a/bio/deepvariant/environment.yaml
+++ b/bio/deepvariant/environment.yaml
@@ -2,6 +2,4 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - deepvariant=0.10.0
-  - tensorflow-estimator=2.0.0
-  - unzip=6.0
+  - deepvariant=1.0.0

--- a/bio/deepvariant/meta.yaml
+++ b/bio/deepvariant/meta.yaml
@@ -3,6 +3,7 @@ description: |
   Call genetic variants using deep neural network. Copyright 2017 Google LLC. BSD 3-Clause "New" or "Revised" https://github.com/google/deepvariant
 authors:
   - Tetsuro Hisayoshi
+  - Nikos Tsardakas Renhuldt
 input:
   - fasta
   - bam

--- a/bio/deepvariant/test/Snakefile
+++ b/bio/deepvariant/test/Snakefile
@@ -5,7 +5,24 @@ rule deepvariant:
     output:
         vcf="calls/{sample}.vcf.gz"
     params:
-        model="wgs",   # {wgs, wes}
+        model="wgs",   # {wgs, wes, pacbio, hybrid}
+        extra=""
+    threads: 2
+    log:
+        "logs/deepvariant/{sample}/stdout.log"
+    wrapper:
+        "master/bio/deepvariant"
+
+
+rule deepvariant_gvcf:
+    input:
+        bam="mapped/{sample}.bam",
+        ref="genome/genome.fasta"
+    output:
+        vcf="gvcf_calls/{sample}.vcf.gz",
+        gvcf="gvcf_calls/{sample}.g.vcf.gz"
+    params:
+        model="wgs",   # {wgs, wes, pacbio, hybrid}
         extra=""
     threads: 2
     log:

--- a/bio/deepvariant/wrapper.py
+++ b/bio/deepvariant/wrapper.py
@@ -14,7 +14,7 @@ log_dir = os.path.dirname(snakemake.log[0])
 output_dir = os.path.dirname(snakemake.output[0])
 
 # sample basename
-basename = os.path.splitext(os.path.basename(snakemake.input.bam[0]))[0]
+basename = os.path.splitext(os.path.basename(snakemake.input.bam))[0]
 
 gvcf = snakemake.output.get("gvcf", None)
 make_examples_gvcf = "--gvcf {tmp_dir} " if gvcf else ""

--- a/bio/deepvariant/wrapper.py
+++ b/bio/deepvariant/wrapper.py
@@ -18,8 +18,10 @@ basename = os.path.splitext(os.path.basename(snakemake.input.bam))[0]
 
 gvcf = snakemake.output.get("gvcf", None)
 make_examples_gvcf = "--gvcf {tmp_dir} " if gvcf else ""
-postprocess_gvcf = ("--gvcf_infile {tmp_dir}/{basename}.gvcf.tfrecord@{snakemake.threads}.gz "
-        "--gvcf_outfile {snakemake.output.gvcf} ") if gvcf else ""
+postprocess_gvcf = (
+    "--gvcf_infile {tmp_dir}/{basename}.gvcf.tfrecord@{snakemake.threads}.gz "
+    "--gvcf_outfile {snakemake.output.gvcf} "
+    ) if gvcf else ""
 
 cmd = (
     "(dv_make_examples.py "

--- a/bio/deepvariant/wrapper.py
+++ b/bio/deepvariant/wrapper.py
@@ -16,22 +16,25 @@ output_dir = os.path.dirname(snakemake.output[0])
 # sample basename
 basename = os.path.splitext(os.path.basename(snakemake.input.bam))[0]
 
+make_examples_gvcf = postprocess_gvcf = ""
 gvcf = snakemake.output.get("gvcf", None)
-make_examples_gvcf = "--gvcf {tmp_dir} " if gvcf else ""
-postprocess_gvcf = (
-    "--gvcf_infile {tmp_dir}/{basename}.gvcf.tfrecord@{snakemake.threads}.gz "
-    "--gvcf_outfile {snakemake.output.gvcf} "
-    ) if gvcf else ""
+if gvcf:
+    make_examples_gvcf = "--gvcf {tmp_dir} "
+    postprocess_gvcf = (
+        "--gvcf_infile {tmp_dir}/{basename}.gvcf.tfrecord@{snakemake.threads}.gz "
+        "--gvcf_outfile {snakemake.output.gvcf} "
+    )
 
 cmd = (
-    "(dv_make_examples.py "
+    "( "
+    "dv_make_examples.py "
     "--cores {snakemake.threads} "
     "--ref {snakemake.input.ref} "
     "--reads {snakemake.input.bam} "
     "--sample {basename} "
     "--examples {tmp_dir} "
     "--logdir {log_dir} "
-    )
+)
 cmd += make_examples_gvcf
 cmd += (
     "{extra} \n"
@@ -43,13 +46,14 @@ cmd += (
     "--model {snakemake.params.model} \n"
     "dv_postprocess_variants.py "
     "--ref {snakemake.input.ref} "
-    )
+)
 cmd += postprocess_gvcf
 cmd += (
     "--infile {tmp_dir}/{basename}.tmp "
-    "--outfile {snakemake.output.vcf} ) {log}"
-    )
-
+    "--outfile {snakemake.output.vcf} "
+    ") "
+    "{log} "
+)
 
 with tempfile.TemporaryDirectory() as tmp_dir:
     shell(cmd)

--- a/bio/deepvariant/wrapper.py
+++ b/bio/deepvariant/wrapper.py
@@ -25,35 +25,24 @@ if gvcf:
         "--gvcf_outfile {snakemake.output.gvcf} "
     )
 
-cmd = (
-    "( "
-    "dv_make_examples.py "
-    "--cores {snakemake.threads} "
-    "--ref {snakemake.input.ref} "
-    "--reads {snakemake.input.bam} "
-    "--sample {basename} "
-    "--examples {tmp_dir} "
-    "--logdir {log_dir} "
-)
-cmd += make_examples_gvcf
-cmd += (
-    "{extra} \n"
-    "dv_call_variants.py "
-    "--cores {snakemake.threads} "
-    "--outfile {tmp_dir}/{basename}.tmp "
-    "--sample {basename} "
-    "--examples {tmp_dir} "
-    "--model {snakemake.params.model} \n"
-    "dv_postprocess_variants.py "
-    "--ref {snakemake.input.ref} "
-)
-cmd += postprocess_gvcf
-cmd += (
-    "--infile {tmp_dir}/{basename}.tmp "
-    "--outfile {snakemake.output.vcf} "
-    ") "
-    "{log} "
-)
-
 with tempfile.TemporaryDirectory() as tmp_dir:
-    shell(cmd)
+    shell(
+        "(dv_make_examples.py "
+        "--cores {snakemake.threads} "
+        "--ref {snakemake.input.ref} "
+        "--reads {snakemake.input.bam} "
+        "--sample {basename} "
+        "--examples {tmp_dir} "
+        "--logdir {log_dir} " + make_examples_gvcf + "{extra} \n"
+        "dv_call_variants.py "
+        "--cores {snakemake.threads} "
+        "--outfile {tmp_dir}/{basename}.tmp "
+        "--sample {basename} "
+        "--examples {tmp_dir} "
+        "--model {snakemake.params.model} \n"
+        "dv_postprocess_variants.py "
+        "--ref {snakemake.input.ref} "
+        + postprocess_gvcf
+        + "--infile {tmp_dir}/{basename}.tmp "
+        "--outfile {snakemake.output.vcf} ) {log}"
+    )

--- a/test.py
+++ b/test.py
@@ -1346,6 +1346,14 @@ def test_deepvariant():
 
 
 @skip_if_not_modified
+def test_deepvariant_gvcf():
+    run(
+        "bio/deepvariant",
+        ["snakemake", "--cores", "1", "gvcf_calls/a.vcf.gz", "gvcf_calls/a.g.vcf.gz", "--use-conda", "-F"],
+    )
+
+
+@skip_if_not_modified
 def test_epic_peaks():
     run(
         "bio/epic/peaks",


### PR DESCRIPTION
This PR updates the deepvariant wrapper to v1.0.0. Since the bioconda deepvariant recipe now supports GPU acceleration this means performance improvements both with regards to variant calling performance and runtime. 

The PR also adds support for generating gVCFs, includes a test for this, and resolves a bug in how the `basename` variable is computed.