### PR TITLE
Add java_opts

### DIFF
--- a/bio/fgbio/annotatebamwithumis/environment.yaml
+++ b/bio/fgbio/annotatebamwithumis/environment.yaml
@@ -4,4 +4,4 @@ channels:
   - defaults
 dependencies:
   - fgbio ==1.4.0
-  - snakemake-wrapper-utils ==0.1.3
+  - snakemake-wrapper-utils ==0.2

--- a/bio/fgbio/annotatebamwithumis/environment.yaml
+++ b/bio/fgbio/annotatebamwithumis/environment.yaml
@@ -3,4 +3,4 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - fgbio ==0.6.1
+  - fgbio ==1.4.0

--- a/bio/fgbio/annotatebamwithumis/environment.yaml
+++ b/bio/fgbio/annotatebamwithumis/environment.yaml
@@ -4,3 +4,4 @@ channels:
   - defaults
 dependencies:
   - fgbio ==1.4.0
+  - snakemake-wrapper-utils ==0.1.3

--- a/bio/fgbio/annotatebamwithumis/test/Snakefile
+++ b/bio/fgbio/annotatebamwithumis/test/Snakefile
@@ -6,7 +6,7 @@ rule AnnotateBam:
         "mapped/{sample}.annotated.bam",
     params: ""
     resources:
-        mem_gb="4" # memory to be propagated to fgbio
+        mem_gb="4" # memory to be given to fgbio
     log:
         "logs/fgbio/annotate_bam/{sample}.log",
     wrapper:

--- a/bio/fgbio/annotatebamwithumis/test/Snakefile
+++ b/bio/fgbio/annotatebamwithumis/test/Snakefile
@@ -1,11 +1,13 @@
 rule AnnotateBam:
     input:
         bam="mapped/{sample}.bam",
-        umi="umi/{sample}.fastq"
+        umi="umi/{sample}.fastq",
     output:
-        "mapped/{sample}.annotated.bam"
-    params: ""
+        "mapped/{sample}.annotated.bam",
+    params:
+        extra="",  #optional
+        java_opts="",  #optional
     log:
-        "logs/fgbio/annotate_bam/{sample}.log"
+        "logs/fgbio/annotate_bam/{sample}.log",
     wrapper:
         "master/bio/fgbio/annotatebamwithumis"

--- a/bio/fgbio/annotatebamwithumis/test/Snakefile
+++ b/bio/fgbio/annotatebamwithumis/test/Snakefile
@@ -4,8 +4,7 @@ rule AnnotateBam:
         umi="umi/{sample}.fastq",
     output:
         "mapped/{sample}.annotated.bam",
-    params:
-        ""
+    params: ""
     resources:
         mem_gb="4" # memory to be propagated to fgbio
     log:

--- a/bio/fgbio/annotatebamwithumis/test/Snakefile
+++ b/bio/fgbio/annotatebamwithumis/test/Snakefile
@@ -5,8 +5,9 @@ rule AnnotateBam:
     output:
         "mapped/{sample}.annotated.bam",
     params:
-        extra="",  #optional
-        java_opts="",  #optional
+        ""
+    resources:
+        mem_gb="4" # memory to be propagated to fgbio
     log:
         "logs/fgbio/annotate_bam/{sample}.log",
     wrapper:

--- a/bio/fgbio/annotatebamwithumis/wrapper.py
+++ b/bio/fgbio/annotatebamwithumis/wrapper.py
@@ -5,12 +5,14 @@ __license__ = "MIT"
 
 
 from snakemake.shell import shell
+from snakemake_wrapper_utils.java import get_java_opts
 
 shell.executable("bash")
 
 log = snakemake.log_fmt_shell(stdout=False, stderr=True)
 
 extra_params = snakemake.params.get("extra", "")
+java_opts = get_java_opts(snakemake)
 
 bam_input = snakemake.input.bam
 
@@ -35,8 +37,6 @@ if output_file is None:
     raise ValueError("Missing output file!")
 elif not isinstance(output_file, str):
     raise ValueError("Output bam-file should be a string: " + str(output_file) + "!")
-
-java_opts = snakemake.params.get("java_opts", "")
 
 shell(
     "fgbio {java_opts} AnnotateBamWithUmis"

--- a/bio/fgbio/annotatebamwithumis/wrapper.py
+++ b/bio/fgbio/annotatebamwithumis/wrapper.py
@@ -36,8 +36,10 @@ if output_file is None:
 elif not isinstance(output_file, str):
     raise ValueError("Output bam-file should be a string: " + str(output_file) + "!")
 
+java_opts = snakemake.params.get("java_opts", "")
+
 shell(
-    "fgbio AnnotateBamWithUmis"
+    "fgbio {java_opts} AnnotateBamWithUmis"
     " -i {bam_input}"
     " -f {umi_input}"
     " -o {output_file}"


### PR DESCRIPTION
### Description

As `fgbio AnnotateBamWithUmis` is very memory consuming and tends to fail with an OutOfMemory-Error an optional `java_opts`-parameter has been added.
Also fgbio has been updated to its latest release.

### QC
<!-- Make sure that you can tick the boxes below. -->

For all wrappers added by this PR, I made sure that

* [x] there is a test case which covers any introduced changes,
* [x] `input:` and `output:` file paths in the resulting rule can be changed arbitrarily,
* [x] either the wrapper can only use a single core, or the example rule contains a `threads: x` statement with `x` being a reasonable default,
* [x] rule names in the test case are in [snake_case](https://en.wikipedia.org/wiki/Snake_case) and somehow tell what the rule is about or match the tools purpose or name (e.g., `map_reads` for a step that maps reads),
* [x] all `environment.yaml` specifications follow [the respective best practices](https://stackoverflow.com/a/64594513/2352071),
* [x] wherever possible, command line arguments are inferred and set automatically (e.g. based on file extensions in `input:` or `output:`),
* [x] all fields of the example rules in the `Snakefile`s and their entries are explained via comments (`input:`/`output:`/`params:` etc.),
* [x] `stderr` and/or `stdout` are logged correctly (`log:`), depending on the wrapped tool,
* [x] temporary files are either written to a unique hidden folder in the working directory, or (better) stored where the Python function `tempfile.gettempdir()` points to (see [here](https://docs.python.org/3/library/tempfile.html#tempfile.gettempdir); this also means that using any Python `tempfile` default behavior works),
* [x] the `meta.yaml` contains a link to the documentation of the respective tool or command,
* [x] `Snakefile`s pass the linting (`snakemake --lint`),
* [x] `Snakefile`s are formatted with [snakefmt](https://github.com/snakemake/snakefmt),
* [x] Python wrapper scripts are formatted with [black](https://black.readthedocs.io).
