### PR TITLE
update metaspades

### DIFF
--- a/bio/spades/metaspades/environment.yaml
+++ b/bio/spades/metaspades/environment.yaml
@@ -4,3 +4,4 @@ channels:
   - defaults
 dependencies:
   - spades >=3.15
+  - python >=3.5, <3.10  # spades doesn't support yet py 3.10 https://github.com/ablab/spades/issues/863

--- a/bio/spades/metaspades/wrapper.py
+++ b/bio/spades/metaspades/wrapper.py
@@ -81,7 +81,9 @@ if not os.path.exists(os.path.join(output_dir, "params.txt")):
 else:
     # params.txt file exitst already I restart from previous run
 
-    shell("echo '\n\nRestart Spades \n' >> {log[0]}")
+    shell("echo '\n\nRestart Spades \n Remove pipline_state file copy files to force copy files if necessary.' >> {log[0]}")
+
+    shell("rm -f {output_dir}/pipeline_state/stage_*_copy_files 2>> {log}")
 
     shell(
         "spades.py --meta "

--- a/bio/spades/metaspades/wrapper.py
+++ b/bio/spades/metaspades/wrapper.py
@@ -81,7 +81,9 @@ if not os.path.exists(os.path.join(output_dir, "params.txt")):
 else:
     # params.txt file exitst already I restart from previous run
 
-    shell("echo '\n\nRestart Spades \n Remove pipline_state file copy files to force copy files if necessary.' >> {log[0]}")
+    shell(
+        "echo '\n\nRestart Spades \n Remove pipline_state file copy files to force copy files if necessary.' >> {log[0]}"
+    )
 
     shell("rm -f {output_dir}/pipeline_state/stage_*_copy_files 2>> {log}")
 


### PR DESCRIPTION
…tput

### Description

<!--Add a description of your PR here-->

emove pipeline state file for spades otherwise it doesn't produce output files

### QC
<!-- Make sure that you can tick the boxes below. -->

For all wrappers added by this PR, I made sure that

* [x] there is a test case which covers any introduced changes,
* [x] `input:` and `output:` file paths in the resulting rule can be changed arbitrarily,
* [x] either the wrapper can only use a single core, or the example rule contains a `threads: x` statement with `x` being a reasonable default,
* [x] rule names in the test case are in [snake_case](https://en.wikipedia.org/wiki/Snake_case) and somehow tell what the rule is about or match the tools purpose or name (e.g., `map_reads` for a step that maps reads),
* [x] all `environment.yaml` specifications follow [the respective best practices](https://stackoverflow.com/a/64594513/2352071),
* [x] wherever possible, command line arguments are inferred and set automatically (e.g. based on file extensions in `input:` or `output:`),
* [ ] all fields of the example rules in the `Snakefile`s and their entries are explained via comments (`input:`/`output:`/`params:` etc.),
* [x] `stderr` and/or `stdout` are logged correctly (`log:`), depending on the wrapped tool,
* [ ] temporary files are either written to a unique hidden folder in the working directory, or (better) stored where the Python function `tempfile.gettempdir()` points to (see [here](https://docs.python.org/3/library/tempfile.html#tempfile.gettempdir); this also means that using any Python `tempfile` default behavior works),
* [ ] the `meta.yaml` contains a link to the documentation of the respective tool or command,
* [ ] `Snakefile`s pass the linting (`snakemake --lint`),
* [ ] `Snakefile`s are formatted with [snakefmt](https://github.com/snakemake/snakefmt),
* [ ] Python wrapper scripts are formatted with [black](https://black.readthedocs.io).
