### PR TITLE
Updata multiqc version to 1.10.1

### DIFF
--- a/bio/multiqc/environment.yaml
+++ b/bio/multiqc/environment.yaml
@@ -3,4 +3,4 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - multiqc == 1.10.1
+  - multiqc ==1.10.1

--- a/bio/multiqc/environment.yaml
+++ b/bio/multiqc/environment.yaml
@@ -3,4 +3,4 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - multiqc ==1.9
+  - multiqc == 1.10.1


### PR DESCRIPTION
Updata multiqc version to 1.10.1

multiqc 1.9 could not parse *.zip file, which is the result of fastqc.