### PR TITLE
feat: parse mem for samtools sort

### DIFF
--- a/bio/samtools/fastq/separate/environment.yaml
+++ b/bio/samtools/fastq/separate/environment.yaml
@@ -3,3 +3,4 @@ channels:
   - bioconda
 dependencies:
   - samtools =1.14
+  - snakemake-wrapper-utils =0.3

--- a/bio/samtools/fastq/separate/wrapper.py
+++ b/bio/samtools/fastq/separate/wrapper.py
@@ -6,6 +6,7 @@ __license__ = "MIT"
 
 import os
 import tempfile
+from pathlib import Path
 from snakemake.shell import shell
 from snakemake_wrapper_utils.snakemake import get_mem
 

--- a/bio/samtools/fastq/separate/wrapper.py
+++ b/bio/samtools/fastq/separate/wrapper.py
@@ -22,7 +22,7 @@ log = snakemake.log_fmt_shell(stdout=True, stderr=True)
 threads = 0 if snakemake.threads <= 2 else snakemake.threads - 2
 
 mem = get_mem(snakemake, "MiB")
-mem = "-m {}M".format(mem / threads) if mem and threads else ""
+mem = "-m {0:.0g}M".format(mem / threads) if mem and threads else ""
 
 with tempfile.TemporaryDirectory() as tmpdir:
     tmp_prefix = Path(tmpdir) / "samtools_fastq.sort_"

--- a/bio/samtools/fastq/separate/wrapper.py
+++ b/bio/samtools/fastq/separate/wrapper.py
@@ -13,8 +13,6 @@ params_sort = snakemake.params.get("sort", "")
 params_fastq = snakemake.params.get("fastq", "")
 log = snakemake.log_fmt_shell(stdout=True, stderr=True)
 
-prefix = os.path.splitext(snakemake.output[0])[0]
-
 # Samtools takes additional threads through its option -@
 # One thread is used bu Samtools sort
 # One thread is used by Samtools fastq
@@ -26,7 +24,7 @@ mem = get_mem(snakemake, "MiB")
 mem = "-m {}M".format(mem / threads) if mem and threads else ""
 
 with tempfile.TemporaryDirectory() as tmpdir:
-    tmp_prefix = Path(tmpdir) / "samtools_sort."
+    tmp_prefix = Path(tmpdir) / "samtools_fastq.sort_"
 
     shell(
         "(samtools sort -n"

--- a/bio/samtools/fastq/separate/wrapper.py
+++ b/bio/samtools/fastq/separate/wrapper.py
@@ -22,7 +22,7 @@ log = snakemake.log_fmt_shell(stdout=True, stderr=True)
 threads = 0 if snakemake.threads <= 2 else snakemake.threads - 2
 
 mem = get_mem(snakemake, "MiB")
-mem = "-m {0:.0g}M".format(mem / threads) if mem and threads else ""
+mem = "-m {0:.0f}M".format(mem / threads) if mem and threads else ""
 
 with tempfile.TemporaryDirectory() as tmpdir:
     tmp_prefix = Path(tmpdir) / "samtools_fastq.sort_"

--- a/bio/samtools/fastq/separate/wrapper.py
+++ b/bio/samtools/fastq/separate/wrapper.py
@@ -21,11 +21,12 @@ prefix = os.path.splitext(snakemake.output[0])[0]
 # before allowing additional threads through samtools sort -@
 threads = "" if snakemake.threads <= 2 else " -@ {} ".format(snakemake.threads - 2)
 
-with tempfile.NamedTemporaryFile() as tmpfile:
+with tempfile.TemporaryDirectory() as tmpdir:
+    tmp_prefix = Path(tmpdir) / "samtools_sort_{:06d}".format(random.randrange(10 ** 6))
     shell(
         "(samtools sort -n "
         " {threads} "
-        " -T {tmpfile.name} "
+        " -T {tmp_prefix} "
         " {params_sort} "
         " {snakemake.input[0]} | "
         "samtools fastq "

--- a/bio/samtools/fastq/separate/wrapper.py
+++ b/bio/samtools/fastq/separate/wrapper.py
@@ -19,7 +19,7 @@ log = snakemake.log_fmt_shell(stdout=True, stderr=True)
 # One thread is used by Samtools fastq
 # So snakemake.threads has to take them into account
 # before allowing additional threads through samtools sort -@
-threads = "" if snakemake.threads <= 2 else "--threads {}".format(snakemake.threads - 2)
+threads = 0 if snakemake.threads <= 2 else snakemake.threads - 2
 
 mem = get_mem(snakemake, "MiB")
 mem = "-m {}M".format(mem / threads) if mem and threads else ""
@@ -29,7 +29,7 @@ with tempfile.TemporaryDirectory() as tmpdir:
 
     shell(
         "(samtools sort -n"
-        " {threads}"
+        " --threads {threads}"
         " {mem}"
         " -T {tmp_prefix}"
         " {params_sort}"

--- a/bio/samtools/fastq/separate/wrapper.py
+++ b/bio/samtools/fastq/separate/wrapper.py
@@ -23,10 +23,10 @@ prefix = os.path.splitext(snakemake.output[0])[0]
 threads = "" if snakemake.threads <= 2 else "--threads {}".format(snakemake.threads - 2)
 
 mem = get_mem(snakemake, "MiB")
-mem = "-m {}M".format(mem / threads) if mem else ""
+mem = "-m {}M".format(mem / threads) if mem and threads else ""
 
 with tempfile.TemporaryDirectory() as tmpdir:
-    tmp_prefix = Path(tmpdir) / "samtools_sort_{:06d}".format(random.randrange(10 ** 6))
+    tmp_prefix = Path(tmpdir) / "samtools_sort."
 
     shell(
         "(samtools sort -n"


### PR DESCRIPTION
<!-- Ensure that the PR title follows conventional commit style (<type>: <description>)-->
<!-- Possible types are here: https://github.com/commitizen/conventional-commit-types/blob/master/index.json -->

### Description

Use new `get_mem` function to provide `samtools sort` with memory per-thread.

### QC
<!-- Make sure that you can tick the boxes below. -->

For all wrappers added by this PR, I made sure that

* [x] there is a test case which covers any introduced changes,
* [x] `input:` and `output:` file paths in the resulting rule can be changed arbitrarily,
* [x] either the wrapper can only use a single core, or the example rule contains a `threads: x` statement with `x` being a reasonable default,
* [x] rule names in the test case are in [snake_case](https://en.wikipedia.org/wiki/Snake_case) and somehow tell what the rule is about or match the tools purpose or name (e.g., `map_reads` for a step that maps reads),
* [x] all `environment.yaml` specifications follow [the respective best practices](https://stackoverflow.com/a/64594513/2352071),
* [x] wherever possible, command line arguments are inferred and set automatically (e.g. based on file extensions in `input:` or `output:`),
* [x] all fields of the example rules in the `Snakefile`s and their entries are explained via comments (`input:`/`output:`/`params:` etc.),
* [x] `stderr` and/or `stdout` are logged correctly (`log:`), depending on the wrapped tool,
* [x] temporary files are either written to a unique hidden folder in the working directory, or (better) stored where the Python function `tempfile.gettempdir()` points to (see [here](https://docs.python.org/3/library/tempfile.html#tempfile.gettempdir); this also means that using any Python `tempfile` default behavior works),
* [x] the `meta.yaml` contains a link to the documentation of the respective tool or command,
* [x] `Snakefile`s pass the linting (`snakemake --lint`),
* [x] `Snakefile`s are formatted with [snakefmt](https://github.com/snakemake/snakefmt),
* [x] Python wrapper scripts are formatted with [black](https://black.readthedocs.io).
