### PR TITLE
Updates bismark related wrappers environment.yaml to bismark ==0.23.0  and bowtie2==2.4.2

### DIFF
--- a/bio/bismark/bam2nuc/environment.yaml
+++ b/bio/bismark/bam2nuc/environment.yaml
@@ -3,6 +3,6 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - bowtie2 == 2.4.2
-  - bismark == 0.23.0
-  - samtools == 1.9
+  - bowtie2 ==2.4.2
+  - bismark ==0.23.0
+  - samtools ==1.9

--- a/bio/bismark/bam2nuc/environment.yaml
+++ b/bio/bismark/bam2nuc/environment.yaml
@@ -3,6 +3,6 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - bowtie2 == 2.3.4.3
-  - bismark == 0.22.1
+  - bowtie2 == 2.4.2
+  - bismark == 0.23.0
   - samtools == 1.9

--- a/bio/bismark/bismark/environment.yaml
+++ b/bio/bismark/bismark/environment.yaml
@@ -3,6 +3,6 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - bowtie2 == 2.4.2
-  - bismark == 0.23.0
-  - samtools == 1.9
+  - bowtie2 ==2.4.2
+  - bismark ==0.23.0
+  - samtools ==1.9

--- a/bio/bismark/bismark/environment.yaml
+++ b/bio/bismark/bismark/environment.yaml
@@ -3,6 +3,6 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - bowtie2 == 2.3.4.3
-  - bismark == 0.22.1
+  - bowtie2 == 2.4.2
+  - bismark == 0.23.0
   - samtools == 1.9

--- a/bio/bismark/bismark2bedGraph/environment.yaml
+++ b/bio/bismark/bismark2bedGraph/environment.yaml
@@ -3,6 +3,6 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - bowtie2 == 2.4.2
-  - bismark == 0.23.0
-  - samtools == 1.9
+  - bowtie2 ==2.4.2
+  - bismark ==0.23.0
+  - samtools ==1.9

--- a/bio/bismark/bismark2bedGraph/environment.yaml
+++ b/bio/bismark/bismark2bedGraph/environment.yaml
@@ -3,6 +3,6 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - bowtie2 == 2.3.4.3
-  - bismark == 0.22.1
+  - bowtie2 == 2.4.2
+  - bismark == 0.23.0
   - samtools == 1.9

--- a/bio/bismark/bismark2report/environment.yaml
+++ b/bio/bismark/bismark2report/environment.yaml
@@ -3,6 +3,6 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - bowtie2 == 2.4.2
-  - bismark == 0.23.0
-  - samtools == 1.9
+  - bowtie2 ==2.4.2
+  - bismark ==0.23.0
+  - samtools ==1.9

--- a/bio/bismark/bismark2report/environment.yaml
+++ b/bio/bismark/bismark2report/environment.yaml
@@ -3,6 +3,6 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - bowtie2 == 2.3.4.3
-  - bismark == 0.22.1
+  - bowtie2 == 2.4.2
+  - bismark == 0.23.0
   - samtools == 1.9

--- a/bio/bismark/bismark2summary/environment.yaml
+++ b/bio/bismark/bismark2summary/environment.yaml
@@ -3,6 +3,6 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - bowtie2 == 2.4.2
-  - bismark == 0.23.0
-  - samtools == 1.9
+  - bowtie2 ==2.4.2
+  - bismark ==0.23.0
+  - samtools ==1.9

--- a/bio/bismark/bismark2summary/environment.yaml
+++ b/bio/bismark/bismark2summary/environment.yaml
@@ -3,6 +3,6 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - bowtie2 == 2.3.4.3
-  - bismark == 0.22.1
+  - bowtie2 == 2.4.2
+  - bismark == 0.23.0
   - samtools == 1.9

--- a/bio/bismark/bismark_genome_preparation/environment.yaml
+++ b/bio/bismark/bismark_genome_preparation/environment.yaml
@@ -3,6 +3,6 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - bowtie2 == 2.3.4.3
+  - bowtie2 == 2.4.2
   - bismark == 0.23.0
   - samtools == 1.9

--- a/bio/bismark/bismark_genome_preparation/environment.yaml
+++ b/bio/bismark/bismark_genome_preparation/environment.yaml
@@ -3,6 +3,6 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - bowtie2 == 2.4.2
-  - bismark == 0.23.0
-  - samtools == 1.9
+  - bowtie2 ==2.4.2
+  - bismark ==0.23.0
+  - samtools ==1.9

--- a/bio/bismark/bismark_genome_preparation/environment.yaml
+++ b/bio/bismark/bismark_genome_preparation/environment.yaml
@@ -4,5 +4,5 @@ channels:
   - defaults
 dependencies:
   - bowtie2 == 2.3.4.3
-  - bismark == 0.22.1
+  - bismark == 0.23.0
   - samtools == 1.9

--- a/bio/bismark/bismark_methylation_extractor/environment.yaml
+++ b/bio/bismark/bismark_methylation_extractor/environment.yaml
@@ -6,4 +6,4 @@ dependencies:
   - bowtie2 ==2.4.2
   - bismark ==0.23.0
   - samtools == 1.9
-  - perl-gdgraph == 1.54  # for bismark plots module
+  - perl-gdgraph ==1.54  # for bismark plots module

--- a/bio/bismark/bismark_methylation_extractor/environment.yaml
+++ b/bio/bismark/bismark_methylation_extractor/environment.yaml
@@ -5,5 +5,5 @@ channels:
 dependencies:
   - bowtie2 ==2.4.2
   - bismark ==0.23.0
-  - samtools == 1.9
+  - samtools ==1.9
   - perl-gdgraph ==1.54  # for bismark plots module

--- a/bio/bismark/bismark_methylation_extractor/environment.yaml
+++ b/bio/bismark/bismark_methylation_extractor/environment.yaml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - bowtie2 == 2.3.4.3
-  - bismark == 0.22.1
+  - bowtie2 == 2.4.2
+  - bismark == 0.23.0
   - samtools == 1.9
   - perl-gdgraph == 1.54  # for bismark plots module

--- a/bio/bismark/bismark_methylation_extractor/environment.yaml
+++ b/bio/bismark/bismark_methylation_extractor/environment.yaml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - bowtie2 == 2.4.2
-  - bismark == 0.23.0
+  - bowtie2 ==2.4.2
+  - bismark ==0.23.0
   - samtools == 1.9
   - perl-gdgraph == 1.54  # for bismark plots module

--- a/bio/bismark/deduplicate_bismark/environment.yaml
+++ b/bio/bismark/deduplicate_bismark/environment.yaml
@@ -3,6 +3,6 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - bowtie2 == 2.4.2
-  - bismark == 0.23.0
-  - samtools == 1.9
+  - bowtie2 ==2.4.2
+  - bismark ==0.23.0
+  - samtools ==1.9

--- a/bio/bismark/deduplicate_bismark/environment.yaml
+++ b/bio/bismark/deduplicate_bismark/environment.yaml
@@ -3,6 +3,6 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - bowtie2 == 2.3.4.3
-  - bismark == 0.22.1
+  - bowtie2 == 2.4.2
+  - bismark == 0.23.0
   - samtools == 1.9


### PR DESCRIPTION
Updates bismark related wrappers environment.yaml to bismark ==0.23.0  and bowtie2==2.4.2. 

I was getting a libtbb file not found error during the bowtie2-build-s stage in the bismark_genome_preparation step.