### PR TITLE
GATK version update

### DIFF
--- a/bio/gatk/genomicsdbimport/environment.yaml
+++ b/bio/gatk/genomicsdbimport/environment.yaml
@@ -3,5 +3,5 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - gatk4 ==4.2.0.0
+  - gatk4 =4.2
   - snakemake-wrapper-utils ==0.1.3

--- a/bio/gatk/genomicsdbimport/meta.yaml
+++ b/bio/gatk/genomicsdbimport/meta.yaml
@@ -8,8 +8,8 @@ input:
 output:
   - A GenomicsDB workspace
 notes: |
-  * The `java_opts` param allows for additional arguments to be passed to the java compiler, e.g. "-XX:ParallelGCThreads=10" (not for `-XmX` or `-Djava.io.tmpdir`, since they are handled automatically).
+  * The `java_opts` param allows for additional arguments to be passed to the java compiler, e.g. `-XX:ParallelGCThreads=10` (not for `-XmX` or `-Djava.io.tmpdir`, since they are handled automatically).
   * The `intervals` param is mandatory
   * By default, the wrapper will create a new database (output directory must be empty or non-existent). If you want to update an existing DB, set `db_action` param to `update`.
   * The `extra` param allows for additional program arguments.
-  * For more information see, https://gatk.broadinstitute.org/hc/en-us/articles/360051305591-GenomicsDBImport
+  * For more information see, https://gatk.broadinstitute.org/hc/en-us/articles/4405451266331-GenomicsDBImport

--- a/bio/gatk/genotypegvcfs/environment.yaml
+++ b/bio/gatk/genotypegvcfs/environment.yaml
@@ -3,5 +3,5 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - gatk4 ==4.2.0.0
+  - gatk4 =4.2
   - snakemake-wrapper-utils ==0.1.3

--- a/bio/gatk/genotypegvcfs/meta.yaml
+++ b/bio/gatk/genotypegvcfs/meta.yaml
@@ -5,10 +5,11 @@ authors:
   - Johannes Köster
   - Jake VanCampen
 input:
-  - GVCF files
+  - GVCF files or GenomicsDB workspace
+  - reference genome
 output:
   - VCF file with genotypes
 notes: |
-  * The `java_opts` param allows for additional arguments to be passed to the java compiler, e.g. "-Xmx4G" for one, and "-Xmx4G -XX:ParallelGCThreads=10" for two options.
+  * The `java_opts` param allows for additional arguments to be passed to the java compiler, e.g. `-XX:ParallelGCThreads=10` (not for `-XmX` or `-Djava.io.tmpdir`, since they are handled automatically).
   * The `extra` param allows for additional program arguments.
-  * For more information see, https://software.broadinstitute.org/gatk/documentation/article?id=11050
+  * For more information see, https://gatk.broadinstitute.org/hc/en-us/articles/4405451397659-GenotypeGVCFs

--- a/bio/gatk/genotypegvcfs/test/Snakefile
+++ b/bio/gatk/genotypegvcfs/test/Snakefile
@@ -11,10 +11,6 @@ rule genotype_gvcfs:
     params:
         extra="",  # optional
         java_opts="", # optional
-    # optional specification of memory usage of the JVM that snakemake will respect with global
-    # resource restrictions (https://snakemake.readthedocs.io/en/latest/snakefiles/rules.html#resources)
-    # and which can be used to request RAM during cluster job submission as `{resources.mem_mb}`:
-    # https://snakemake.readthedocs.io/en/latest/executing/cluster.html#job-properties
     resources:
         mem_mb=1024
     wrapper:

--- a/bio/gatk/haplotypecaller/environment.yaml
+++ b/bio/gatk/haplotypecaller/environment.yaml
@@ -3,5 +3,5 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - gatk4 ==4.1.4.1
+  - gatk4 =4.2
   - snakemake-wrapper-utils ==0.1.3

--- a/bio/gatk/haplotypecaller/meta.yaml
+++ b/bio/gatk/haplotypecaller/meta.yaml
@@ -9,7 +9,7 @@ input:
 output:
   - GVCF file
 notes: |
-  * The `java_opts` param allows for additional arguments to be passed to the java compiler, e.g. "-Xmx4G" for one, and "-Xmx4G -XX:ParallelGCThreads=10" for two options.
+  * The `java_opts` param allows for additional arguments to be passed to the java compiler, e.g. `-XX:ParallelGCThreads=10` (not for `-XmX` or `-Djava.io.tmpdir`, since they are handled automatically).
   * The `extra` param allows for additional program arguments.
-  * For more information see, https://software.broadinstitute.org/gatk/documentation/article?id=11050
+  * For more information see, https://gatk.broadinstitute.org/hc/en-us/articles/4405451272731-HaplotypeCaller
 

--- a/bio/gatk/haplotypecaller/test/Snakefile
+++ b/bio/gatk/haplotypecaller/test/Snakefile
@@ -12,10 +12,6 @@ rule haplotype_caller:
     params:
         extra="",  # optional
         java_opts="", # optional
-    # optional specification of memory usage of the JVM that snakemake will respect with global
-    # resource restrictions (https://snakemake.readthedocs.io/en/latest/snakefiles/rules.html#resources)
-    # and which can be used to request RAM during cluster job submission as `{resources.mem_mb}`:
-    # https://snakemake.readthedocs.io/en/latest/executing/cluster.html#job-properties
     resources:
         mem_mb=1024
     wrapper:


### PR DESCRIPTION
### Description

Update GATK version

### QC
<!-- Make sure that you can tick the boxes below. -->

For all wrappers added by this PR, I made sure that

* [x] there is a test case which covers any introduced changes,
* [x] `input:` and `output:` file paths in the resulting rule can be changed arbitrarily,
* [x] either the wrapper can only use a single core, or the example rule contains a `threads: x` statement with `x` being a reasonable default,
* [x] rule names in the test case are in [snake_case](https://en.wikipedia.org/wiki/Snake_case) and somehow tell what the rule is about or match the tools purpose or name (e.g., `map_reads` for a step that maps reads),
* [x] all `environment.yaml` specifications follow [the respective best practices](https://stackoverflow.com/a/64594513/2352071),
* [x] wherever possible, command line arguments are inferred and set automatically (e.g. based on file extensions in `input:` or `output:`),
* [ ] all fields of the example rules in the `Snakefile`s and their entries are explained via comments (`input:`/`output:`/`params:` etc.),
* [x] `stderr` and/or `stdout` are logged correctly (`log:`), depending on the wrapped tool,
* [x] temporary files are either written to a unique hidden folder in the working directory, or (better) stored where the Python function `tempfile.gettempdir()` points to (see [here](https://docs.python.org/3/library/tempfile.html#tempfile.gettempdir); this also means that using any Python `tempfile` default behavior works),
* [x] the `meta.yaml` contains a link to the documentation of the respective tool or command,
* [x] `Snakefile`s pass the linting (`snakemake --lint`),
* [x] `Snakefile`s are formatted with [snakefmt](https://github.com/snakemake/snakefmt),
* [x] Python wrapper scripts are formatted with [black](https://black.readthedocs.io).
