### PR TITLE
feat: explicitly specify bwa index in bwa samxe

### DIFF
--- a/bio/bwa/aln/test/Snakefile
+++ b/bio/bwa/aln/test/Snakefile
@@ -1,7 +1,6 @@
 rule bwa_aln:
     input:
         fastq="reads/{sample}.{pair}.fastq",
-        # Index can be a list of (all) files created by bwa, or one of them
         idx=multiext("genome", ".amb", ".ann", ".bwt", ".pac", ".sa"),
     output:
         "sai/{sample}.{pair}.sai",

--- a/bio/bwa/mem-samblaster/test/Snakefile
+++ b/bio/bwa/mem-samblaster/test/Snakefile
@@ -1,7 +1,6 @@
 rule bwa_mem:
     input:
         reads=["reads/{sample}.1.fastq", "reads/{sample}.2.fastq"],
-        # Index can be a list of (all) files created by bwa, or one of them
         idx=multiext("genome", ".amb", ".ann", ".bwt", ".pac", ".sa"),
     output:
         bam="mapped/{sample}.bam",

--- a/bio/bwa/mem/test/Snakefile
+++ b/bio/bwa/mem/test/Snakefile
@@ -1,7 +1,6 @@
 rule bwa_mem:
     input:
         reads=["reads/{sample}.1.fastq", "reads/{sample}.2.fastq"],
-        # Index can be a list of (all) files created by bwa, or one of them
         idx=multiext("genome", ".amb", ".ann", ".bwt", ".pac", ".sa"),
     output:
         "mapped/{sample}.bam",

--- a/bio/bwa/mem/test/Snakefile_picard
+++ b/bio/bwa/mem/test/Snakefile_picard
@@ -1,7 +1,6 @@
 rule bwa_mem:
     input:
         reads=["reads/{sample}.1.fastq", "reads/{sample}.2.fastq"],
-        # Index can be a list of (all) files created by bwa, or one of them
         idx=multiext("genome", ".amb", ".ann", ".bwt", ".pac", ".sa"),
     output:
         "mapped/{sample}.bam",

--- a/bio/bwa/mem/test/Snakefile_samtools
+++ b/bio/bwa/mem/test/Snakefile_samtools
@@ -1,7 +1,6 @@
 rule bwa_mem:
     input:
         reads=["reads/{sample}.1.fastq", "reads/{sample}.2.fastq"],
-        # Index can be a list of (all) files created by bwa, or one of them
         idx=multiext("genome", ".amb", ".ann", ".bwt", ".pac", ".sa"),
     output:
         "mapped/{sample}.bam",

--- a/bio/bwa/sampe/test/Snakefile
+++ b/bio/bwa/sampe/test/Snakefile
@@ -2,7 +2,6 @@ rule bwa_sampe:
     input:
         fastq=["reads/{sample}.1.fastq", "reads/{sample}.2.fastq"],
         sai=["sai/{sample}.1.sai", "sai/{sample}.2.sai"],
-        # Index can be a list of (all) files created by bwa, or one of them
         idx=multiext("genome", ".amb", ".ann", ".bwt", ".pac", ".sa"),
     output:
         "mapped/{sample}.bam",

--- a/bio/bwa/sampe/test/Snakefile_picard
+++ b/bio/bwa/sampe/test/Snakefile_picard
@@ -2,7 +2,6 @@ rule bwa_sampe:
     input:
         fastq=["reads/{sample}.1.fastq", "reads/{sample}.2.fastq"],
         sai=["sai/{sample}.1.sai", "sai/{sample}.2.sai"],
-        # Index can be a list of (all) files created by bwa, or one of them
         idx=multiext("genome", ".amb", ".ann", ".bwt", ".pac", ".sa"),
     output:
         "mapped/{sample}.bam",

--- a/bio/bwa/sampe/test/Snakefile_samtools
+++ b/bio/bwa/sampe/test/Snakefile_samtools
@@ -2,7 +2,6 @@ rule bwa_sampe:
     input:
         fastq=["reads/{sample}.1.fastq", "reads/{sample}.2.fastq"],
         sai=["sai/{sample}.1.sai", "sai/{sample}.2.sai"],
-        # Index can be a list of (all) files created by bwa, or one of them
         idx=multiext("genome", ".amb", ".ann", ".bwt", ".pac", ".sa"),
     output:
         "mapped/{sample}.bam",

--- a/bio/bwa/samse/test/Snakefile
+++ b/bio/bwa/samse/test/Snakefile
@@ -2,7 +2,6 @@ rule bwa_samse:
     input:
         fastq="reads/{sample}.1.fastq",
         sai="sai/{sample}.1.sai",
-        # Index can be a list of (all) files created by bwa, or one of them
         idx=multiext("genome", ".amb", ".ann", ".bwt", ".pac", ".sa"),
     output:
         "mapped/{sample}.bam",

--- a/bio/bwa/samse/test/Snakefile_picard
+++ b/bio/bwa/samse/test/Snakefile_picard
@@ -2,7 +2,6 @@ rule bwa_samse:
     input:
         fastq="reads/{sample}.1.fastq",
         sai="sai/{sample}.1.sai",
-        # Index can be a list of (all) files created by bwa, or one of them
         idx=multiext("genome", ".amb", ".ann", ".bwt", ".pac", ".sa"),
     output:
         "mapped/{sample}.bam",

--- a/bio/bwa/samse/test/Snakefile_samtools
+++ b/bio/bwa/samse/test/Snakefile_samtools
@@ -2,7 +2,6 @@ rule bwa_samse:
     input:
         fastq="reads/{sample}.1.fastq",
         sai="sai/{sample}.1.sai",
-        # Index can be a list of (all) files created by bwa, or one of them
         idx=multiext("genome", ".amb", ".ann", ".bwt", ".pac", ".sa"),
     output:
         "mapped/{sample}.bam",

--- a/bio/bwa/samxe/meta.yaml
+++ b/bio/bwa/samxe/meta.yaml
@@ -1,4 +1,13 @@
 name: "bwa sam(se/pe)"
-description: Map paired-end reads with either bwa samse or sampe. For more information about BWA see `BWA documentation <http://bio-bwa.sourceforge.net/bwa.shtml>`_.
+description: Map paired-end reads with either bwa samse or sampe.
 authors:
   - Filipe G. Vieira
+input:
+  - FASTQ file(s)
+  - SAI file(s)
+  - reference genome
+output:
+  - SAM/BAM alignment file
+notes: |
+  * The `extra` param allows for additional program arguments.
+  * For more information see, http://bio-bwa.sourceforge.net/bwa.shtml

--- a/bio/bwa/samxe/test/Snakefile
+++ b/bio/bwa/samxe/test/Snakefile
@@ -2,7 +2,6 @@ rule bwa_sam_pe:
     input:
         fastq=["reads/{sample}.1.fastq", "reads/{sample}.2.fastq"],
         sai=["sai/{sample}.1.sai", "sai/{sample}.2.sai"],
-        # Index can be a list of (all) files created by bwa, or one of them
         idx=multiext("genome", ".amb", ".ann", ".bwt", ".pac", ".sa"),
     output:
         "mapped/{sample}.pe.sam",
@@ -19,7 +18,6 @@ rule bwa_sam_se:
     input:
         fastq="reads/{sample}.1.fastq",
         sai="sai/{sample}.1.sai",
-        # Index can be a list of (all) files created by bwa, or one of them
         idx=multiext("genome", ".amb", ".ann", ".bwt", ".pac", ".sa"),
     output:
         "mapped/{sample}.se.sam",
@@ -36,7 +34,6 @@ rule bwa_bam_pe:
     input:
         fastq=["reads/{sample}.1.fastq", "reads/{sample}.2.fastq"],
         sai=["sai/{sample}.1.sai", "sai/{sample}.2.sai"],
-        # Index can be a list of (all) files created by bwa, or one of them
         idx=multiext("genome", ".amb", ".ann", ".bwt", ".pac", ".sa"),
     output:
         "mapped/{sample}.pe.bam",
@@ -53,7 +50,6 @@ rule bwa_bam_se:
     input:
         fastq="reads/{sample}.1.fastq",
         sai="sai/{sample}.1.sai",
-        # Index can be a list of (all) files created by bwa, or one of them
         idx=multiext("genome", ".amb", ".ann", ".bwt", ".pac", ".sa"),
     output:
         "mapped/{sample}.se.bam",

--- a/bio/bwa/samxe/test/Snakefile
+++ b/bio/bwa/samxe/test/Snakefile
@@ -2,10 +2,11 @@ rule bwa_sam_pe:
     input:
         fastq=["reads/{sample}.1.fastq", "reads/{sample}.2.fastq"],
         sai=["sai/{sample}.1.sai", "sai/{sample}.2.sai"],
+        # Index can be a list of (all) files created by bwa, or one of them
+        idx=multiext("genome", ".amb", ".ann", ".bwt", ".pac", ".sa"),
     output:
         "mapped/{sample}.pe.sam",
     params:
-        index="genome",
         extra=r"-r '@RG\tID:{sample}\tSM:{sample}'",  # optional: Extra parameters for bwa.
         sort="none",
     log:
@@ -18,10 +19,11 @@ rule bwa_sam_se:
     input:
         fastq="reads/{sample}.1.fastq",
         sai="sai/{sample}.1.sai",
+        # Index can be a list of (all) files created by bwa, or one of them
+        idx=multiext("genome", ".amb", ".ann", ".bwt", ".pac", ".sa"),
     output:
         "mapped/{sample}.se.sam",
     params:
-        index="genome",
         extra=r"-r '@RG\tID:{sample}\tSM:{sample}'",  # optional: Extra parameters for bwa.
         sort="none",
     log:
@@ -34,10 +36,11 @@ rule bwa_bam_pe:
     input:
         fastq=["reads/{sample}.1.fastq", "reads/{sample}.2.fastq"],
         sai=["sai/{sample}.1.sai", "sai/{sample}.2.sai"],
+        # Index can be a list of (all) files created by bwa, or one of them
+        idx=multiext("genome", ".amb", ".ann", ".bwt", ".pac", ".sa"),
     output:
         "mapped/{sample}.pe.bam",
     params:
-        index="genome",
         extra=r"-r '@RG\tID:{sample}\tSM:{sample}'",  # optional: Extra parameters for bwa.
         sort="none",
     log:
@@ -50,10 +53,11 @@ rule bwa_bam_se:
     input:
         fastq="reads/{sample}.1.fastq",
         sai="sai/{sample}.1.sai",
+        # Index can be a list of (all) files created by bwa, or one of them
+        idx=multiext("genome", ".amb", ".ann", ".bwt", ".pac", ".sa"),
     output:
         "mapped/{sample}.se.bam",
     params:
-        index="genome",
         extra=r"-r '@RG\tID:{sample}\tSM:{sample}'",  # optional: Extra parameters for bwa.
         sort="none",
     log:

--- a/bio/bwa/samxe/test/Snakefile_picard
+++ b/bio/bwa/samxe/test/Snakefile_picard
@@ -2,7 +2,6 @@ rule bwa_sam_pe:
     input:
         fastq=["reads/{sample}.1.fastq", "reads/{sample}.2.fastq"],
         sai=["sai/{sample}.1.sai", "sai/{sample}.2.sai"],
-        # Index can be a list of (all) files created by bwa, or one of them
         idx=multiext("genome", ".amb", ".ann", ".bwt", ".pac", ".sa"),
     output:
         "mapped/{sample}.pe.picard_sort.sam",
@@ -21,7 +20,6 @@ rule bwa_sam_se:
     input:
         fastq="reads/{sample}.1.fastq",
         sai="sai/{sample}.1.sai",
-        # Index can be a list of (all) files created by bwa, or one of them
         idx=multiext("genome", ".amb", ".ann", ".bwt", ".pac", ".sa"),
     output:
         "mapped/{sample}.se.picard_sort.sam",
@@ -40,7 +38,6 @@ rule bwa_bam_pe:
     input:
         fastq=["reads/{sample}.1.fastq", "reads/{sample}.2.fastq"],
         sai=["sai/{sample}.1.sai", "sai/{sample}.2.sai"],
-        # Index can be a list of (all) files created by bwa, or one of them
         idx=multiext("genome", ".amb", ".ann", ".bwt", ".pac", ".sa"),
     output:
         "mapped/{sample}.pe.picard_sort.bam",
@@ -59,7 +56,6 @@ rule bwa_bam_se:
     input:
         fastq="reads/{sample}.1.fastq",
         sai="sai/{sample}.1.sai",
-        # Index can be a list of (all) files created by bwa, or one of them
         idx=multiext("genome", ".amb", ".ann", ".bwt", ".pac", ".sa"),
     output:
         "mapped/{sample}.se.picard_sort.bam",

--- a/bio/bwa/samxe/test/Snakefile_picard
+++ b/bio/bwa/samxe/test/Snakefile_picard
@@ -2,10 +2,11 @@ rule bwa_sam_pe:
     input:
         fastq=["reads/{sample}.1.fastq", "reads/{sample}.2.fastq"],
         sai=["sai/{sample}.1.sai", "sai/{sample}.2.sai"],
+        # Index can be a list of (all) files created by bwa, or one of them
+        idx=multiext("genome", ".amb", ".ann", ".bwt", ".pac", ".sa"),
     output:
         "mapped/{sample}.pe.picard_sort.sam",
     params:
-        index="genome",
         extra=r"-r '@RG\tID:{sample}\tSM:{sample}'",  # optional: Extra parameters for bwa.
         sort="picard",  # optional: Enable sorting. Possible values: 'none', 'samtools' or 'picard'`
         sort_order="queryname",  # optional: Sort by 'queryname' or 'coordinate'
@@ -20,10 +21,11 @@ rule bwa_sam_se:
     input:
         fastq="reads/{sample}.1.fastq",
         sai="sai/{sample}.1.sai",
+        # Index can be a list of (all) files created by bwa, or one of them
+        idx=multiext("genome", ".amb", ".ann", ".bwt", ".pac", ".sa"),
     output:
         "mapped/{sample}.se.picard_sort.sam",
     params:
-        index="genome",
         extra=r"-r '@RG\tID:{sample}\tSM:{sample}'",  # optional: Extra parameters for bwa.
         sort="picard",  # optional: Enable sorting. Possible values: 'none', 'samtools' or 'picard'`
         sort_order="queryname",  # optional: Sort by 'queryname' or 'coordinate'
@@ -38,10 +40,11 @@ rule bwa_bam_pe:
     input:
         fastq=["reads/{sample}.1.fastq", "reads/{sample}.2.fastq"],
         sai=["sai/{sample}.1.sai", "sai/{sample}.2.sai"],
+        # Index can be a list of (all) files created by bwa, or one of them
+        idx=multiext("genome", ".amb", ".ann", ".bwt", ".pac", ".sa"),
     output:
         "mapped/{sample}.pe.picard_sort.bam",
     params:
-        index="genome",
         extra=r"-r '@RG\tID:{sample}\tSM:{sample}'",  # optional: Extra parameters for bwa.
         sort="picard",  # optional: Enable sorting. Possible values: 'none', 'samtools' or 'picard'`
         sort_order="queryname",  # optional: Sort by 'queryname' or 'coordinate'
@@ -56,10 +59,11 @@ rule bwa_bam_se:
     input:
         fastq="reads/{sample}.1.fastq",
         sai="sai/{sample}.1.sai",
+        # Index can be a list of (all) files created by bwa, or one of them
+        idx=multiext("genome", ".amb", ".ann", ".bwt", ".pac", ".sa"),
     output:
         "mapped/{sample}.se.picard_sort.bam",
     params:
-        index="genome",
         extra=r"-r '@RG\tID:{sample}\tSM:{sample}'",  # optional: Extra parameters for bwa.
         sort="picard",  # optional: Enable sorting. Possible values: 'none', 'samtools' or 'picard'`
         sort_order="queryname",  # optional: Sort by 'queryname' or 'coordinate'

--- a/bio/bwa/samxe/test/Snakefile_samtools
+++ b/bio/bwa/samxe/test/Snakefile_samtools
@@ -2,7 +2,6 @@ rule bwa_sam_pe:
     input:
         fastq=["reads/{sample}.1.fastq", "reads/{sample}.2.fastq"],
         sai=["sai/{sample}.1.sai", "sai/{sample}.2.sai"],
-        # Index can be a list of (all) files created by bwa, or one of them
         idx=multiext("genome", ".amb", ".ann", ".bwt", ".pac", ".sa"),
     output:
         "mapped/{sample}.pe.samtools_sort.sam",
@@ -21,7 +20,6 @@ rule bwa_sam_se:
     input:
         fastq="reads/{sample}.1.fastq",
         sai="sai/{sample}.1.sai",
-        # Index can be a list of (all) files created by bwa, or one of them
         idx=multiext("genome", ".amb", ".ann", ".bwt", ".pac", ".sa"),
     output:
         "mapped/{sample}.se.samtools_sort.sam",
@@ -40,7 +38,6 @@ rule bwa_bam_pe:
     input:
         fastq=["reads/{sample}.1.fastq", "reads/{sample}.2.fastq"],
         sai=["sai/{sample}.1.sai", "sai/{sample}.2.sai"],
-        # Index can be a list of (all) files created by bwa, or one of them
         idx=multiext("genome", ".amb", ".ann", ".bwt", ".pac", ".sa"),
     output:
         "mapped/{sample}.pe.samtools_sort.bam",
@@ -59,7 +56,6 @@ rule bwa_bam_se:
     input:
         fastq="reads/{sample}.1.fastq",
         sai="sai/{sample}.1.sai",
-        # Index can be a list of (all) files created by bwa, or one of them
         idx=multiext("genome", ".amb", ".ann", ".bwt", ".pac", ".sa"),
     output:
         "mapped/{sample}.se.samtools_sort.bam",

--- a/bio/bwa/samxe/test/Snakefile_samtools
+++ b/bio/bwa/samxe/test/Snakefile_samtools
@@ -2,10 +2,11 @@ rule bwa_sam_pe:
     input:
         fastq=["reads/{sample}.1.fastq", "reads/{sample}.2.fastq"],
         sai=["sai/{sample}.1.sai", "sai/{sample}.2.sai"],
+        # Index can be a list of (all) files created by bwa, or one of them
+        idx=multiext("genome", ".amb", ".ann", ".bwt", ".pac", ".sa"),
     output:
         "mapped/{sample}.pe.samtools_sort.sam",
     params:
-        index="genome",
         extra=r"-r '@RG\tID:{sample}\tSM:{sample}'",  # optional: Extra parameters for bwa.
         sort="samtools",  # optional: Enable sorting. Possible values: 'none', 'samtools' or 'picard'`
         sort_order="queryname",  # optional: Sort by 'queryname' or 'coordinate'
@@ -20,10 +21,11 @@ rule bwa_sam_se:
     input:
         fastq="reads/{sample}.1.fastq",
         sai="sai/{sample}.1.sai",
+        # Index can be a list of (all) files created by bwa, or one of them
+        idx=multiext("genome", ".amb", ".ann", ".bwt", ".pac", ".sa"),
     output:
         "mapped/{sample}.se.samtools_sort.sam",
     params:
-        index="genome",
         extra=r"-r '@RG\tID:{sample}\tSM:{sample}'",  # optional: Extra parameters for bwa.
         sort="samtools",  # optional: Enable sorting. Possible values: 'none', 'samtools' or 'picard'`
         sort_order="queryname",  # optional: Sort by 'queryname' or 'coordinate'
@@ -38,10 +40,11 @@ rule bwa_bam_pe:
     input:
         fastq=["reads/{sample}.1.fastq", "reads/{sample}.2.fastq"],
         sai=["sai/{sample}.1.sai", "sai/{sample}.2.sai"],
+        # Index can be a list of (all) files created by bwa, or one of them
+        idx=multiext("genome", ".amb", ".ann", ".bwt", ".pac", ".sa"),
     output:
         "mapped/{sample}.pe.samtools_sort.bam",
     params:
-        index="genome",
         extra=r"-r '@RG\tID:{sample}\tSM:{sample}'",  # optional: Extra parameters for bwa.
         sort="samtools",  # optional: Enable sorting. Possible values: 'none', 'samtools' or 'picard'`
         sort_order="queryname",  # optional: Sort by 'queryname' or 'coordinate'
@@ -56,10 +59,11 @@ rule bwa_bam_se:
     input:
         fastq="reads/{sample}.1.fastq",
         sai="sai/{sample}.1.sai",
+        # Index can be a list of (all) files created by bwa, or one of them
+        idx=multiext("genome", ".amb", ".ann", ".bwt", ".pac", ".sa"),
     output:
         "mapped/{sample}.se.samtools_sort.bam",
     params:
-        index="genome",
         extra=r"-r '@RG\tID:{sample}\tSM:{sample}'",  # optional: Extra parameters for bwa.
         sort="samtools",  # optional: Enable sorting. Possible values: 'none', 'samtools' or 'picard'`
         sort_order="queryname",  # optional: Sort by 'queryname' or 'coordinate'

--- a/bio/bwa/samxe/wrapper.py
+++ b/bio/bwa/samxe/wrapper.py
@@ -10,6 +10,12 @@ from os import path
 from snakemake.shell import shell
 
 
+index = snakemake.input.get("idx", "")
+if isinstance(index, str):
+    index = path.splitext(snakemake.input.idx)[0]
+else:
+    index = path.splitext(snakemake.input.idx[0])[0]
+
 # Check inputs.
 fastq = (
     snakemake.input.fastq
@@ -80,7 +86,7 @@ else:
 shell(
     "(bwa {alg}"
     " {extra}"
-    " {snakemake.params.index}"
+    " {index}"
     " {snakemake.input.sai}"
     " {snakemake.input.fastq}"
     " | " + pipe_cmd + ") {log}"


### PR DESCRIPTION
<!-- Ensure that the PR title follows conventional commit style (<type>: <description>)-->
<!-- Possible types are here: https://github.com/commitizen/conventional-commit-types/blob/master/index.json -->

### Description

Following #232, doing the same for the `smaxe` wrapper. 

### QC
<!-- Make sure that you can tick the boxes below. -->

For all wrappers added by this PR, I made sure that

* [x] there is a test case which covers any introduced changes,
* [x] `input:` and `output:` file paths in the resulting rule can be changed arbitrarily,
* [x] either the wrapper can only use a single core, or the example rule contains a `threads: x` statement with `x` being a reasonable default,
* [x] rule names in the test case are in [snake_case](https://en.wikipedia.org/wiki/Snake_case) and somehow tell what the rule is about or match the tools purpose or name (e.g., `map_reads` for a step that maps reads),
* [x] all `environment.yaml` specifications follow [the respective best practices](https://stackoverflow.com/a/64594513/2352071),
* [x] wherever possible, command line arguments are inferred and set automatically (e.g. based on file extensions in `input:` or `output:`),
* [x] all fields of the example rules in the `Snakefile`s and their entries are explained via comments (`input:`/`output:`/`params:` etc.),
* [x] `stderr` and/or `stdout` are logged correctly (`log:`), depending on the wrapped tool,
* [x] temporary files are either written to a unique hidden folder in the working directory, or (better) stored where the Python function `tempfile.gettempdir()` points to (see [here](https://docs.python.org/3/library/tempfile.html#tempfile.gettempdir); this also means that using any Python `tempfile` default behavior works),
* [x] the `meta.yaml` contains a link to the documentation of the respective tool or command,
* [x] `Snakefile`s pass the linting (`snakemake --lint`),
* [x] `Snakefile`s are formatted with [snakefmt](https://github.com/snakemake/snakefmt),
* [x] Python wrapper scripts are formatted with [black](https://black.readthedocs.io).
