### PR TITLE
MultiQC: pin Python >= 3.7 as a dependency.

### DIFF
--- a/bio/multiqc/environment.yaml
+++ b/bio/multiqc/environment.yaml
@@ -4,3 +4,4 @@ channels:
   - defaults
 dependencies:
   - multiqc ==1.10.1
+  - python >=3.7


### PR DESCRIPTION
Hi,

If merged, this PR will:
- pin `python >=3.7` as a requirement to the `environment.yaml` file of the MultiQC wrapper.

### Description

This fixes an encoding error caused by installing older versions of Python when running the MultiQC wrapper. The error is documented here: https://click.palletsprojects.com/en/8.0.x/unicode-support/ where it says that 'Python thinks you are restricted to ASCII data'. It is fixed by newer versions of Python. Although [the MultiQC recipe supports Python >= 3.6](https://github.com/bioconda/bioconda-recipes/blob/b15e0daf4d34cb40cfc3e98901da3f5f587fe0e6/recipes/multiqc/meta.yaml#L23), I think it can be argued that it would be best to prevent this for this particular wrapper. Please let me know if you think this is reasonable, and thank you for any assistance you can provide.

Best,
V

### QC
<!-- Make sure that you can tick the boxes below. -->

For all wrappers added by this PR, I made sure that

* ~~there is a test case which covers any introduced changes,~~
* ~~`input:` and `output:` file paths in the resulting rule can be changed arbitrarily,~~
* ~~either the wrapper can only use a single core, or the example rule contains a `threads: x` statement with `x` being a reasonable default,~~
* ~~rule names in the test case are in [snake_case](https://en.wikipedia.org/wiki/Snake_case) and somehow tell what the rule is about or match the tools purpose or name (e.g., `map_reads` for a step that maps reads),~~
* [x] all `environment.yaml` specifications follow [the respective best practices](https://stackoverflow.com/a/64594513/2352071),
* ~~wherever possible, command line arguments are inferred and set automatically (e.g. based on file extensions in `input:` or `output:`),~~
* ~~all fields of the example rules in the `Snakefile`s and their entries are explained via comments (`input:`/`output:`/`params:` etc.),~~
* ~~`stderr` and/or `stdout` are logged correctly (`log:`), depending on the wrapped tool,~~
* ~~temporary files are either written to a unique hidden folder in the working directory, or (better) stored where the Python function `tempfile.gettempdir()` points to (see [here](https://docs.python.org/3/library/tempfile.html#tempfile.gettempdir); this also means that using any Python `tempfile` default behavior works),~~
* ~~the `meta.yaml` contains a link to the documentation of the respective tool or command,~~
* ~~`Snakefile`s pass the linting (`snakemake --lint`),~~
* ~~`Snakefile`s are formatted with [snakefmt](https://github.com/snakemake/snakefmt),~~
* ~~Python wrapper scripts are formatted with [black](https://black.readthedocs.io).~~
