### PR TITLE
Cutadapt/se: fixed bug in wrapper.py

### DIFF
--- a/bio/cutadapt/se/wrapper.py
+++ b/bio/cutadapt/se/wrapper.py
@@ -22,8 +22,8 @@ assert (
 
 shell(
     "cutadapt"
-    " {snakemake.params.adapters}"
-    " {snakemake.params.extra}"
+    " {adapters}"
+    " {extra}"
     " -j {snakemake.threads}"
     " -o {snakemake.output.fastq}"
     " {snakemake.input[0]}"


### PR DESCRIPTION
Line 20 (and practical use of cutadapt) suggests, that defining only adapters or extra in params should work. However currently omitting either results in AttributeError.

### Description

Proposed change allows for defining only adapters or only extra, which much better suits practical use of cutadapt.
### QC

For all wrappers added by this PR, I made sure that

* [X] there is a test case which covers any introduced changes,
* [X] `input:` and `output:` file paths in the resulting rule can be changed arbitrarily,
* [X] rule names in the test case are in [snake_case](https://en.wikipedia.org/wiki/Snake_case) and somehow tell what the rule is about or match the tools purpose or name (e.g., `map_reads` for a step that maps reads),
* [X] all `environment.yaml` specifications follow [the respective best practices](https://stackoverflow.com/a/64594513/2352071),
* [X] wherever possible, command line arguments are inferred and set automatically (e.g. based on file extensions in `input:` or `output:`),
* [X] all fields of the example rules in the `Snakefile`s and their entries are explained via comments (`input:`/`output:`/`params:` etc.),
* [X] `stderr` and/or `stdout` are logged correctly (`log:`), depending on the wrapped tool,
* [X] temporary files are either written to a unique hidden folder in the working directory, or (better) stored where the Python function `tempfile.gettempdir()` points to (see [here](https://docs.python.org/3/library/tempfile.html#tempfile.gettempdir); this also means that using any Python `tempfile` default behavior works),
* [X] the `meta.yaml` contains a link to the documentation of the respective tool or command,
* [X] `Snakefile`s pass the linting (`snakemake --lint`),
* [X] `Snakefile`s are formatted with [snakefmt](https://github.com/snakemake/snakefmt),
* [X] Python wrapper scripts are formatted with [black](https://black.readthedocs.io).
