### PR TITLE
Fix freebayes normalization

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,9 @@ jobs:
   docs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
+        with:
+          submodules: recursive
 
       - name: Setup Sphinx environment
         run: |
@@ -30,10 +32,9 @@ jobs:
   testing:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
-
-      - name: Checkout submodules
-        uses: textbook/git-checkout-submodule-action@2.0.0
+      - uses: actions/checkout@v2
+        with:
+          submodules: recursive
 
       - name: Setup Snakemake environment
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,9 +13,7 @@ jobs:
   docs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-        with:
-          submodules: recursive
+      - uses: actions/checkout@v1
 
       - name: Setup Sphinx environment
         run: |

--- a/bio/freebayes/environment.yaml
+++ b/bio/freebayes/environment.yaml
@@ -2,7 +2,7 @@ channels:
   - bioconda
   - conda-forge
 dependencies:
-  - freebayes =1.3.1
+  - freebayes =1.3.2
   - bcftools =1.11
   - parallel =20190522
   - bedtools >=2.29

--- a/bio/freebayes/meta.yaml
+++ b/bio/freebayes/meta.yaml
@@ -12,6 +12,6 @@ output:
 notes: |
   * The `extra` param allows for additional arguments for freebayes.
   * The `uncompressed_bcf`param allows for uncompressed BCF output.
-  * The `normalize` param allows to use `bcftools norm` to normalize indels.
+  * The optional `normalize` param allows to use `bcftools norm` to normalize indels. When set one of the following params must be passed: -a, -f, -m, -D or -d
   * The `chunkzise` param allows setting reference genome chunk size for parallelization (default: 100000)
   * For more inforamtion see, https://github.com/freebayes/freebayes

--- a/bio/freebayes/test/Snakefile
+++ b/bio/freebayes/test/Snakefile
@@ -15,7 +15,7 @@ rule freebayes:
     params:
         extra="",         # optional parameters
         chunksize=100000, # reference genome chunk size for parallelization (default: 100000)
-        normalize=False,  # optinal flag to use bcftools norm to normalize indels (Valid flags are -a, -f, -m, -D or -d)
+        normalize=False,  # optional flag to use bcftools norm to normalize indels (Valid params are -a, -f, -m, -D or -d)
     threads: 2
     wrapper:
         "master/bio/freebayes"

--- a/bio/freebayes/test/Snakefile
+++ b/bio/freebayes/test/Snakefile
@@ -4,17 +4,17 @@ rule freebayes:
         # you can have a list of samples here
         samples="mapped/{sample}.bam",
         # the matching BAI indexes have to present for freebayes
-        indexes="mapped/{sample}.bam.bai"
+        indexes="mapped/{sample}.bam.bai",
         # optional BED file specifying chromosomal regions on which freebayes 
         # should run, e.g. all regions that show coverage
         #regions="/path/to/region-file.bed"
     output:
-        "calls/{sample}.vcf"  # either .vcf or .bcf
+        "calls/{sample}.vcf",  # either .vcf or .bcf
     log:
-        "logs/freebayes/{sample}.log"
+        "logs/freebayes/{sample}.log",
     params:
-        extra="",         # optional parameters
-        chunksize=100000, # reference genome chunk size for parallelization (default: 100000)
+        extra="",  # optional parameters
+        chunksize=100000,  # reference genome chunk size for parallelization (default: 100000)
         normalize=False,  # optional flag to use bcftools norm to normalize indels (Valid params are -a, -f, -m, -D or -d)
     threads: 2
     wrapper:

--- a/bio/freebayes/test/Snakefile
+++ b/bio/freebayes/test/Snakefile
@@ -7,7 +7,7 @@ rule freebayes:
         indexes="mapped/{sample}.bam.bai",
         # optional BED file specifying chromosomal regions on which freebayes 
         # should run, e.g. all regions that show coverage
-        #regions="/path/to/region-file.bed"
+        #regions="path/to/region-file.bed"
     output:
         "calls/{sample}.vcf",  # either .vcf or .bcf
     log:

--- a/bio/freebayes/test/Snakefile
+++ b/bio/freebayes/test/Snakefile
@@ -15,7 +15,7 @@ rule freebayes:
     params:
         extra="",         # optional parameters
         chunksize=100000, # reference genome chunk size for parallelization (default: 100000)
-        normalize=False,  # flag to use bcftools norm to normalize indels
+        normalize=False,  # optinal flag to use bcftools norm to normalize indels (Valid flags are -a, -f, -m, -D or -d)
     threads: 2
     wrapper:
         "master/bio/freebayes"

--- a/bio/freebayes/wrapper.py
+++ b/bio/freebayes/wrapper.py
@@ -6,6 +6,7 @@ __license__ = "MIT"
 
 from os import path
 from snakemake.shell import shell
+from tempfile import TemporaryDirectory
 
 shell.executable("bash")
 
@@ -62,7 +63,8 @@ else:
         snakemake=snakemake, regions=regions
     )
 
-shell(
-    "({freebayes} {params} -f {snakemake.input.ref}"
-    " {snakemake.input.samples} | bcftools sort - {pipe} > {snakemake.output[0]}) {log}"
-)
+with TemporaryDirectory() as tempdir:
+    shell(
+        "({freebayes} {params} -f {snakemake.input.ref}"
+        " {snakemake.input.samples} | bcftools sort -T {tempdir} - {pipe} > {snakemake.output[0]}) {log}"
+    )

--- a/bio/freebayes/wrapper.py
+++ b/bio/freebayes/wrapper.py
@@ -13,7 +13,6 @@ log = snakemake.log_fmt_shell(stdout=False, stderr=True)
 
 params = snakemake.params.get("extra", "")
 norm = snakemake.params.get("normalize", False)
-assert norm in [True, False]
 
 
 # Infer output format
@@ -38,7 +37,7 @@ else:
 
 pipe = ""
 if norm:
-    pipe = f"| bcftools norm --output-type {out_format} -"
+    pipe = f"| bcftools norm {norm} --output-type {out_format} -"
 else:
     pipe = f"| bcftools view --output-type {out_format} -"
 

--- a/bio/freebayes/wrapper.py
+++ b/bio/freebayes/wrapper.py
@@ -64,5 +64,5 @@ else:
 
 shell(
     "({freebayes} {params} -f {snakemake.input.ref}"
-    " {snakemake.input.samples} {pipe} > {snakemake.output[0]}) {log}"
+    " {snakemake.input.samples} | bcftools sort - {pipe} > {snakemake.output[0]}) {log}"
 )


### PR DESCRIPTION
### Description

When setting `normalize = True` die rule fails as `bcftools norm` requires a parameter.
This is fixed by changing the `normalize` parameter into a string allowing the user to select the desired parameter. 

### QC
<!-- Make sure that you can tick the boxes below. -->

For all wrappers added by this PR, I made sure that

* [x] there is a test case which covers any introduced changes,
* [x] `input:` and `output:` file paths in the resulting rule can be changed arbitrarily,
* [x] either the wrapper can only use a single core, or the example rule contains a `threads: x` statement with `x` being a reasonable default,
* [x] rule names in the test case are in [snake_case](https://en.wikipedia.org/wiki/Snake_case) and somehow tell what the rule is about or match the tools purpose or name (e.g., `map_reads` for a step that maps reads),
* [x] all `environment.yaml` specifications follow [the respective best practices](https://stackoverflow.com/a/64594513/2352071),
* [x] wherever possible, command line arguments are inferred and set automatically (e.g. based on file extensions in `input:` or `output:`),
* [x] all fields of the example rules in the `Snakefile`s and their entries are explained via comments (`input:`/`output:`/`params:` etc.),
* [x] `stderr` and/or `stdout` are logged correctly (`log:`), depending on the wrapped tool,
* [x] temporary files are either written to a unique hidden folder in the working directory, or (better) stored where the Python function `tempfile.gettempdir()` points to (see [here](https://docs.python.org/3/library/tempfile.html#tempfile.gettempdir); this also means that using any Python `tempfile` default behavior works),
* [x] the `meta.yaml` contains a link to the documentation of the respective tool or command,
* [x] `Snakefile`s pass the linting (`snakemake --lint`),
* [x] `Snakefile`s are formatted with [snakefmt](https://github.com/snakemake/snakefmt),
* [x] Python wrapper scripts are formatted with [black](https://black.readthedocs.io).
