### PR TITLE
Make STAR output prefix more flexible

### DIFF
--- a/bio/star/align/wrapper.py
+++ b/bio/star/align/wrapper.py
@@ -36,7 +36,9 @@ if fq1[0].endswith(".gz"):
 else:
     readcmd = ""
 
-outprefix = os.path.dirname(snakemake.output[0]) + "/"
+outprefix = snakemake.output[0].split("Aligned.out.")[0]
+if outprefix == os.path.dirname(snakemake.output[0]):
+    outprefix += "/"
 
 shell(
     "STAR "

--- a/bio/star/align/wrapper.py
+++ b/bio/star/align/wrapper.py
@@ -36,7 +36,13 @@ if fq1[0].endswith(".gz"):
 else:
     readcmd = ""
 
-outprefix = snakemake.output[0].split("Aligned.out.")[0]
+if "SortedByCoordinate" in extra:
+    bamprefix = "Aligned.sortedByCoord.out."
+else:
+    bamprefix = "Aligned.out."
+
+outprefix = snakemake.output[0].split(bamprefix)[0]
+
 if outprefix == os.path.dirname(snakemake.output[0]):
     outprefix += "/"
 


### PR DESCRIPTION
### Description

This change allows a user to use output prefixes that are not limited to an output directory, but could also include other information.

This is useful in cases when one would like for the output sam/bam files to include for example the sample name in the file name itself (useful when loading multiple bam files into visualisers).

### QC
<!-- Make sure that you can tick the boxes below. -->

For all wrappers added by this PR, I made sure that

* [x] there is a test case which covers any introduced changes,
* [x] `input:` and `output:` file paths in the resulting rule can be changed arbitrarily,
* [x] either the wrapper can only use a single core, or the example rule contains a `threads: x` statement with `x` being a reasonable default,
* [x] rule names in the test case are in [snake_case](https://en.wikipedia.org/wiki/Snake_case) and somehow tell what the rule is about or match the tools purpose or name (e.g., `map_reads` for a step that maps reads),
* [x] all `environment.yaml` specifications follow [the respective best practices](https://stackoverflow.com/a/64594513/2352071),
* [x] wherever possible, command line arguments are inferred and set automatically (e.g. based on file extensions in `input:` or `output:`),
* [x] all fields of the example rules in the `Snakefile`s and their entries are explained via comments (`input:`/`output:`/`params:` etc.),
* [x] `stderr` and/or `stdout` are logged correctly (`log:`), depending on the wrapped tool,
* [x] temporary files are either written to a unique hidden folder in the working directory, or (better) stored where the Python function `tempfile.gettempdir()` points to (see [here](https://docs.python.org/3/library/tempfile.html#tempfile.gettempdir); this also means that using any Python `tempfile` default behavior works),
* [x] the `meta.yaml` contains a link to the documentation of the respective tool or command,
* [x] `Snakefile`s pass the linting (`snakemake --lint`),
* [x] `Snakefile`s are formatted with [snakefmt](https://github.com/snakemake/snakefmt),
* [x] Python wrapper scripts are formatted with [black](https://black.readthedocs.io).
