### PR TITLE
Add cosmic database download wrapper

### DIFF
--- a/bio/cosmic-db/environment.yaml
+++ b/bio/cosmic-db/environment.yaml
@@ -1,0 +1,8 @@
+channels:
+  - bioconda
+  - conda-forge
+  - defaults
+dependencies:
+  - curl =7
+  - python >=3.6.2
+  - requests =2.25

--- a/bio/cosmic-db/meta.yaml
+++ b/bio/cosmic-db/meta.yaml
@@ -1,0 +1,9 @@
+name: cosmic-db
+description: |
+  Download cosmic databases from https://cancer.sanger.ac.uk/cosmic/download
+authors:
+  - Till Hartmann
+input:
+  - genome build, cosmic release version, dataset and file name
+output:
+  - database

--- a/bio/cosmic-db/test/Snakefile
+++ b/bio/cosmic-db/test/Snakefile
@@ -1,0 +1,16 @@
+envvars:
+    "COSMIC_EMAIL",
+    "COSMIC_PW"
+
+rule cosmic_download:
+    output:
+        "resources/{db}"
+    params:
+        build="GRCh38",
+        dataset="cosmic",
+        version="v92",
+        file=lambda wc: wc.db  # e.g. "CosmicHGNC.tsv.gz"
+    log:
+        "logs/cosmic-db/{db}.log"
+    wrapper:
+        "master/bio/cosmic-db"

--- a/bio/cosmic-db/wrapper.py
+++ b/bio/cosmic-db/wrapper.py
@@ -1,0 +1,67 @@
+"""Snakemake wrapper for trimming paired-end reads using cutadapt."""
+
+__author__ = "Till Hartmann"
+__copyright__ = "Copyright 2021, Till Hartmann"
+__email__ = "till.hartmann@udo.edu"
+__license__ = "MIT"
+
+import requests
+import os
+from typing import List
+from snakemake.shell import shell
+
+email = os.environ["COSMIC_EMAIL"]
+password = os.environ["COSMIC_PW"]
+assert email, "$COSMIC_EMAIL is not set"
+assert password, "$COSMIC_PW is not set"
+
+COSMIC_URL = "https://cancer.sanger.ac.uk/cosmic/file_download"
+
+
+def available_builds() -> List[str]:
+    builds = requests.get(COSMIC_URL).json()
+    return builds
+
+
+def available_datasets(build: str) -> List[str]:
+    datasets = requests.get(f"{COSMIC_URL}/{build}").json()
+    return [d.rpartition("/")[-1] for d in datasets]
+
+
+def available_versions(build: str, dataset: str) -> List[str]:
+    versions = requests.get(f"{COSMIC_URL}/{build}/{dataset}").json()
+    return [v.rpartition("/")[-1] for v in versions]
+
+
+def available_files(build: str, dataset: str, version: str) -> List[str]:
+    files = requests.get(f"{COSMIC_URL}/{build}/{dataset}/{version}").json()
+    return [f.rpartition("/")[-1] for f in files]
+
+
+def download_path(build: str, dataset: str, version: str, file: str) -> str:
+    return f"{COSMIC_URL}/{build}/{dataset}/{version}/{file}"
+
+
+build = snakemake.params.get("build", "")
+dataset = snakemake.params.get("dataset", "")
+version = snakemake.params.get("version", "")
+file = snakemake.params.get("file", "")
+log = snakemake.log_fmt_shell(stdout=False, stderr=True)
+
+builds = available_builds()
+assert build in builds, f"{build} is not available. Choose one of: {builds}."
+
+datasets = available_datasets(build)
+assert dataset in datasets, f"{dataset} is not available. Choose one of: {datasets}."
+
+versions = available_versions(build, dataset)
+assert version in versions, f"{version} is not available. Choose one of: {versions}."
+
+files = available_files(build, dataset, version)
+assert file in files, f"{file} is not available. Choose one of: {files}."
+
+download_url = requests.get(
+    download_path(build, dataset, version, file), auth=(email, password)
+).json()["url"].strip()
+
+shell('curl "{download_url}" -o {snakemake.output[0]} {log}')

--- a/test.py
+++ b/test.py
@@ -126,6 +126,14 @@ def run(wrapper, cmd, check_log=None):
 
 
 @skip_if_not_modified
+def test_download_cosmic_db():
+    run(
+        "bio/cosmic-db",
+        ["snakemake", "--cores", "1", "--use-conda", "resources/CosmicHGNC.tsv.gz"],
+    )
+
+
+@skip_if_not_modified
 def test_open_cravat_run():
     run(
         "bio/open-cravat/run",


### PR DESCRIPTION
This PR adds a wrapper for downloading files from [COSMIC](https://cancer.sanger.ac.uk/cosmic/download).
It expects the following parameters to be set:
 - `build` (at the moment either "GRCh37" or "GRCh38")
 - `dataset` (at the moment either "cosmic" or "cell_lines")
 - `version` (at the moment "v83" to "v92" or "latest")
 - `file` (which in the example Snakefile is derived from the output via the `{db}` wildcard)

Since new builds, datasets, versions and files may be added in the future, this wrapper will query the endpoints in order to check if the requested combination is actually available (at the time this wrapper is executed).