### PR TITLE
Handle refseq files in vep annotate 

### DIFF
--- a/bio/vep/annotate/wrapper.py
+++ b/bio/vep/annotate/wrapper.py
@@ -42,7 +42,7 @@ if gff:
 
 if cache:
     entrypath = get_only_child_dir(get_only_child_dir(Path(cache)))
-    species = entrypath.parent.name.strip("_refseq")
+    species = entrypath.parent.name[:-7] if entrypath.parent.name.endswith("_seqref") else entrypath.parent.name
     release, build = entrypath.name.split("_")
     cache = (
         "--offline --cache --dir_cache {cache} --cache_version {release} --species {species} --assembly {build}"

--- a/bio/vep/annotate/wrapper.py
+++ b/bio/vep/annotate/wrapper.py
@@ -42,7 +42,7 @@ if gff:
 
 if cache:
     entrypath = get_only_child_dir(get_only_child_dir(Path(cache)))
-    species = entrypath.parent.name
+    species = entrypath.parent.name.strip("_refseq")
     release, build = entrypath.name.split("_")
     cache = (
         "--offline --cache --dir_cache {cache} --cache_version {release} --species {species} --assembly {build}"

--- a/bio/vep/annotate/wrapper.py
+++ b/bio/vep/annotate/wrapper.py
@@ -42,7 +42,7 @@ if gff:
 
 if cache:
     entrypath = get_only_child_dir(get_only_child_dir(Path(cache)))
-    species = entrypath.parent.name[:-7] if entrypath.parent.name.endswith("_seqref") else entrypath.parent.name
+    species = entrypath.parent.name[:-7] if entrypath.parent.name.endswith("_refseq") else entrypath.parent.name
     release, build = entrypath.name.split("_")
     cache = (
         "--offline --cache --dir_cache {cache} --cache_version {release} --species {species} --assembly {build}"


### PR DESCRIPTION
### Description

This removes the `_refseq` suffix from the species as vep already extends it when setting the `--refseq` parameter resulting in `<species>_refseq_refseq` executing vep.

### QC
<!-- Make sure that you can tick the boxes below. -->

For all wrappers added by this PR, I made sure that

* [ ] there is a test case which covers any introduced changes,
* [ ] `input:` and `output:` file paths in the resulting rule can be changed arbitrarily,
* [ ] rule names in the test case are in [snake_case](https://en.wikipedia.org/wiki/Snake_case) and somehow tell what the rule is about or match the tools purpose or name (e.g., `map_reads` for a step that maps reads),
* [ ] all `environment.yaml` specifications follow [the respective best practices](https://stackoverflow.com/a/64594513/2352071),
* [ ] wherever possible, command line arguments are inferred and set automatically (e.g. based on file extensions in `input:` or `output:`),
* [ ] all fields of the example rules in the `Snakefile`s and their entries are explained via comments (`input:`/`output:`/`params:` etc.),
* [ ] `stderr` and/or `stdout` are logged correctly (`log:`), depending on the wrapped tool,
* [ ] temporary files are either written to a unique hidden folder in the working directory, or (better) stored where the Python function `tempfile.gettempdir()` points to (see [here](https://docs.python.org/3/library/tempfile.html#tempfile.gettempdir); this also means that using any Python `tempfile` default behavior works),
* [ ] the `meta.yaml` contains a link to the documentation of the respective tool or command,
* [ ] `Snakefile`s pass the linting (`snakemake --lint`),
* [ ] `Snakefile`s are formatted with [snakefmt](https://github.com/snakemake/snakefmt),
* [ ] Python wrapper scripts are formatted with [black](https://black.readthedocs.io).
