### PR TITLE
Updates deepvariant to v1.1.0

### DIFF
--- a/bio/deepvariant/environment.yaml
+++ b/bio/deepvariant/environment.yaml
@@ -2,4 +2,4 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - deepvariant=1.1.0
+  - deepvariant ==1.1.0

--- a/bio/deepvariant/environment.yaml
+++ b/bio/deepvariant/environment.yaml
@@ -2,4 +2,4 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - deepvariant=1.0.0
+  - deepvariant=1.1.0

--- a/bio/deepvariant/test/Snakefile
+++ b/bio/deepvariant/test/Snakefile
@@ -6,6 +6,7 @@ rule deepvariant:
         vcf="calls/{sample}.vcf.gz"
     params:
         model="wgs",   # {wgs, wes, pacbio, hybrid}
+        sample_name=lambda w: w.sample, # optional
         extra=""
     threads: 2
     log:

--- a/bio/deepvariant/wrapper.py
+++ b/bio/deepvariant/wrapper.py
@@ -14,8 +14,9 @@ log_dir = os.path.dirname(snakemake.log[0])
 output_dir = os.path.dirname(snakemake.output[0])
 
 # sample basename
-sample_name = snakemake.params.get('sample_name',
-    os.path.splitext(os.path.basename(snakemake.input.bam))[0])
+sample_name = snakemake.params.get(
+    "sample_name", os.path.splitext(os.path.basename(snakemake.input.bam))[0]
+)
 
 
 make_examples_gvcf = postprocess_gvcf = ""

--- a/bio/deepvariant/wrapper.py
+++ b/bio/deepvariant/wrapper.py
@@ -14,14 +14,16 @@ log_dir = os.path.dirname(snakemake.log[0])
 output_dir = os.path.dirname(snakemake.output[0])
 
 # sample basename
-basename = os.path.splitext(os.path.basename(snakemake.input.bam))[0]
+sample_name = snakemake.params.get('sample_name',
+    os.path.splitext(os.path.basename(snakemake.input.bam))[0])
+
 
 make_examples_gvcf = postprocess_gvcf = ""
 gvcf = snakemake.output.get("gvcf", None)
 if gvcf:
     make_examples_gvcf = "--gvcf {tmp_dir} "
     postprocess_gvcf = (
-        "--gvcf_infile {tmp_dir}/{basename}.gvcf.tfrecord@{snakemake.threads}.gz "
+        "--gvcf_infile {tmp_dir}/{sample_name}.gvcf.tfrecord@{snakemake.threads}.gz "
         "--gvcf_outfile {snakemake.output.gvcf} "
     )
 
@@ -31,18 +33,18 @@ with tempfile.TemporaryDirectory() as tmp_dir:
         "--cores {snakemake.threads} "
         "--ref {snakemake.input.ref} "
         "--reads {snakemake.input.bam} "
-        "--sample {basename} "
+        "--sample {sample_name} "
         "--examples {tmp_dir} "
         "--logdir {log_dir} " + make_examples_gvcf + "{extra} \n"
         "dv_call_variants.py "
         "--cores {snakemake.threads} "
-        "--outfile {tmp_dir}/{basename}.tmp "
-        "--sample {basename} "
+        "--outfile {tmp_dir}/{sample_name}.tmp "
+        "--sample {sample_name} "
         "--examples {tmp_dir} "
         "--model {snakemake.params.model} \n"
         "dv_postprocess_variants.py "
         "--ref {snakemake.input.ref} "
         + postprocess_gvcf
-        + "--infile {tmp_dir}/{basename}.tmp "
+        + "--infile {tmp_dir}/{sample_name}.tmp "
         "--outfile {snakemake.output.vcf} ) {log}"
     )

--- a/bio/deepvariant/wrapper.py
+++ b/bio/deepvariant/wrapper.py
@@ -13,7 +13,7 @@ extra = snakemake.params.get("extra", "")
 log_dir = os.path.dirname(snakemake.log[0])
 output_dir = os.path.dirname(snakemake.output[0])
 
-# sample basename
+# sample name defaults to basename
 sample_name = snakemake.params.get(
     "sample_name", os.path.splitext(os.path.basename(snakemake.input.bam))[0]
 )


### PR DESCRIPTION
This PR updates DeepVariant to v1.1.0. The upstream bioconda recipe does not yet support e.g. DeepTrio, but the PR https://github.com/bioconda/bioconda-recipes/pull/27988 adds the missing `--sample_name` argument to the `dv_make_examples.py` wrapper. This in turn avoids problems downstream, as samples in vcfs may have other names than `default`.