### PR TITLE
Updates bwa-mem samtools to v1.12, adds `--write-index` flag

### DIFF
--- a/bio/bwa/mem/environment.yaml
+++ b/bio/bwa/mem/environment.yaml
@@ -4,5 +4,5 @@ channels:
   - defaults
 dependencies:
   - bwa ==0.7.17
-  - samtools ==1.9
+  - samtools ==1.12
   - picard ==2.20.1

--- a/bio/bwa/mem/test/Snakefile_samtools
+++ b/bio/bwa/mem/test/Snakefile_samtools
@@ -29,8 +29,7 @@ rule bwa_mem_write_index:
         extra=r"-R '@RG\tID:{sample}\tSM:{sample}'",
         sort="samtools",             # Can be 'none', 'samtools' or 'picard'.
         sort_order="coordinate",  # Can be 'queryname' or 'coordinate'.
-        sort_extra="",            # Extra args for samtools/picard.
-        write_index=True            # True to write, may be left out
+        sort_extra="--write-index",            # Extra args for samtools/picard.
     threads: 8
     wrapper:
         "master/bio/bwa/mem"

--- a/bio/bwa/mem/test/Snakefile_samtools
+++ b/bio/bwa/mem/test/Snakefile_samtools
@@ -14,3 +14,23 @@ rule bwa_mem:
     threads: 8
     wrapper:
         "master/bio/bwa/mem"
+
+
+rule bwa_mem_write_index:
+    input:
+        reads=["reads/{sample}.1.fastq", "reads/{sample}.2.fastq"]
+    output:
+        "mapped_with_index/{sample}.bam",
+        "mapped_with_index/{sample}.bam.csi"
+    log:
+        "logs/bwa_mem/{sample}.log"
+    params:
+        index="genome",
+        extra=r"-R '@RG\tID:{sample}\tSM:{sample}'",
+        sort="samtools",             # Can be 'none', 'samtools' or 'picard'.
+        sort_order="coordinate",  # Can be 'queryname' or 'coordinate'.
+        sort_extra="",            # Extra args for samtools/picard.
+        write_index=True            # True to write, may be left out
+    threads: 8
+    wrapper:
+        "master/bio/bwa/mem"

--- a/bio/bwa/mem/wrapper.py
+++ b/bio/bwa/mem/wrapper.py
@@ -15,6 +15,7 @@ extra = snakemake.params.get("extra", "")
 sort = snakemake.params.get("sort", "none")
 sort_order = snakemake.params.get("sort_order", "coordinate")
 sort_extra = snakemake.params.get("sort_extra", "")
+write_index = snakemake.params.get("write_index", False)
 
 log = snakemake.log_fmt_shell(stdout=False, stderr=True)
 
@@ -42,6 +43,10 @@ elif sort == "samtools":
     # Add name flag if needed.
     if sort_order == "queryname":
         sort_extra += " -n"
+
+    # Add write-index flag
+    if write_index is True:
+        sort_extra += " --write-index"
 
     prefix = path.splitext(snakemake.output[0])[0]
     sort_extra += " -T " + prefix + ".tmp"

--- a/bio/bwa/mem/wrapper.py
+++ b/bio/bwa/mem/wrapper.py
@@ -15,7 +15,6 @@ extra = snakemake.params.get("extra", "")
 sort = snakemake.params.get("sort", "none")
 sort_order = snakemake.params.get("sort_order", "coordinate")
 sort_extra = snakemake.params.get("sort_extra", "")
-write_index = snakemake.params.get("write_index", False)
 
 log = snakemake.log_fmt_shell(stdout=False, stderr=True)
 
@@ -43,10 +42,6 @@ elif sort == "samtools":
     # Add name flag if needed.
     if sort_order == "queryname":
         sort_extra += " -n"
-
-    # Add write-index flag
-    if write_index is True:
-        sort_extra += " --write-index"
 
     prefix = path.splitext(snakemake.output[0])[0]
     sort_extra += " -T " + prefix + ".tmp"

--- a/test.py
+++ b/test.py
@@ -880,6 +880,24 @@ def test_bwa_mem_sort_samtools():
 
 
 @skip_if_not_modified
+def test_bwa_mem_sort_samtools_write_index():
+    run(
+        "bio/bwa/mem",
+        [
+            "snakemake",
+            "--cores",
+            "1",
+            "mapped_with_index/a.bam",
+            "mapped_with_index/a.bam.csi",
+            "--use-conda",
+            "-F",
+            "-s",
+            "Snakefile_samtools",
+        ],
+    )
+
+
+@skip_if_not_modified
 def test_bwa_mem_sort_picard():
     run(
         "bio/bwa/mem",


### PR DESCRIPTION
Hey! The bwa mem wrapper is using samtools 1.9 currently. The latest version is 1.12, and it provides the nifty `--write-index` flag. I've added an optional parameter to add this flag in the wrapper, as well as a test to see that this works. Solved this by letting the param take the value `True` to add the flag - not sure if this is the best way to do it, but it seems to work.