### PR TITLE
Bump trim_galore version and fix formatting

### DIFF
--- a/bio/trim_galore/pe/environment.yaml
+++ b/bio/trim_galore/pe/environment.yaml
@@ -3,4 +3,4 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - trim-galore ==0.4.5
+  - trim-galore ==0.6.6

--- a/bio/trim_galore/pe/test/Snakefile
+++ b/bio/trim_galore/pe/test/Snakefile
@@ -1,14 +1,14 @@
 rule trim_galore_pe:
     input:
-        ["reads/{sample}.1.fastq.gz", "reads/{sample}.2.fastq.gz"]
+        ["reads/{sample}.1.fastq.gz", "reads/{sample}.2.fastq.gz"],
     output:
         "trimmed/{sample}.1_val_1.fq.gz",
-         "trimmed/{sample}.1.fastq.gz_trimming_report.txt",
-         "trimmed/{sample}.2_val_2.fq.gz",
-         "trimmed/{sample}.2.fastq.gz_trimming_report.txt"
+        "trimmed/{sample}.1.fastq.gz_trimming_report.txt",
+        "trimmed/{sample}.2_val_2.fq.gz",
+        "trimmed/{sample}.2.fastq.gz_trimming_report.txt",
     params:
-        extra="--illumina -q 20"
+        extra="--illumina -q 20",
     log:
-        "logs/trim_galore/{sample}.log"
+        "logs/trim_galore/{sample}.log",
     wrapper:
         "master/bio/trim_galore/pe"

--- a/bio/trim_galore/se/environment.yaml
+++ b/bio/trim_galore/se/environment.yaml
@@ -3,4 +3,4 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - trim-galore ==0.4.3
+  - trim-galore ==0.6.6

--- a/bio/trim_galore/se/test/Snakefile
+++ b/bio/trim_galore/se/test/Snakefile
@@ -1,12 +1,12 @@
 rule trim_galore_se:
     input:
-        "reads/{sample}.fastq.gz"
+        "reads/{sample}.fastq.gz",
     output:
         "trimmed/{sample}_trimmed.fq.gz",
-         "trimmed/{sample}.fastq.gz_trimming_report.txt"
+        "trimmed/{sample}.fastq.gz_trimming_report.txt",
     params:
-        extra="--illumina -q 20"
+        extra="--illumina -q 20",
     log:
-        "logs/trim_galore/{sample}.log"
+        "logs/trim_galore/{sample}.log",
     wrapper:
         "master/bio/trim_galore/se"


### PR DESCRIPTION
### Description

<!--Add a description of your PR here-->

### QC
<!-- Make sure that you can tick the boxes below. -->

For all wrappers added by this PR, I made sure that

* [ x] there is a test case which covers any introduced changes,
* [ x] `input:` and `output:` file paths in the resulting rule can be changed arbitrarily,
* [ x] rule names in the test case are in [snake_case](https://en.wikipedia.org/wiki/Snake_case) and somehow tell what the rule is about or match the tools purpose or name (e.g., `map_reads` for a step that maps reads),
* [ x] all `environment.yaml` specifications follow [the respective best practices](https://stackoverflow.com/a/64594513/2352071),
* [ x] wherever possible, command line arguments are inferred and set automatically (e.g. based on file extensions in `input:` or `output:`),
* [ x] all fields of the example rules in the `Snakefile`s and their entries are explained via comments (`input:`/`output:`/`params:` etc.),
* [ x] `stderr` and/or `stdout` are logged correctly (`log:`), depending on the wrapped tool,
* [x ] temporary files are either written to a unique hidden folder in the working directory, or (better) stored where the Python function `tempfile.gettempdir()` points to (see [here](https://docs.python.org/3/library/tempfile.html#tempfile.gettempdir); this also means that using any Python `tempfile` default behavior works),
* [ x] the `meta.yaml` contains a link to the documentation of the respective tool or command,
* [x ] `Snakefile`s pass the linting (`snakemake --lint`),
* [ x] `Snakefile`s are formatted with [snakefmt](https://github.com/snakemake/snakefmt),
* [x ] Python wrapper scripts are formatted with [black](https://black.readthedocs.io).
