### PR TITLE
Added parentheses to include both steps in log

### DIFF
--- a/bio/strelka/germline/wrapper.py
+++ b/bio/strelka/germline/wrapper.py
@@ -21,7 +21,7 @@ else:
     run_dir = snakemake.output
 
 shell(
-    "configureStrelkaGermlineWorkflow.py "  # configure the strelka run
+    "(configureStrelkaGermlineWorkflow.py "  # configure the strelka run
     "--bam {bam} "  # input bam
     "--referenceFasta {snakemake.input.fasta} "  # reference genome
     "--runDir {run_dir} "  # output directory
@@ -29,6 +29,6 @@ shell(
     "&& {run_dir}/runWorkflow.py "  # run the strelka workflow
     "-m local "  # run in local mode
     "-j {snakemake.threads} "  # number of threads
-    "{run_extra} "  # additional parameters for the run
+    "{run_extra}) "  # additional parameters for the run
     "{log}"
 )  # logging


### PR DESCRIPTION
### Description

This PR adds parentheses around the body of the strelka germline shell script to catch the log information of both parts in the logfile, fixing a previous error.

### QC
<!-- Make sure that you can tick the boxes below. -->

For all wrappers added by this PR, I made sure that

* [x] there is a test case which covers any introduced changes,
* [x] `input:` and `output:` file paths in the resulting rule can be changed arbitrarily,
* [x] rule names in the test case are in [snake_case](https://en.wikipedia.org/wiki/Snake_case) and somehow tell what the rule is about or match the tools purpose or name (e.g., `map_reads` for a step that maps reads),
* [x] all `environment.yaml` specifications follow [the respective best practices](https://stackoverflow.com/a/64594513/2352071),
* [x] wherever possible, command line arguments are inferred and set automatically (e.g. based on file extensions in `input:` or `output:`),
* [x] all fields of the example rules in the `Snakefile`s and their entries are explained via comments (`input:`/`output:`/`params:` etc.),
* [x] `stderr` and/or `stdout` are logged correctly (`log:`), depending on the wrapped tool,
* [x] temporary files are either written to a unique hidden folder in the working directory, or (better) stored where the Python function `tempfile.gettempdir()` points to (see [here](https://docs.python.org/3/library/tempfile.html#tempfile.gettempdir); this also means that using any Python `tempfile` default behavior works),
* [x] the `meta.yaml` contains a link to the documentation of the respective tool or command,
* [x] `Snakefile`s pass the linting (`snakemake --lint`),
* [x] `Snakefile`s are formatted with [snakefmt](https://github.com/snakemake/snakefmt),
* [x] Python wrapper scripts are formatted with [black](https://black.readthedocs.io).
