### PR TITLE
feat: added shards temp folder

### DIFF
--- a/bio/gatk/applybqsrspark/wrapper.py
+++ b/bio/gatk/applybqsrspark/wrapper.py
@@ -17,20 +17,18 @@ spark_master = snakemake.params.get(
 spark_extra = snakemake.params.get("spark_extra", "")
 java_opts = get_java_opts(snakemake)
 
-tmpdir = tempfile.gettempdir()
-# This folder must not exist; it is created by GATK
-tmpdir_shards = Path(tmpdir) / "applybqsrspark.shards_{:06d}".format(
-    random.randrange(10**6)
-)
-
 log = snakemake.log_fmt_shell(stdout=True, stderr=True)
 
-shell(
-    "gatk --java-options '{java_opts}' ApplyBQSRSpark {extra} "
-    "--reference {snakemake.input.ref} --input {snakemake.input.bam} "
-    "--bqsr-recal-file {snakemake.input.recal_table} "
-    "--tmp-dir {tmpdir} --output-shard-tmp-dir {tmpdir_shards} "
-    "--output {snakemake.output.bam} "
-    "-- --spark-runner {spark_runner} --spark-master {spark_master} {spark_extra} "
-    "{log}"
-)
+with tempfile.TemporaryDirectory() as tmpdir:
+    # This folder must not exist; it is created by GATK
+    tmpdir_shards = Path(tmpdir) / "shards_{:06d}".format(random.randrange(10 ** 6))
+
+    shell(
+        "gatk --java-options '{java_opts}' ApplyBQSRSpark {extra} "
+        "--reference {snakemake.input.ref} --input {snakemake.input.bam} "
+        "--bqsr-recal-file {snakemake.input.recal_table} "
+        "--tmp-dir {tmpdir} --output-shard-tmp-dir {tmpdir_shards} "
+        "--output {snakemake.output.bam} "
+        "-- --spark-runner {spark_runner} --spark-master {spark_master} {spark_extra} "
+        "{log}"
+    )


### PR DESCRIPTION
<!-- Ensure that the PR title follows conventional commit style (<type>: <description>)-->
<!-- Possible types are here: https://github.com/commitizen/conventional-commit-types/blob/master/index.json -->

### Description

<!-- Add a description of your PR here-->
Added temp dir to `--output-shard-tmp-dir` in ApplyBQSRSpark.

### QC
<!-- Make sure that you can tick the boxes below. -->

For all wrappers added by this PR, I made sure that

* [x] there is a test case which covers any introduced changes,
* [x] `input:` and `output:` file paths in the resulting rule can be changed arbitrarily,
* [x] either the wrapper can only use a single core, or the example rule contains a `threads: x` statement with `x` being a reasonable default,
* [x] rule names in the test case are in [snake_case](https://en.wikipedia.org/wiki/Snake_case) and somehow tell what the rule is about or match the tools purpose or name (e.g., `map_reads` for a step that maps reads),
* [x] all `environment.yaml` specifications follow [the respective best practices](https://stackoverflow.com/a/64594513/2352071),
* [x] wherever possible, command line arguments are inferred and set automatically (e.g. based on file extensions in `input:` or `output:`),
* [x] all fields of the example rules in the `Snakefile`s and their entries are explained via comments (`input:`/`output:`/`params:` etc.),
* [x] `stderr` and/or `stdout` are logged correctly (`log:`), depending on the wrapped tool,
* [x] temporary files are either written to a unique hidden folder in the working directory, or (better) stored where the Python function `tempfile.gettempdir()` points to (see [here](https://docs.python.org/3/library/tempfile.html#tempfile.gettempdir); this also means that using any Python `tempfile` default behavior works),
* [x] the `meta.yaml` contains a link to the documentation of the respective tool or command,
* [x] `Snakefile`s pass the linting (`snakemake --lint`),
* [x] `Snakefile`s are formatted with [snakefmt](https://github.com/snakemake/snakefmt),
* [x] Python wrapper scripts are formatted with [black](https://black.readthedocs.io).
