### PR TITLE
fix: proper tempfile handling for STAR and improved documentation

### DIFF
--- a/bio/star/align/environment.yaml
+++ b/bio/star/align/environment.yaml
@@ -2,4 +2,4 @@ channels:
   - bioconda
   - conda-forge
 dependencies:
-  - star ==2.7.8a
+  - star ==2.7.9a

--- a/bio/star/align/meta.yaml
+++ b/bio/star/align/meta.yaml
@@ -3,3 +3,6 @@ description: Map reads with STAR.
 authors:
   - Johannes Köster
   - Tomás Di Domenico
+notes: |
+  * The `extra` param allows for additional program arguments.
+  * For more information see, https://github.com/alexdobin/STAR

--- a/bio/star/align/test/Snakefile
+++ b/bio/star/align/test/Snakefile
@@ -2,36 +2,37 @@ rule star_pe_multi:
     input:
         # use a list for multiple fastq files for one sample
         # usually technical replicates across lanes/flowcells
-        fq1 = ["reads/{sample}_R1.1.fastq", "reads/{sample}_R1.2.fastq"],
+        fq1=["reads/{sample}_R1.1.fastq", "reads/{sample}_R1.2.fastq"],
         # paired end reads needs to be ordered so each item in the two lists match
-        fq2 = ["reads/{sample}_R2.1.fastq", "reads/{sample}_R2.2.fastq"] #optional
+        fq2=["reads/{sample}_R2.1.fastq", "reads/{sample}_R2.2.fastq"],  #optional
     output:
         # see STAR manual for additional output files
-        "star/pe/{sample}/Aligned.out.sam"
+        "star/pe/{sample}/Aligned.out.sam",
     log:
-        "logs/star/pe/{sample}.log"
+        "logs/star/pe/{sample}.log",
     params:
         # path to STAR reference genome index
         index="index",
         # optional parameters
-        extra=""
+        extra="",
     threads: 8
     wrapper:
         "master/bio/star/align"
 
+
 rule star_se:
     input:
-        fq1 = "reads/{sample}_R1.1.fastq"
+        fq1="reads/{sample}_R1.1.fastq",
     output:
         # see STAR manual for additional output files
-        "star/{sample}/Aligned.out.sam"
+        "star/{sample}/Aligned.out.sam",
     log:
-        "logs/star/{sample}.log"
+        "logs/star/{sample}.log",
     params:
         # path to STAR reference genome index
         index="index",
         # optional parameters
-        extra=""
+        extra="",
     threads: 8
     wrapper:
         "master/bio/star/align"

--- a/bio/star/align/wrapper.py
+++ b/bio/star/align/wrapper.py
@@ -57,6 +57,6 @@ with tempfile.TemporaryDirectory() as tmpdir:
         "{readcmd} "
         "--outFileNamePrefix {outprefix} "
         "--outStd Log "
-        "--outTmpDir {tmpdir} "
+        "--outTmpDir {tmpdir}/STARtmp "
         "{log}"
     )

--- a/bio/star/align/wrapper.py
+++ b/bio/star/align/wrapper.py
@@ -5,6 +5,7 @@ __license__ = "MIT"
 
 
 import os
+import tempfile
 from snakemake.shell import shell
 
 extra = snakemake.params.get("extra", "")
@@ -46,14 +47,16 @@ outprefix = snakemake.output[0].split(bamprefix)[0]
 if outprefix == os.path.dirname(snakemake.output[0]):
     outprefix += "/"
 
-shell(
-    "STAR "
-    "{extra} "
-    "--runThreadN {snakemake.threads} "
-    "--genomeDir {snakemake.params.index} "
-    "--readFilesIn {input_str} "
-    "{readcmd} "
-    "--outFileNamePrefix {outprefix} "
-    "--outStd Log "
-    "{log}"
-)
+with tempfile.TemporaryDirectory() as tmpdir:
+    shell(
+        "STAR "
+        "{extra} "
+        "--runThreadN {snakemake.threads} "
+        "--genomeDir {snakemake.params.index} "
+        "--readFilesIn {input_str} "
+        "{readcmd} "
+        "--outFileNamePrefix {outprefix} "
+        "--outStd Log "
+        "--outTmpDir {tmpdir} "
+        "{log}"
+    )


### PR DESCRIPTION
### Description

<!--Add a description of your PR here-->

### QC
<!-- Make sure that you can tick the boxes below. -->

For all wrappers added by this PR, I made sure that

* [x] there is a test case which covers any introduced changes,
* [x] `input:` and `output:` file paths in the resulting rule can be changed arbitrarily,
* [x] either the wrapper can only use a single core, or the example rule contains a `threads: x` statement with `x` being a reasonable default,
* [x] rule names in the test case are in [snake_case](https://en.wikipedia.org/wiki/Snake_case) and somehow tell what the rule is about or match the tools purpose or name (e.g., `map_reads` for a step that maps reads),
* [x] all `environment.yaml` specifications follow [the respective best practices](https://stackoverflow.com/a/64594513/2352071),
* [x] wherever possible, command line arguments are inferred and set automatically (e.g. based on file extensions in `input:` or `output:`),
* [x] all fields of the example rules in the `Snakefile`s and their entries are explained via comments (`input:`/`output:`/`params:` etc.),
* [x] `stderr` and/or `stdout` are logged correctly (`log:`), depending on the wrapped tool,
* [x] temporary files are either written to a unique hidden folder in the working directory, or (better) stored where the Python function `tempfile.gettempdir()` points to (see [here](https://docs.python.org/3/library/tempfile.html#tempfile.gettempdir); this also means that using any Python `tempfile` default behavior works),
* [x] the `meta.yaml` contains a link to the documentation of the respective tool or command,
* [x] `Snakefile`s pass the linting (`snakemake --lint`),
* [x] `Snakefile`s are formatted with [snakefmt](https://github.com/snakemake/snakefmt),
* [x] Python wrapper scripts are formatted with [black](https://black.readthedocs.io).
