### PR TITLE
Update wrapper.py for cutadapt/pe.

### DIFF
--- a/bio/cutadapt/pe/wrapper.py
+++ b/bio/cutadapt/pe/wrapper.py
@@ -22,8 +22,8 @@ assert (
 
 shell(
     "cutadapt"
-    " {snakemake.params.adapters}"
-    " {snakemake.params.extra}"
+    " {adapters}"
+    " {extra}"
     " -o {snakemake.output.fastq1}"
     " -p {snakemake.output.fastq2}"
     " -j {snakemake.threads}"


### PR DESCRIPTION
The current version raises an exception when in line 20, neither extra nor adapters is specified.  Based on this logic, it should be the case that if either is specified the command should work, but if params.adapters is not specified, the shell command fails (because params.adapters does not exist in line 25).