### PR TITLE
fasterq-dump: Implemented handling of memory

### DIFF
--- a/bio/sra-tools/fasterq-dump/wrapper.py
+++ b/bio/sra-tools/fasterq-dump/wrapper.py
@@ -23,7 +23,7 @@ for output in snakemake.output:
     if out_ext == ".gz":
         compress += f"pigz -p {snakemake.threads} {out_name}; "
     elif out_ext == ".bz2":
-        compress += f"pbzip2 -p {snakemake.threads} {out_name}; "
+        compress += f"pbzip2 -p{snakemake.threads} {out_name}; "
 
 
 mem = snakemake.resources.get("mem_gb", "")

--- a/bio/sra-tools/fasterq-dump/wrapper.py
+++ b/bio/sra-tools/fasterq-dump/wrapper.py
@@ -8,6 +8,20 @@ import tempfile
 from snakemake.shell import shell
 
 
+def get_mem(snakemake, out_unit="MB"):
+    # Store resources.mem in MB
+    mem_mb = snakemake.resources.get("mem_gb", 0) * 1024
+    if not mem_mb:
+        mem_mb = snakemake.resources.get("mem_mb", 0)
+
+    if out_unit == "MB":
+        return mem_mb
+    elif out_unit == "GB":
+        return mem_mb / 1024
+    else:
+        raise valueError("invalid out_unit, only MB and GB supported.")
+
+
 log = snakemake.log_fmt_shell(stdout=True, stderr=True)
 extra = snakemake.params.get("extra", "")
 
@@ -46,17 +60,3 @@ with tempfile.TemporaryDirectory() as tmp:
         "{compress}"
         ") {log}"
     )
-
-
-def get_mem(snakemake, out_unit="MB"):
-    # Store resources.mem in MB
-    mem_mb = snakemake.resources.get("mem_gb", 0) * 1024
-    if not mem_mb:
-        mem_mb = snakemake.resources.get("mem_mb", 0)
-
-    if out_unit == "MB":
-        return mem_mb
-    elif out_unit == "GB":
-        return mem_mb / 1024
-    else:
-        raise valueError("invalid out_unit, only MB and GB supported.")

--- a/bio/sra-tools/fasterq-dump/wrapper.py
+++ b/bio/sra-tools/fasterq-dump/wrapper.py
@@ -12,28 +12,32 @@ log = snakemake.log_fmt_shell(stdout=True, stderr=True)
 extra = snakemake.params.get("extra", "")
 
 
+# Parse memory
+mem = ""
+mem_mb = get_mem(snakemake, "MB")
+
+
+# Outdir
 outdir = os.path.dirname(snakemake.output[0])
 if outdir:
     outdir = f"--outdir {outdir}"
 
 
+# Output compression
 compress = ""
+if mem_mb:
+    mem = f"-m{mem_mb}"
+
 for output in snakemake.output:
     out_name, out_ext = os.path.splitext(output)
     if out_ext == ".gz":
         compress += f"pigz -p {snakemake.threads} {out_name}; "
     elif out_ext == ".bz2":
-        compress += f"pbzip2 -p{snakemake.threads} {out_name}; "
+        compress += f"pbzip2 -p{snakemake.threads} {mem} {out_name}; "
 
 
-mem = snakemake.resources.get("mem_gb", "")
-if mem:
-    mem = f"--mem {mem}G"
-else:
-    mem = snakemake.resources.get("mem_mb", "")
-    if mem:
-        mem = f"--mem {mem}M"
-
+if mem_mb:
+    mem = f"--mem_mb {mem_mb}M"
 
 with tempfile.TemporaryDirectory() as tmp:
     shell(
@@ -42,3 +46,17 @@ with tempfile.TemporaryDirectory() as tmp:
         "{compress}"
         ") {log}"
     )
+
+
+def get_mem(snakemake, out_unit="MB"):
+    # Store resources.mem in MB
+    mem_mb = snakemake.resources.get("mem_gb", 0) * 1024
+    if not mem_mb:
+        mem_mb = snakemake.resources.get("mem_mb", 0)
+
+    if out_unit == "MB":
+        return mem_mb
+    elif out_unit == "GB":
+        return mem_mb / 1024
+    else:
+        raise valueError("invalid out_unit, only MB and GB supported.")

--- a/bio/sra-tools/fasterq-dump/wrapper.py
+++ b/bio/sra-tools/fasterq-dump/wrapper.py
@@ -23,12 +23,21 @@ for output in snakemake.output:
     if out_ext == ".gz":
         compress += f"pigz -p {snakemake.threads} {out_name}; "
     elif out_ext == ".bz2":
-        compress += f"pbzip2 -p{snakemake.threads} {out_name}; "
+        compress += f"pbzip2 -p {snakemake.threads} {out_name}; "
+
+
+mem = snakemake.resources.get("mem_gb", "")
+if mem:
+    mem = f"--mem {mem}G"
+else:
+    mem = snakemake.resources.get("mem_mb", "")
+    if mem:
+        mem = f"--mem {mem}M"
 
 
 with tempfile.TemporaryDirectory() as tmp:
     shell(
-        "(fasterq-dump --temp {tmp} --threads {snakemake.threads} "
+        "(fasterq-dump --temp {tmp} --threads {snakemake.threads} {mem} "
         "{extra} {outdir} {snakemake.wildcards.accession}; "
         "{compress}"
         ") {log}"

--- a/bio/sra-tools/fasterq-dump/wrapper.py
+++ b/bio/sra-tools/fasterq-dump/wrapper.py
@@ -51,7 +51,7 @@ for output in snakemake.output:
 
 
 if mem_mb:
-    mem = f"--mem_mb {mem_mb}M"
+    mem = f"--mem {mem_mb}M"
 
 with tempfile.TemporaryDirectory() as tmp:
     shell(


### PR DESCRIPTION
### Description

<!--Add a description of your PR here-->

### QC
<!-- Make sure that you can tick the boxes below. -->

For all wrappers added by this PR, I made sure that

* [x] there is a test case which covers any introduced changes,
* [x] `input:` and `output:` file paths in the resulting rule can be changed arbitrarily,
* [x] either the wrapper can only use a single core, or the example rule contains a `threads: x` statement with `x` being a reasonable default,
* [x] rule names in the test case are in [snake_case](https://en.wikipedia.org/wiki/Snake_case) and somehow tell what the rule is about or match the tools purpose or name (e.g., `map_reads` for a step that maps reads),
* [x] all `environment.yaml` specifications follow [the respective best practices](https://stackoverflow.com/a/64594513/2352071),
* [x] wherever possible, command line arguments are inferred and set automatically (e.g. based on file extensions in `input:` or `output:`),
* [x] all fields of the example rules in the `Snakefile`s and their entries are explained via comments (`input:`/`output:`/`params:` etc.),
* [x] `stderr` and/or `stdout` are logged correctly (`log:`), depending on the wrapped tool,
* [x] temporary files are either written to a unique hidden folder in the working directory, or (better) stored where the Python function `tempfile.gettempdir()` points to (see [here](https://docs.python.org/3/library/tempfile.html#tempfile.gettempdir); this also means that using any Python `tempfile` default behavior works),
* [x] the `meta.yaml` contains a link to the documentation of the respective tool or command,
* [x] `Snakefile`s pass the linting (`snakemake --lint`),
* [x] `Snakefile`s are formatted with [snakefmt](https://github.com/snakemake/snakefmt),
* [x] Python wrapper scripts are formatted with [black](https://black.readthedocs.io).
