### PR TITLE
VariantRecalibrator Wrapper Fix

### DIFF
--- a/bio/gatk/variantrecalibrator/wrapper.py
+++ b/bio/gatk/variantrecalibrator/wrapper.py
@@ -34,7 +34,7 @@ def fmt_res(resname, resparams):
     )
 
 
-resources = [
+annotation_resources = [
     "--resource:{}".format(fmt_res(resname, resparams))
     for resname, resparams in snakemake.params["resources"].items()
 ]
@@ -45,7 +45,7 @@ if snakemake.output.tranches:
 
 log = snakemake.log_fmt_shell(stdout=True, stderr=True)
 shell(
-    "gatk --java-options '{java_opts}' VariantRecalibrator {extra} {resources} "
+    "gatk --java-options '{java_opts}' VariantRecalibrator {extra} {annotation_resources} "
     "-R {snakemake.input.ref} -V {snakemake.input.vcf} "
     "-mode {snakemake.params.mode} "
     "--output {snakemake.output.vcf} "


### PR DESCRIPTION
Changed resources variable name in VariantRecalibrator wrapper so as to not collide with the resources keyword.

Perhaps due to a change in snakemake itself, using the variable `resources` in the wrapper was resulting in a name collision in https://github.com/snakemake/snakemake/blob/0503a73ea59241a826684725ac26b876eab52f72/snakemake/shell.py#L193.  The code in `shell.py` is apparently supposed to access the rule's `resources:` but was instead getting the `resources` defined in the wrapper script and causing an exception to be raised:
```
tmpdir_resource = resources.get("tmpdir", None)
AttributeError: 'list' object has no attribute 'get'
```

### Description

<!--Add a description of your PR here-->

### QC
<!-- Make sure that you can tick the boxes below. -->

For all wrappers added by this PR, I made sure that

* [ ] there is a test case which covers any introduced changes,
* [ ] `input:` and `output:` file paths in the resulting rule can be changed arbitrarily,
* [ ] rule names in the test case are in [snake_case](https://en.wikipedia.org/wiki/Snake_case) and somehow tell what the rule is about or match the tools purpose or name (e.g., `map_reads` for a step that maps reads),
* [ ] all `environment.yaml` specifications follow [the respective best practices](https://stackoverflow.com/a/64594513/2352071),
* [ ] wherever possible, command line arguments are inferred and set automatically (e.g. based on file extensions in `input:` or `output:`),
* [ ] all fields of the example rules in the `Snakefile`s and their entries are explained via comments (`input:`/`output:`/`params:` etc.),
* [ ] `stderr` and/or `stdout` are logged correctly (`log:`), depending on the wrapped tool,
* [ ] temporary files are either written to a unique hidden folder in the working directory, or (better) stored where the Python function `tempfile.gettempdir()` points to (see [here](https://docs.python.org/3/library/tempfile.html#tempfile.gettempdir); this also means that using any Python `tempfile` default behavior works),
* [ ] the `meta.yaml` contains a link to the documentation of the respective tool or command,
* [ ] `Snakefile`s pass the linting (`snakemake --lint`),
* [ ] `Snakefile`s are formatted with [snakefmt](https://github.com/snakemake/snakefmt),
* [ ] Python wrapper scripts are formatted with [black](https://black.readthedocs.io).
