### PR TITLE
Enhance vep annotate

### DIFF
--- a/bio/vep/annotate/meta.yaml
+++ b/bio/vep/annotate/meta.yaml
@@ -2,3 +2,4 @@ name: vep annotate
 description: Annotate variant calls with VEP.
 authors:
   - Johannes Köster
+  - Felix Mölder

--- a/bio/vep/annotate/test/Snakefile
+++ b/bio/vep/annotate/test/Snakefile
@@ -3,12 +3,14 @@ rule annotate_variants:
         calls="variants.bcf",  # .vcf, .vcf.gz or .bcf
         cache="resources/vep/cache",  # can be omitted if fasta and gff are specified
         plugins="resources/vep/plugins",
-        LoFtool="resources/vep/plugins/LoFtool_scores.txt",
         # optionally add reference genome fasta
         # fasta="genome.fasta",
         # fai="genome.fasta.fai", # fasta index
         # gff="annotation.gff",
         # csi="annotation.gff.csi", # tabix index
+        # add mandatory aux-files required by some plugins if not present in the cache directory.
+        # aux files must be defined as following: "<plugin> = /path/to/file" where plugin must be in lowercase
+        # revel = path/to/revel_scores.tsv.gz
     output:
         calls="variants.annotated.bcf",  # .vcf, .vcf.gz or .bcf
         stats="variants.html",

--- a/bio/vep/annotate/test/Snakefile
+++ b/bio/vep/annotate/test/Snakefile
@@ -1,9 +1,9 @@
 rule annotate_variants:
     input:
         calls="variants.bcf",  # .vcf, .vcf.gz or .bcf
-        cache="resources/vep/cache", # can be omitted if fasta and gff are specified
+        cache="resources/vep/cache",  # can be omitted if fasta and gff are specified
         plugins="resources/vep/plugins",
-        LoFtool="resources/vep/plugins/LoFtool_scores.txt"
+        LoFtool="resources/vep/plugins/LoFtool_scores.txt",
         # optionally add reference genome fasta
         # fasta="genome.fasta",
         # fai="genome.fasta.fai", # fasta index
@@ -11,14 +11,14 @@ rule annotate_variants:
         # csi="annotation.gff.csi", # tabix index
     output:
         calls="variants.annotated.bcf",  # .vcf, .vcf.gz or .bcf
-        stats="variants.html"
+        stats="variants.html",
     params:
         # Pass a list of plugins to use, see https://www.ensembl.org/info/docs/tools/vep/script/vep_plugins.html
         # Plugin args can be added as well, e.g. via an entry "MyPlugin,1,FOO", see docs.
         plugins=["LoFtool"],
-        extra="--everything"  # optional: extra arguments
+        extra="--everything",  # optional: extra arguments
     log:
-        "logs/vep/annotate.log"
+        "logs/vep/annotate.log",
     threads: 4
     wrapper:
         "master/bio/vep/annotate"

--- a/bio/vep/annotate/test/Snakefile
+++ b/bio/vep/annotate/test/Snakefile
@@ -3,6 +3,7 @@ rule annotate_variants:
         calls="variants.bcf",  # .vcf, .vcf.gz or .bcf
         cache="resources/vep/cache", # can be omitted if fasta and gff are specified
         plugins="resources/vep/plugins",
+        LoFtool="resources/vep/plugins/LoFtool_scores.txt"
         # optionally add reference genome fasta
         # fasta="genome.fasta",
         # fai="genome.fasta.fai", # fasta index

--- a/bio/vep/annotate/test/Snakefile
+++ b/bio/vep/annotate/test/Snakefile
@@ -8,7 +8,7 @@ rule annotate_variants:
         # fai="genome.fasta.fai", # fasta index
         # gff="annotation.gff",
         # csi="annotation.gff.csi", # tabix index
-        # add mandatory aux-files required by some plugins if not present in the cache directory.
+        # add mandatory aux-files required by some plugins if not present in the VEP plugin directory specified above.
         # aux files must be defined as following: "<plugin> = /path/to/file" where plugin must be in lowercase
         # revel = path/to/revel_scores.tsv.gz
     output:

--- a/bio/vep/annotate/wrapper.py
+++ b/bio/vep/annotate/wrapper.py
@@ -3,6 +3,7 @@ __copyright__ = "Copyright 2020, Johannes Köster"
 __email__ = "johannes.koester@uni-due.de"
 __license__ = "MIT"
 
+import os
 from pathlib import Path
 from snakemake.shell import shell
 
@@ -22,16 +23,16 @@ fork = "--fork {}".format(snakemake.threads) if snakemake.threads > 1 else ""
 stats = snakemake.output.stats
 cache = snakemake.input.get("cache", "")
 plugins = snakemake.input.plugins
+plugin_aux_files = {"LoFtool": "LoFtool_scores.txt", "ExACpLI": "ExACpLI_values.txt"}
 
-load_plugins = " ".join(
-    map(
-        "--plugin {}".format,
-        [
-            ",".join([plugin, snakemake.input.get(plugin, "")])
-            for plugin in snakemake.params.plugins
-        ],
-    )
-)
+load_plugins = []
+for plugin in snakemake.params.plugins:
+    if plugin in plugin_aux_files.keys():
+        aux_path = os.path.join(cache, plugin_aux_files[plugin])
+        load_plugins.append(",".join([plugin, aux_path]))
+    else:
+        load_plugins.append(",".join([plugin, snakemake.input.get(plugin.lower(), "")]))
+load_plugins = " ".join(map("--plugin {}".format, load_plugins))
 
 if snakemake.output.calls.endswith(".vcf.gz"):
     fmt = "z"

--- a/bio/vep/annotate/wrapper.py
+++ b/bio/vep/annotate/wrapper.py
@@ -28,7 +28,7 @@ plugin_aux_files = {"LoFtool": "LoFtool_scores.txt", "ExACpLI": "ExACpLI_values.
 load_plugins = []
 for plugin in snakemake.params.plugins:
     if plugin in plugin_aux_files.keys():
-        aux_path = os.path.join(cache, plugin_aux_files[plugin])
+        aux_path = os.path.join(plugins, plugin_aux_files[plugin])
         load_plugins.append(",".join([plugin, aux_path]))
     else:
         load_plugins.append(",".join([plugin, snakemake.input.get(plugin.lower(), "")]))

--- a/bio/vep/annotate/wrapper.py
+++ b/bio/vep/annotate/wrapper.py
@@ -23,7 +23,15 @@ stats = snakemake.output.stats
 cache = snakemake.input.get("cache", "")
 plugins = snakemake.input.plugins
 
-load_plugins = " ".join(map("--plugin {}".format, snakemake.params.plugins))
+load_plugins = "".join(
+    map(
+        "--plugin {}".format,
+        [
+            ",".join([plugin, snakemake.input.get(plugin, "")])
+            for plugin in snakemake.params.plugins
+        ],
+    )
+)
 
 if snakemake.output.calls.endswith(".vcf.gz"):
     fmt = "z"

--- a/bio/vep/annotate/wrapper.py
+++ b/bio/vep/annotate/wrapper.py
@@ -23,7 +23,7 @@ stats = snakemake.output.stats
 cache = snakemake.input.get("cache", "")
 plugins = snakemake.input.plugins
 
-load_plugins = "".join(
+load_plugins = " ".join(
     map(
         "--plugin {}".format,
         [


### PR DESCRIPTION
### Description

As plugins may require aux-files these are now read from the input.
In case of aux files that are placed in the cache-directory by default the wrapper automatically adds these to the parameter string. 
In case no input with the plugin name exists or no default file is in the cache directory the wrapper assumes that no aux-file is required to apply the plugin.

### QC
<!-- Make sure that you can tick the boxes below. -->

For all wrappers added by this PR, I made sure that

* [x] there is a test case which covers any introduced changes,
* [x] `input:` and `output:` file paths in the resulting rule can be changed arbitrarily,
* [x] either the wrapper can only use a single core, or the example rule contains a `threads: x` statement with `x` being a reasonable default,
* [x] rule names in the test case are in [snake_case](https://en.wikipedia.org/wiki/Snake_case) and somehow tell what the rule is about or match the tools purpose or name (e.g., `map_reads` for a step that maps reads),
* [x] all `environment.yaml` specifications follow [the respective best practices](https://stackoverflow.com/a/64594513/2352071),
* [x] wherever possible, command line arguments are inferred and set automatically (e.g. based on file extensions in `input:` or `output:`),
* [x] all fields of the example rules in the `Snakefile`s and their entries are explained via comments (`input:`/`output:`/`params:` etc.),
* [x] `stderr` and/or `stdout` are logged correctly (`log:`), depending on the wrapped tool,
* [x] temporary files are either written to a unique hidden folder in the working directory, or (better) stored where the Python function `tempfile.gettempdir()` points to (see [here](https://docs.python.org/3/library/tempfile.html#tempfile.gettempdir); this also means that using any Python `tempfile` default behavior works),
* [x] the `meta.yaml` contains a link to the documentation of the respective tool or command,
* [x] `Snakefile`s pass the linting (`snakemake --lint`),
* [x] `Snakefile`s are formatted with [snakefmt](https://github.com/snakemake/snakefmt),
* [x] Python wrapper scripts are formatted with [black](https://black.readthedocs.io).
