### PR TITLE
Added support for automated thread specification

### DIFF
--- a/bio/gatk/haplotypecaller/test/Snakefile
+++ b/bio/gatk/haplotypecaller/test/Snakefile
@@ -2,17 +2,18 @@ rule haplotype_caller:
     input:
         # single or list of bam files
         bam="mapped/{sample}.bam",
-        ref="genome.fasta"
+        ref="genome.fasta",
         # known="dbsnp.vcf"  # optional
     output:
         gvcf="calls/{sample}.g.vcf",
-#	bam="{sample}.assemb_haplo.bam",
+    # 	bam="{sample}.assemb_haplo.bam",
     log:
-        "logs/gatk/haplotypecaller/{sample}.log"
+        "logs/gatk/haplotypecaller/{sample}.log",
     params:
         extra="",  # optional
-        java_opts="", # optional
+        java_opts="",  # optional
+    threads: 4
     resources:
-        mem_mb=1024
+        mem_mb=1024,
     wrapper:
         "master/bio/gatk/haplotypecaller"

--- a/bio/gatk/haplotypecaller/wrapper.py
+++ b/bio/gatk/haplotypecaller/wrapper.py
@@ -28,6 +28,7 @@ bams = list(map("-I {}".format, bams))
 log = snakemake.log_fmt_shell(stdout=True, stderr=True)
 shell(
     "gatk --java-options '{java_opts}' HaplotypeCaller {extra} "
+    "--native-pair-hmm-threads {snakemake.threads} "
     "-R {snakemake.input.ref} {bams} "
     "-ERC GVCF {bam_output} "
     "-O {snakemake.output.gvcf} {known} {log}"


### PR DESCRIPTION
### Description

Added support for automated thread specification.

### QC
<!-- Make sure that you can tick the boxes below. -->

For all wrappers added by this PR, I made sure that

* [x] there is a test case which covers any introduced changes,
* [x] `input:` and `output:` file paths in the resulting rule can be changed arbitrarily,
* [x] either the wrapper can only use a single core, or the example rule contains a `threads: x` statement with `x` being a reasonable default,
* [x] rule names in the test case are in [snake_case](https://en.wikipedia.org/wiki/Snake_case) and somehow tell what the rule is about or match the tools purpose or name (e.g., `map_reads` for a step that maps reads),
* [x] all `environment.yaml` specifications follow [the respective best practices](https://stackoverflow.com/a/64594513/2352071),
* [x] wherever possible, command line arguments are inferred and set automatically (e.g. based on file extensions in `input:` or `output:`),
* [x] all fields of the example rules in the `Snakefile`s and their entries are explained via comments (`input:`/`output:`/`params:` etc.),
* [x] `stderr` and/or `stdout` are logged correctly (`log:`), depending on the wrapped tool,
* [x] temporary files are either written to a unique hidden folder in the working directory, or (better) stored where the Python function `tempfile.gettempdir()` points to (see [here](https://docs.python.org/3/library/tempfile.html#tempfile.gettempdir); this also means that using any Python `tempfile` default behavior works),
* [x] the `meta.yaml` contains a link to the documentation of the respective tool or command,
* [x] `Snakefile`s pass the linting (`snakemake --lint`),
* [x] `Snakefile`s are formatted with [snakefmt](https://github.com/snakemake/snakefmt),
* [x] Python wrapper scripts are formatted with [black](https://black.readthedocs.io).
