### PR TITLE
Changed bowtie2 version for wrapper to avoid dyld: Library not loaded: @rpath/libtbb.dylib error

### DIFF
--- a/bio/bowtie2/align/environment.yaml
+++ b/bio/bowtie2/align/environment.yaml
@@ -3,5 +3,5 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - bowtie2 ==2.4.1  # Keep consistent with version specified in bowtie2/build
+  - bowtie2 ==2.4.4  # Keep consistent with version specified in bowtie2/build
   - samtools ==1.10

--- a/bio/bowtie2/build/environment.yaml
+++ b/bio/bowtie2/build/environment.yaml
@@ -3,5 +3,5 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - bowtie2 ==2.4.1  # Keep consistent with version specified in bowtie2/align
+  - bowtie2 ==2.4.4  # Keep consistent with version specified in bowtie2/align
   - samtools ==1.10


### PR DESCRIPTION
### Description

<!--The older version of bowtie has a bug that give a dyld: Library not loaded: @rpath/libtbb.dylib error -->
I updated the bowtie version used in the environment.yml file from bowtie2 v2.4.1 to bowtie2 v2.2.4

I updated the environment.yml files for both bowtie align and bowtie build so that the versions match

### QC

I did not change anything else except for the bowtie2 version in both environment.yml files, so I have not ticked any boxes below as this is a very minor fix.



For all wrappers added by this PR, I made sure that

* [x] there is a test case which covers any introduced changes,
* [x] `input:` and `output:` file paths in the resulting rule can be changed arbitrarily,
* [x] rule names in the test case are in [snake_case](https://en.wikipedia.org/wiki/Snake_case) and somehow tell what the rule is about or match the tools purpose or name (e.g., `map_reads` for a step that maps reads),
* [x] all `environment.yaml` specifications follow [the respective best practices](https://stackoverflow.com/a/64594513/2352071),
* [x] wherever possible, command line arguments are inferred and set automatically (e.g. based on file extensions in `input:` or `output:`),
* [x] all fields of the example rules in the `Snakefile`s and their entries are explained via comments (`input:`/`output:`/`params:` etc.),
* [x] `stderr` and/or `stdout` are logged correctly (`log:`), depending on the wrapped tool,
* [x] temporary files are either written to a unique hidden folder in the working directory, or (better) stored where the Python function `tempfile.gettempdir()` points to (see [here](https://docs.python.org/3/library/tempfile.html#tempfile.gettempdir); this also means that using any Python `tempfile` default behavior works),
* [x] the `meta.yaml` contains a link to the documentation of the respective tool or command,
* [x] `Snakefile`s pass the linting (`snakemake --lint`),
* [x] `Snakefile`s are formatted with [snakefmt](https://github.com/snakemake/snakefmt),
* [x] Python wrapper scripts are formatted with [black](https://black.readthedocs.io).
