### PR TITLE
fix: correct log file handling for all bcftools wrappers

### DIFF
--- a/bio/bcftools/call/test/Snakefile
+++ b/bio/bcftools/call/test/Snakefile
@@ -4,7 +4,7 @@ rule bcftools_call:
     output:
         calls="{sample}.calls.bcf",
     params:
-        caller="-m", # valid options include -c/--consensus-caller or -m/--multiallelic-caller
+        caller="-m",  # valid options include -c/--consensus-caller or -m/--multiallelic-caller
         options="--ploidy 1 --prior 0.001",
     log:
         "logs/bcftools_call/{sample}.log",

--- a/bio/bcftools/call/wrapper.py
+++ b/bio/bcftools/call/wrapper.py
@@ -22,7 +22,9 @@ if caller_opt.strip() not in valid_caller_opts:
 
 options = snakemake.params.get("options", "")
 
+log = snakemake.log_fmt_shell(stdout=False, stderr=True)
+
 shell(
     "bcftools call {options} {caller_opt} --threads {snakemake.threads} "
-    "-o {snakemake.output.calls} {snakemake.input.pileup} 2> {snakemake.log}"
+    "-o {snakemake.output.calls} {snakemake.input.pileup} {log}"
 )

--- a/bio/bcftools/concat/test/Snakefile
+++ b/bio/bcftools/concat/test/Snakefile
@@ -4,7 +4,7 @@ rule bcftools_concat:
     output:
         "all.bcf",
     log:
-        "logs/all.log",
+        "logs/bcftools-concat.log",
     params:
         uncompressed_bcf=False,
         extra="",  # optional parameters for bcftools concat (except -o)

--- a/bio/bcftools/index/test/Snakefile
+++ b/bio/bcftools/index/test/Snakefile
@@ -1,11 +1,11 @@
 rule bcftools_index:
     input:
-        "a.bcf"
+        "a.bcf",
     output:
-        "a.bcf.csi"
+        "a.bcf.csi",
     log:
-        "logs/bcftools-index.log"
+        "logs/bcftools-index.log",
     params:
-        extra=""  # optional parameters for bcftools index
+        extra="",  # optional parameters for bcftools index
     wrapper:
         "master/bio/bcftools/index"

--- a/bio/bcftools/index/test/Snakefile
+++ b/bio/bcftools/index/test/Snakefile
@@ -3,6 +3,8 @@ rule bcftools_index:
         "a.bcf"
     output:
         "a.bcf.csi"
+    log:
+        "logs/bcftools-index.log"
     params:
         extra=""  # optional parameters for bcftools index
     wrapper:

--- a/bio/bcftools/index/wrapper.py
+++ b/bio/bcftools/index/wrapper.py
@@ -9,4 +9,6 @@ from snakemake.shell import shell
 ## Extract arguments
 extra = snakemake.params.get("extra", "")
 
-shell("bcftools index" " {extra}" " {snakemake.input[0]}")
+log = snakemake.log_fmt_shell(stdout=False, stderr=True)
+
+shell("bcftools index {extra} {snakemake.input[0]} {log}")

--- a/bio/bcftools/merge/test/Snakefile
+++ b/bio/bcftools/merge/test/Snakefile
@@ -3,6 +3,8 @@ rule bcftools_merge:
         calls=["a.bcf", "b.bcf"]
     output:
         "all.bcf"
+    log:
+        "logs/bcftools-merge.log"
     params:
         ""  # optional parameters for bcftools concat (except -o)
     wrapper:

--- a/bio/bcftools/merge/test/Snakefile
+++ b/bio/bcftools/merge/test/Snakefile
@@ -1,11 +1,11 @@
 rule bcftools_merge:
     input:
-        calls=["a.bcf", "b.bcf"]
+        calls=["a.bcf", "b.bcf"],
     output:
-        "all.bcf"
+        "all.bcf",
     log:
-        "logs/bcftools-merge.log"
+        "logs/bcftools-merge.log",
     params:
-        ""  # optional parameters for bcftools concat (except -o)
+        "",  # optional parameters for bcftools concat (except -o)
     wrapper:
         "master/bio/bcftools/merge"

--- a/bio/bcftools/merge/wrapper.py
+++ b/bio/bcftools/merge/wrapper.py
@@ -6,7 +6,9 @@ __license__ = "MIT"
 
 from snakemake.shell import shell
 
+log = snakemake.log_fmt_shell(stdout=False, stderr=True)
+
 shell(
     "bcftools merge {snakemake.params} -o {snakemake.output[0]} "
-    "{snakemake.input.calls}"
+    "{snakemake.input.calls} {log}"
 )

--- a/bio/bcftools/mpileup/test/Snakefile
+++ b/bio/bcftools/mpileup/test/Snakefile
@@ -1,7 +1,7 @@
 rule bcftools_mpileup:
     input:
         index="genome.fasta.fai",
-        ref="genome.fasta", # this can be left out if --no-reference is in options
+        ref="genome.fasta",  # this can be left out if --no-reference is in options
         alignments="mapped/{sample}.bam",
     output:
         pileup="pileups/{sample}.pileup.bcf",

--- a/bio/bcftools/mpileup/wrapper.py
+++ b/bio/bcftools/mpileup/wrapper.py
@@ -6,11 +6,11 @@ __license__ = "MIT"
 
 from snakemake.shell import shell
 
-
 class MissingReferenceError(Exception):
     pass
 
 
+log = snakemake.log_fmt_shell(stdout=False, stderr=True)
 options = snakemake.params.get("options", "")
 
 # determine if a fasta reference is provided or not and add to options
@@ -26,5 +26,5 @@ if "--no-reference" not in options:
 shell(
     "bcftools mpileup {options} --threads {snakemake.threads} "
     "--output {snakemake.output.pileup} "
-    "{snakemake.input.alignments} 2> {snakemake.log}"
+    "{snakemake.input.alignments} {log}"
 )

--- a/bio/bcftools/mpileup/wrapper.py
+++ b/bio/bcftools/mpileup/wrapper.py
@@ -6,6 +6,7 @@ __license__ = "MIT"
 
 from snakemake.shell import shell
 
+
 class MissingReferenceError(Exception):
     pass
 

--- a/bio/bcftools/norm/test/Snakefile
+++ b/bio/bcftools/norm/test/Snakefile
@@ -3,6 +3,8 @@ rule norm_vcf:
         "{prefix}.vcf"
     output:
         "{prefix}.vcf"
+    log:
+        "logs/bcftools-norm/{prefix}.log"
     params:
         ""  # optional parameters for bcftools norm (except -o)
     wrapper:

--- a/bio/bcftools/norm/test/Snakefile
+++ b/bio/bcftools/norm/test/Snakefile
@@ -1,11 +1,11 @@
 rule norm_vcf:
     input:
-        "{prefix}.vcf"
+        "{prefix}.vcf",
     output:
-        "{prefix}.vcf"
+        "{prefix}.vcf",
     log:
-        "logs/bcftools-norm/{prefix}.log"
+        "logs/bcftools-norm/{prefix}.log",
     params:
-        ""  # optional parameters for bcftools norm (except -o)
+        "",  # optional parameters for bcftools norm (except -o)
     wrapper:
         "master/bio/bcftools/norm"

--- a/bio/bcftools/norm/wrapper.py
+++ b/bio/bcftools/norm/wrapper.py
@@ -5,8 +5,9 @@ __license__ = "MIT"
 
 
 from snakemake.shell import shell
+log = snakemake.log_fmt_shell(stdout=False, stderr=True)
 
 
 shell(
-    "bcftools norm {snakemake.params} {snakemake.input[0]} " "-o {snakemake.output[0]}"
+    "bcftools norm {snakemake.params} {snakemake.input[0]} -o {snakemake.output[0]} {log}"
 )

--- a/bio/bcftools/norm/wrapper.py
+++ b/bio/bcftools/norm/wrapper.py
@@ -5,6 +5,7 @@ __license__ = "MIT"
 
 
 from snakemake.shell import shell
+
 log = snakemake.log_fmt_shell(stdout=False, stderr=True)
 
 

--- a/bio/bcftools/reheader/test/Snakefile
+++ b/bio/bcftools/reheader/test/Snakefile
@@ -4,13 +4,13 @@ rule bcftools_reheader:
         ## new header, can be omitted if "samples" is set
         header="header.txt",
         ## file containing new sample names, can be omitted if "header" is set
-        samples="samples.tsv"
+        samples="samples.tsv",
     output:
-        "a.reheader.bcf"
+        "a.reheader.bcf",
     log:
-        "logs/bcftools-reheader.log"
+        "logs/bcftools-reheader.log",
     params:
         extra="",  # optional parameters for bcftools reheader
-        view_extra="-O b"  # add output format for internal bcftools view call
+        view_extra="-O b",  # add output format for internal bcftools view call
     wrapper:
         "master/bio/bcftools/reheader"

--- a/bio/bcftools/reheader/test/Snakefile
+++ b/bio/bcftools/reheader/test/Snakefile
@@ -7,6 +7,8 @@ rule bcftools_reheader:
         samples="samples.tsv"
     output:
         "a.reheader.bcf"
+    log:
+        "logs/bcftools-reheader.log"
     params:
         extra="",  # optional parameters for bcftools reheader
         view_extra="-O b"  # add output format for internal bcftools view call

--- a/bio/bcftools/reheader/wrapper.py
+++ b/bio/bcftools/reheader/wrapper.py
@@ -22,6 +22,8 @@ else:
 extra = snakemake.params.get("extra", "")
 view_extra = snakemake.params.get("view_extra", "")
 
+log = snakemake.log_fmt_shell(stdout=False, stderr=True)
+
 shell(
     "bcftools reheader "
     "{extra} "
@@ -31,4 +33,5 @@ shell(
     "| bcftools view "
     "{view_extra} "
     "> {snakemake.output}"
+    "{log}"
 )

--- a/bio/bcftools/sort/test/Snakefile
+++ b/bio/bcftools/sort/test/Snakefile
@@ -1,17 +1,17 @@
 rule bcftools_sort:
     input:
-        "{sample}.bcf"
+        "{sample}.bcf",
     output:
-        "{sample}.sorted.bcf"
+        "{sample}.sorted.bcf",
     log:
-        "logs/bcftools/sort/{sample}.log"
+        "logs/bcftools/sort/{sample}.log",
     params:
-        tmp_dir = "`mktemp -d`",
+        tmp_dir="`mktemp -d`",
         # Set to True, in case you want uncompressed BCF output
-        uncompressed_bcf = False,
+        uncompressed_bcf=False,
         # Extra arguments
-        extras = ""
+        extras="",
     resources:
-        mem_mb = 8000
+        mem_mb=8000,
     wrapper:
         "master/bio/bcftools/sort"

--- a/utils/nextflow/test/Snakefile
+++ b/utils/nextflow/test/Snakefile
@@ -7,10 +7,10 @@ rule all:  # [hide]
 rule get_genome:  # [hide]
     output:  # [hide]
         "data/genome.fasta",  # [hide]
-    conda:
-        "envs/curl.yaml"
-    log:
-        "logs/get-genome.log"
+    conda:  # [hide]
+        "envs/curl.yaml"  # [hide]
+    log:  # [hide]
+        "logs/get-genome.log"  # [hide]
     shell:  # [hide]
         "curl -L https://raw.githubusercontent.com/nf-core/test-datasets/atacseq/reference/genome.fa > {output} 2> {log}"  # [hide]
 
@@ -18,10 +18,10 @@ rule get_genome:  # [hide]
 rule get_annotation:  # [hide]
     output:  # [hide]
         "data/genome.gtf",  # [hide]
-    conda:
-        "envs/curl.yaml"
-    log:
-        "logs/get-annotation.log"
+    conda:  # [hide]
+        "envs/curl.yaml"  # [hide]
+    log:  # [hide]
+        "logs/get-annotation.log"  # [hide]
     shell:  # [hide]
         "curl -L https://raw.githubusercontent.com/nf-core/test-datasets/atacseq/reference/genes.gtf > {output} 2> {log}"  # [hide]
 
@@ -29,10 +29,10 @@ rule get_annotation:  # [hide]
 rule get_design:  # [hide]
     output:  # [hide]
         "design.csv",  # [hide]
-    conda:
-        "envs/curl.yaml"
-    log:
-        "logs/get-design.log"
+    conda:  # [hide]
+        "envs/curl.yaml"  # [hide]
+    log:  # [hide]
+        "logs/get-design.log"  # [hide]
     shell:  # [hide]
         "curl -L https://raw.githubusercontent.com/nf-core/test-datasets/chipseq/design.csv > {output} 2> {log}"  # [hide]
 


### PR DESCRIPTION
<!-- Ensure that the PR title follows conventional commit style (<type>: <description>)-->
<!-- Possible types are here: https://github.com/commitizen/conventional-commit-types/blob/master/index.json -->

### Description

<!-- Add a description of your PR here-->

### QC
<!-- Make sure that you can tick the boxes below. -->

For all wrappers added by this PR, I made sure that

* [x] there is a test case which covers any introduced changes,
* [x] `input:` and `output:` file paths in the resulting rule can be changed arbitrarily,
* [x] either the wrapper can only use a single core, or the example rule contains a `threads: x` statement with `x` being a reasonable default,
* [x] rule names in the test case are in [snake_case](https://en.wikipedia.org/wiki/Snake_case) and somehow tell what the rule is about or match the tools purpose or name (e.g., `map_reads` for a step that maps reads),
* [x] all `environment.yaml` specifications follow [the respective best practices](https://stackoverflow.com/a/64594513/2352071),
* [x] wherever possible, command line arguments are inferred and set automatically (e.g. based on file extensions in `input:` or `output:`),
* [x] all fields of the example rules in the `Snakefile`s and their entries are explained via comments (`input:`/`output:`/`params:` etc.),
* [x] `stderr` and/or `stdout` are logged correctly (`log:`), depending on the wrapped tool,
* [x] temporary files are either written to a unique hidden folder in the working directory, or (better) stored where the Python function `tempfile.gettempdir()` points to (see [here](https://docs.python.org/3/library/tempfile.html#tempfile.gettempdir); this also means that using any Python `tempfile` default behavior works),
* [x] the `meta.yaml` contains a link to the documentation of the respective tool or command,
* [x] `Snakefile`s pass the linting (`snakemake --lint`),
* [x] `Snakefile`s are formatted with [snakefmt](https://github.com/snakemake/snakefmt),
* [x] Python wrapper scripts are formatted with [black](https://black.readthedocs.io).
