### PR TITLE
fix: fix passing of extra args in vardict wrapper

### DIFF
--- a/bio/vardict/wrapper.py
+++ b/bio/vardict/wrapper.py
@@ -36,6 +36,7 @@ else:
 shell(
     "vardict-java -G {reference} "
     "-f {af_th} "
+    " {extra} "
     "-th {snakemake.threads} "
     "{bed_columns} "
     "-N '{name}' "


### PR DESCRIPTION
fix: add missing extra to shell

