### PR TITLE
update rasusa to v0.6

### DIFF
--- a/bio/rasusa/environment.yaml
+++ b/bio/rasusa/environment.yaml
@@ -2,4 +2,4 @@ channels:
   - bioconda
   - conda-forge
 dependencies:
-  - rasusa ==0.3.0
+  - rasusa =0.6

--- a/bio/rasusa/meta.yaml
+++ b/bio/rasusa/meta.yaml
@@ -1,4 +1,23 @@
-name: rasusa
-description: Randomly subsample sequencing reads to a specified coverage using `rasusa <https://github.com/mbhall88/rasusa>`_.
+name:        rasusa
+description: Randomly subsample sequencing reads to a specified coverage.
+url:         https://github.com/mbhall88/rasusa
 authors:
   - Michael Hall
+input:
+  - Reads to subsample in FASTA/Q format. Input files can be named or unnamed.
+output:
+  - File paths to write subsampled reads to. If using paired-end data, make sure there are two output files in the same order as the input.
+params:
+  bases: >
+    Explicitly set the number of bases required e.g., 4.3kb, 7Tb, 9000, 4.1MB |nl|
+    If this option is given, ``coverage`` and ``genome_size`` are ignored
+  coverage: >
+    The desired coverage to sub-sample the reads to. |nl|
+    If ``bases`` is not provided, this option and ``genome_size`` are required
+  genome_size: >
+    Genome size to calculate coverage with respect to. e.g., 4.3kb, 7Tb, 9000, 4.1MB |nl|
+    Alternatively, a FASTA/Q index file can be provided and the genome size will be set
+    to the sum of all reference sequences. |nl|
+    If ``bases`` is not provided, this option and ``coverage`` are required
+  options: >
+    Any other options as listed in `the docs <https://github.com/mbhall88/rasusa#usage>`_.

--- a/bio/rasusa/test/Snakefile
+++ b/bio/rasusa/test/Snakefile
@@ -7,8 +7,9 @@ rule subsample:
         r2="{sample}.subsampled.r2.fq",
     params:
         options="--seed 15",
-        genome_size="3mb", # required
-        coverage=20, # required
+        genome_size="3mb",  # required, unless `bases` is given
+        coverage=20,  # required, unless `bases is given
+        #bases="2gb"
     log:
         "logs/subsample/{sample}.log",
     wrapper:

--- a/bio/rasusa/wrapper.py
+++ b/bio/rasusa/wrapper.py
@@ -9,9 +9,16 @@ from snakemake.shell import shell
 
 options = snakemake.params.get("options", "")
 
+bases = snakemake.params.get("bases")
+if bases is not None:
+    options += " -b {}".format(bases)
+else:
+    covg = snakemake.params.get("coverage")
+    gsize = snakemake.params.get("genome_size")
+    if covg is None or gsize is None:
+        raise ValueError(
+            "If `bases` is not given, then `coverage` and `genome_size` must be"
+        )
+    options += " -g {gsize} -c {covg}".format(gsize=gsize, covg=covg)
 
-shell(
-    "rasusa {options} -i {snakemake.input} -o {snakemake.output} "
-    "-c {snakemake.params.coverage} -g {snakemake.params.genome_size} "
-    "2> {snakemake.log}"
-)
+shell("rasusa {options} -i {snakemake.input} -o {snakemake.output} 2> {snakemake.log}")

--- a/docs/_templates/wrapper.rst
+++ b/docs/_templates/wrapper.rst
@@ -97,3 +97,7 @@ Code
 .. code-block:: {{ wrapper_lang }}
 
 {{ wrapper }}
+
+.. |nl| raw:: html
+
+   <br>

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -49,6 +49,8 @@ those marked optional, should be provided.
 * **params** (optional): A `mapping`_ of parameters that can be used in the wrapper's ``params`` directive. If no parameters are used for the wrapper, this field can be omitted.
 * **notes** (optional): Anything of note that does not fit into the scope of the other fields.
 
+You can add a newline to the rendered text in these fields with the addition of ``|nl|``
+
 Example
 ^^^^^^^
 


### PR DESCRIPTION
### Description
Updated the `rasusa` wrapper to version 0.6.

I also added a directive in the wrapper docs template to allow explicit newlines in the `meta.yaml` fields with the use of `|nl|`.

### QC
<!-- Make sure that you can tick the boxes below. -->

For all wrappers added by this PR, I made sure that

* [x] there is a test case which covers any introduced changes,
* [x] `input:` and `output:` file paths in the resulting rule can be changed arbitrarily,
* [x] rule names in the test case are in [snake_case](https://en.wikipedia.org/wiki/Snake_case) and somehow tell what the rule is about or match the tools purpose or name (e.g., `map_reads` for a step that maps reads),
* [x] all `environment.yaml` specifications follow [the respective best practices](https://stackoverflow.com/a/64594513/2352071),
* [x] wherever possible, command line arguments are inferred and set automatically (e.g. based on file extensions in `input:` or `output:`),
* [x] all fields of the example rules in the `Snakefile`s and their entries are explained via comments (`input:`/`output:`/`params:` etc.),
* [x] `stderr` and/or `stdout` are logged correctly (`log:`), depending on the wrapped tool,
* [x] temporary files are either written to a unique hidden folder in the working directory, or (better) stored where the Python function `tempfile.gettempdir()` points to (see [here](https://docs.python.org/3/library/tempfile.html#tempfile.gettempdir); this also means that using any Python `tempfile` default behavior works),
* [x] the `meta.yaml` contains a link to the documentation of the respective tool or command,
* [x] `Snakefile`s pass the linting (`snakemake --lint`),
* [x] `Snakefile`s are formatted with [snakefmt](https://github.com/snakemake/snakefmt),
* [x] Python wrapper scripts are formatted with [black](https://black.readthedocs.io).
