### PR TITLE
feat: Chromosome wise ensembl variation download

### DIFF
--- a/bio/reference/ensembl-variation/test/Snakefile
+++ b/bio/reference/ensembl-variation/test/Snakefile
@@ -1,9 +1,10 @@
 rule get_variation:
+    # Optional: add fai as input to get VCF with annotated contig lengths (as required by GATK)
+    # and properly sorted VCFs.
+    # input:
+    #     fai="refs/genome.fasta.fai"
     output:
         vcf="refs/variation.vcf.gz",
-        # Optional: add fai to get VCF with annotated contig lengths (as required by GATK)
-        # and properly sorted VCFs.
-        # fai="refs/genome.fasta.fai"
     params:
         species="saccharomyces_cerevisiae",
         release="98",  # releases <98 are unsupported

--- a/bio/reference/ensembl-variation/test/Snakefile
+++ b/bio/reference/ensembl-variation/test/Snakefile
@@ -1,16 +1,17 @@
 rule get_variation:
     output:
-        vcf="refs/variation.vcf.gz"
+        vcf="refs/variation.vcf.gz",
         # Optional: add fai to get VCF with annotated contig lengths (as required by GATK)
         # and properly sorted VCFs.
         # fai="refs/genome.fasta.fai"
     params:
         species="saccharomyces_cerevisiae",
-        release="98", # releases <98 are unsupported
+        release="98",  # releases <98 are unsupported
         build="R64-1-1",
-        type="all" # one of "all", "somatic", "structural_variation"
+        type="all",  # one of "all", "somatic", "structural_variation"
+        # chromosome="21", # optionally constrain to chromosome, only supported for homo_sapiens
     log:
-        "logs/get_variation.log"
+        "logs/get_variation.log",
     cache: True  # save space and time with between workflow caching (see docs)
     wrapper:
         "master/bio/reference/ensembl-variation"

--- a/bio/reference/ensembl-variation/test/chrom_wise.smk
+++ b/bio/reference/ensembl-variation/test/chrom_wise.smk
@@ -1,0 +1,13 @@
+rule get_variation:
+    output:
+        vcf="refs/variation.vcf.gz"
+    params:
+        species="homo_sapiens",
+        release="104",
+        build="GRCh38",
+        type="all", # one of "all", "somatic", "structural_variation"
+        chromosome="21",
+    log:
+        "logs/get_variation.log"
+    wrapper:
+        "master/bio/reference/ensembl-variation"

--- a/bio/reference/ensembl-variation/wrapper.py
+++ b/bio/reference/ensembl-variation/wrapper.py
@@ -35,10 +35,10 @@ if chromosome and type != "all":
 
 if type == "all":
     if species == "homo_sapiens" and release >= 93:
-        chroms = list(range(1, 23)) + ["X", "Y", "MT"] if not chromosome else [chromosome]
-        suffixes = [
-            "-chr{}".format(chrom) for chrom in chroms
-        ]
+        chroms = (
+            list(range(1, 23)) + ["X", "Y", "MT"] if not chromosome else [chromosome]
+        )
+        suffixes = ["-chr{}".format(chrom) for chrom in chroms]
     else:
         if chromosome:
             raise ValueError(

--- a/bio/reference/ensembl-variation/wrapper.py
+++ b/bio/reference/ensembl-variation/wrapper.py
@@ -14,6 +14,7 @@ species = snakemake.params.species.lower()
 release = int(snakemake.params.release)
 build = snakemake.params.build
 type = snakemake.params.type
+chromosome = snakemake.params.get("chromosome", "")
 
 if release < 98:
     print("Ensembl releases <98 are unsupported.", file=open(snakemake.log[0], "w"))
@@ -26,12 +27,24 @@ if release >= 81 and build == "GRCh37":
 
 log = snakemake.log_fmt_shell(stdout=False, stderr=True)
 
+if chromosome and type != "all":
+    raise ValueError(
+        "Parameter chromosome given but chromosome-wise download"
+        "is only implemented for type='all'."
+    )
+
 if type == "all":
     if species == "homo_sapiens" and release >= 93:
+        chroms = list(range(1, 23)) + ["X", "Y", "MT"] if not chromosome else [chromosome]
         suffixes = [
-            "-chr{}".format(chrom) for chrom in list(range(1, 23)) + ["X", "Y", "MT"]
+            "-chr{}".format(chrom) for chrom in chroms
         ]
     else:
+        if chromosome:
+            raise ValueError(
+                "Parameter chromosome given but chromosome-wise download"
+                "is only implemented for homo_sapiens in releases >=93."
+            )
         suffixes = [""]
 elif type == "somatic":
     suffixes = ["_somatic"]

--- a/test.py
+++ b/test.py
@@ -3460,6 +3460,13 @@ def test_ensembl_variation_grch37():
         ["snakemake", "-s", "grch37.smk", "--cores", "1", "--use-conda", "-F"],
     )
 
+@skip_if_not_modified
+def test_ensembl_variation_chromosome():
+    run(
+        "bio/reference/ensembl-variation",
+        ["snakemake", "-s", "chrom_wise.smk", "--cores", "1", "--use-conda", "-F"],
+    )
+
 
 @skip_if_not_modified
 def test_ensembl_variation_with_contig_lengths():


### PR DESCRIPTION
### Description

Allow to define a chromosome when downloading ensembl variation.

### QC
<!-- Make sure that you can tick the boxes below. -->

For all wrappers added by this PR, I made sure that

* [x] there is a test case which covers any introduced changes,
* [x] `input:` and `output:` file paths in the resulting rule can be changed arbitrarily,
* [x] rule names in the test case are in [snake_case](https://en.wikipedia.org/wiki/Snake_case) and somehow tell what the rule is about or match the tools purpose or name (e.g., `map_reads` for a step that maps reads),
* [x] all `environment.yaml` specifications follow [the respective best practices](https://stackoverflow.com/a/64594513/2352071),
* [x] wherever possible, command line arguments are inferred and set automatically (e.g. based on file extensions in `input:` or `output:`),
* [x] all fields of the example rules in the `Snakefile`s and their entries are explained via comments (`input:`/`output:`/`params:` etc.),
* [x] `stderr` and/or `stdout` are logged correctly (`log:`), depending on the wrapped tool,
* [x] temporary files are either written to a unique hidden folder in the working directory, or (better) stored where the Python function `tempfile.gettempdir()` points to (see [here](https://docs.python.org/3/library/tempfile.html#tempfile.gettempdir); this also means that using any Python `tempfile` default behavior works),
* [x] the `meta.yaml` contains a link to the documentation of the respective tool or command,
* [x] `Snakefile`s pass the linting (`snakemake --lint`),
* [x] `Snakefile`s are formatted with [snakefmt](https://github.com/snakemake/snakefmt),
* [x] Python wrapper scripts are formatted with [black](https://black.readthedocs.io).
