### PR TITLE
feat: automatically set temp dir tempfile

### DIFF
--- a/bio/biobambam2/bamsormadup/test/Snakefile
+++ b/bio/biobambam2/bamsormadup/test/Snakefile
@@ -1,15 +1,15 @@
 rule mark_duplicates:
     input:
-        "mapped/{sample}.bam"
+        "mapped/{sample}.bam",
     output:
         bam="dedup/{sample}.bam",
         index="dedup/{sample}.bai",
         metrics="dedup/{sample}.metrics.txt",
     log:
-        "logs/{sample}.log"
+        "logs/{sample}.log",
     params:
-        extra="SO=coordinate"
+        extra="SO=coordinate",
     resources:
-        mem_mb=1024
+        mem_mb=1024,
     wrapper:
         "master/bio/biobambam2/bamsormadup"

--- a/bio/biobambam2/bamsormadup/wrapper.py
+++ b/bio/biobambam2/bamsormadup/wrapper.py
@@ -4,6 +4,8 @@ __license__ = "MIT"
 
 
 import os
+import random
+import tempfile
 from snakemake.shell import shell
 
 
@@ -28,6 +30,18 @@ if metrics:
     metrics = f"M={metrics}"
 
 
-shell(
-    "bamsormadup threads={snakemake.threads} inputformat={in_format} outputformat={out_format} {index} {metrics} {extra} < {snakemake.input[0]} > {snakemake.output[0]} {log}"
-)
+with tempfile.TemporaryDirectory() as tmpdir:
+    # This folder must not exist; it is created by BamSorMaDup
+    tmpdir_bamsormadup = Path(tmpdir) / "bamsormadup_{:06d}".format(
+        random.randrange(10 ** 6)
+    )
+
+    shell(
+        "bamsormadup threads={snakemake.threads}"
+        " inputformat={in_format}"
+        " tmpfile={tmpdir_bamsormadup}"
+        " outputformat={out_format}"
+        " {index} {metrics} {extra}"
+        " < {snakemake.input[0]} > {snakemake.output[0]}"
+        " {log}"
+    )


### PR DESCRIPTION
<!-- Ensure that the PR title follows conventional commit style (<type>: <description>)-->
<!-- Possible types are here: https://github.com/commitizen/conventional-commit-types/blob/master/index.json -->

### Description

Automatically set temp dir through `tempfile`.

### QC
<!-- Make sure that you can tick the boxes below. -->

For all wrappers added by this PR, I made sure that

* [x] there is a test case which covers any introduced changes,
* [x] `input:` and `output:` file paths in the resulting rule can be changed arbitrarily,
* [x] either the wrapper can only use a single core, or the example rule contains a `threads: x` statement with `x` being a reasonable default,
* [x] rule names in the test case are in [snake_case](https://en.wikipedia.org/wiki/Snake_case) and somehow tell what the rule is about or match the tools purpose or name (e.g., `map_reads` for a step that maps reads),
* [x] all `environment.yaml` specifications follow [the respective best practices](https://stackoverflow.com/a/64594513/2352071),
* [x] wherever possible, command line arguments are inferred and set automatically (e.g. based on file extensions in `input:` or `output:`),
* [x] all fields of the example rules in the `Snakefile`s and their entries are explained via comments (`input:`/`output:`/`params:` etc.),
* [x] `stderr` and/or `stdout` are logged correctly (`log:`), depending on the wrapped tool,
* [x] temporary files are either written to a unique hidden folder in the working directory, or (better) stored where the Python function `tempfile.gettempdir()` points to (see [here](https://docs.python.org/3/library/tempfile.html#tempfile.gettempdir); this also means that using any Python `tempfile` default behavior works),
* [x] the `meta.yaml` contains a link to the documentation of the respective tool or command,
* [x] `Snakefile`s pass the linting (`snakemake --lint`),
* [x] `Snakefile`s are formatted with [snakefmt](https://github.com/snakemake/snakefmt),
* [x] Python wrapper scripts are formatted with [black](https://black.readthedocs.io).
