### PR TITLE
feat: added STAR temp dir

### DIFF
--- a/bio/star/align/environment.yaml
+++ b/bio/star/align/environment.yaml
@@ -2,4 +2,4 @@ channels:
   - bioconda
   - conda-forge
 dependencies:
-  - star ==2.7.9a
+  - star =2.7

--- a/bio/star/align/meta.yaml
+++ b/bio/star/align/meta.yaml
@@ -3,8 +3,8 @@ description: Map reads with STAR.
 authors:
   - Johannes Köster
   - Tomás Di Domenico
+  - Filipe G. Vieira
 notes: |
-  * It is necessary to specify (at least) two output file, to correclty identify the output prefix
   * The `extra` param allows for additional program arguments.
   * It is advisable to consider updating the limits setting before running STAR,
     such as executing `ulimit -n 10000`, to avoid an issue like this:

--- a/bio/star/align/meta.yaml
+++ b/bio/star/align/meta.yaml
@@ -4,6 +4,7 @@ authors:
   - Johannes Köster
   - Tomás Di Domenico
 notes: |
+  * It is necessary to specify (at least) two output file, to correclty identify the output prefix
   * The `extra` param allows for additional program arguments.
   * It is advisable to consider updating the limits setting before running STAR,
     such as executing `ulimit -n 10000`, to avoid an issue like this:

--- a/bio/star/align/test/Snakefile
+++ b/bio/star/align/test/Snakefile
@@ -12,7 +12,7 @@ rule star_pe_multi:
         "logs/star/pe/{sample}.log",
     params:
         # path to STAR reference genome index
-        index="index",
+        idx="index",
         # optional parameters
         extra="",
     threads: 8
@@ -30,7 +30,7 @@ rule star_se:
         "logs/star/{sample}.log",
     params:
         # path to STAR reference genome index
-        index="index",
+        idx="index",
         # optional parameters
         extra="",
     threads: 8

--- a/bio/star/align/test/Snakefile
+++ b/bio/star/align/test/Snakefile
@@ -7,8 +7,8 @@ rule star_pe_multi:
         fq2=["reads/{sample}_R2.1.fastq", "reads/{sample}_R2.2.fastq"],  #optional
     output:
         # see STAR manual for additional output files
-        "star/pe/{sample}/Aligned.out.sam",
-        "star/pe/{sample}/Log.out",
+        sam="star/pe/{sample}/Aligned.out.sam",
+        log="star/pe/{sample}/Log.out",
     log:
         "logs/star/pe/{sample}.log",
     params:
@@ -26,8 +26,8 @@ rule star_se:
         fq1="reads/{sample}_R1.1.fastq",
     output:
         # see STAR manual for additional output files
-        "star/se/{sample}/Aligned.out.sam",
-        "star/se/{sample}/Log.out",
+        sam="star/se/{sample}/Aligned.out.sam",
+        log="star/se/{sample}/Log.out",
     log:
         "logs/star/se/{sample}.log",
     params:

--- a/bio/star/align/test/Snakefile
+++ b/bio/star/align/test/Snakefile
@@ -8,6 +8,7 @@ rule star_pe_multi:
     output:
         # see STAR manual for additional output files
         "star/pe/{sample}/Aligned.out.sam",
+        "star/pe/{sample}/Log.out",
     log:
         "logs/star/pe/{sample}.log",
     params:
@@ -26,6 +27,7 @@ rule star_se:
     output:
         # see STAR manual for additional output files
         "star/se/{sample}/Aligned.out.sam",
+        "star/se/{sample}/Log.out",
     log:
         "logs/star/se/{sample}.log",
     params:

--- a/bio/star/align/test/Snakefile
+++ b/bio/star/align/test/Snakefile
@@ -25,9 +25,9 @@ rule star_se:
         fq1="reads/{sample}_R1.1.fastq",
     output:
         # see STAR manual for additional output files
-        "star/{sample}/Aligned.out.sam",
+        "star/se/{sample}/Aligned.out.sam",
     log:
-        "logs/star/{sample}.log",
+        "logs/star/se/{sample}.log",
     params:
         # path to STAR reference genome index
         idx="index",

--- a/bio/star/align/wrapper.py
+++ b/bio/star/align/wrapper.py
@@ -41,10 +41,6 @@ index = snakemake.input.get("idx")
 if not index:
     index = snakemake.params.get("idx", "")
 
-outprefix = os.path.commonprefix(snakemake.output)
-if outprefix == os.path.dirname(snakemake.output[0]):
-    outprefix += "/"
-
 with tempfile.TemporaryDirectory() as tmpdir:
     shell(
         "STAR "
@@ -53,18 +49,30 @@ with tempfile.TemporaryDirectory() as tmpdir:
         " --readFilesIn {input_str}"
         " {readcmd}"
         " {extra}"
-        " --outTmpDir {tmpdir}/STARtmp"
-        " --outFileNamePrefix {outprefix}"
+        " --outTmpDir {tmpdir}/temp"
+        " --outFileNamePrefix {tmpdir}/"
         " --outStd Log "
         " {log}"
     )
 
     if "SortedByCoordinate" in extra:
-        bamprefix = "Aligned.sortedByCoord.out."
+        bamprefix = "Aligned.sortedByCoord.out"
     else:
-        bamprefix = "Aligned.out."
+        bamprefix = "Aligned.out"
 
     if snakemake.output.get("bam"):
-        shell("cat {outprefix}{bamprefix}bam > {snakemake.output.bam:q}")
-    elif snakemake.output.get("sam"):
-        shell("cat {outprefix}{bamprefix}sam > {snakemake.output.sam:q}")
+        shell("cat {tmpdir}/{bamprefix}.bam > {snakemake.output.bam:q}")
+    if snakemake.output.get("sam"):
+        shell("cat {tmpdir}/{bamprefix}.sam > {snakemake.output.sam:q}")
+    if snakemake.output.get("reads_per_gene"):
+        shell("cat {tmpdir}/ReadsPerGene.out.tab > {snakemake.output.reads_per_gene:q}")
+    if snakemake.output.get("chim_junc"):
+        shell("cat {tmpdir}/Chimeric.out.junction > {snakemake.output.chim_junc:q}")
+    if snakemake.output.get("sj"):
+        shell("cat {tmpdir}/SJ.out.tab > {snakemake.output.sj:q}")
+    if snakemake.output.get("log"):
+        shell("cat {tmpdir}/Log.out > {snakemake.output.log:q}")
+    if snakemake.output.get("log_progress"):
+        shell("cat {tmpdir}/Log.progress.out > {snakemake.output.log_progress:q}")
+    if snakemake.output.get("log_final"):
+        shell("cat {tmpdir}/Log.final.out > {snakemake.output.log_final:q}")

--- a/bio/star/align/wrapper.py
+++ b/bio/star/align/wrapper.py
@@ -37,16 +37,11 @@ if fq1[0].endswith(".gz"):
 else:
     readcmd = ""
 
-if "SortedByCoordinate" in extra:
-    bamprefix = "Aligned.sortedByCoord.out."
-else:
-    bamprefix = "Aligned.out."
-
 index = snakemake.input.get("idx")
 if not index:
     index = snakemake.params.get("idx", "")
 
-outprefix = snakemake.output[0].split(bamprefix)[0]
+outprefix = os.path.commonprefix(snakemake.output)
 if outprefix == os.path.dirname(snakemake.output[0]):
     outprefix += "/"
 
@@ -60,11 +55,15 @@ with tempfile.TemporaryDirectory() as tmpdir:
         " {extra}"
         " --outTmpDir {tmpdir}/STARtmp"
         " --outFileNamePrefix {outprefix}"
-        " --outStd Log"
         " {log}"
     )
 
+    if "SortedByCoordinate" in extra:
+        bamprefix = "Aligned.sortedByCoord.out."
+    else:
+        bamprefix = "Aligned.out."
+
     if snakemake.output.get("bam"):
-        shell("cp {outprefix}{bamprefix}bam {snakemake.output.bam:q}")
+        shell("mv {outprefix}{bamprefix}bam {snakemake.output.bam:q}")
     elif snakemake.output.get("bam"):
-        shell("cp {outprefix}{bamprefix}sam {snakemake.output.sam:q}")
+        shell("mv {outprefix}{bamprefix}sam {snakemake.output.sam:q}")

--- a/bio/star/align/wrapper.py
+++ b/bio/star/align/wrapper.py
@@ -46,16 +46,6 @@ if outprefix == os.path.dirname(snakemake.output[0]):
     outprefix += "/"
 
 with tempfile.TemporaryDirectory() as tmpdir:
-    if "SortedByCoordinate" in extra:
-        bamprefix = "Aligned.sortedByCoord.out."
-    else:
-        bamprefix = "Aligned.out."
-
-    if snakemake.output.get("bam"):
-        shell("ln -s {outprefix}{bamprefix}bam {snakemake.output.bam:q}")
-    elif snakemake.output.get("bam"):
-        shell("ln -s {outprefix}{bamprefix}sam {snakemake.output.sam:q}")
-
     shell(
         "STAR "
         " --runThreadN {snakemake.threads}"
@@ -67,3 +57,13 @@ with tempfile.TemporaryDirectory() as tmpdir:
         " --outFileNamePrefix {outprefix}"
         " {log}"
     )
+
+    if "SortedByCoordinate" in extra:
+        bamprefix = "Aligned.sortedByCoord.out."
+    else:
+        bamprefix = "Aligned.out."
+
+    if snakemake.output.get("bam"):
+        shell("cat {outprefix}{bamprefix}bam > {snakemake.output.bam:q}")
+    elif snakemake.output.get("bam"):
+        shell("cat {outprefix}{bamprefix}sam > {snakemake.output.sam:q}")

--- a/bio/star/align/wrapper.py
+++ b/bio/star/align/wrapper.py
@@ -55,6 +55,7 @@ with tempfile.TemporaryDirectory() as tmpdir:
         " {extra}"
         " --outTmpDir {tmpdir}/STARtmp"
         " --outFileNamePrefix {outprefix}"
+        "--outStd Log "
         " {log}"
     )
 

--- a/bio/star/align/wrapper.py
+++ b/bio/star/align/wrapper.py
@@ -65,6 +65,6 @@ with tempfile.TemporaryDirectory() as tmpdir:
     )
 
     if snakemake.output.get("bam"):
-        shell("mv {outprefix}/{bamprefix}.bam {snakemake.output.bam:q}")
+        shell("cp {outprefix}{bamprefix}bam {snakemake.output.bam:q}")
     elif snakemake.output.get("bam"):
-        shell("mv {outprefix}/{bamprefix}.sam {snakemake.output.sam:q}")
+        shell("cp {outprefix}{bamprefix}sam {snakemake.output.sam:q}")

--- a/bio/star/align/wrapper.py
+++ b/bio/star/align/wrapper.py
@@ -47,7 +47,6 @@ if not index:
     index = snakemake.params.get("idx", "")
 
 outprefix = snakemake.output[0].split(bamprefix)[0]
-
 if outprefix == os.path.dirname(snakemake.output[0]):
     outprefix += "/"
 
@@ -64,3 +63,8 @@ with tempfile.TemporaryDirectory() as tmpdir:
         " --outStd Log"
         " {log}"
     )
+
+    if snakemake.output.get("bam"):
+        shell("mv {outprefix}/{bamprefix}.bam {snakemake.output.bam:q}")
+    elif snakemake.output.get("bam"):
+        shell("mv {outprefix}/{bamprefix}.sam {snakemake.output.sam:q}")

--- a/bio/star/align/wrapper.py
+++ b/bio/star/align/wrapper.py
@@ -65,5 +65,5 @@ with tempfile.TemporaryDirectory() as tmpdir:
 
     if snakemake.output.get("bam"):
         shell("cat {outprefix}{bamprefix}bam > {snakemake.output.bam:q}")
-    elif snakemake.output.get("bam"):
+    elif snakemake.output.get("sam"):
         shell("cat {outprefix}{bamprefix}sam > {snakemake.output.sam:q}")

--- a/bio/star/align/wrapper.py
+++ b/bio/star/align/wrapper.py
@@ -46,6 +46,16 @@ if outprefix == os.path.dirname(snakemake.output[0]):
     outprefix += "/"
 
 with tempfile.TemporaryDirectory() as tmpdir:
+    if "SortedByCoordinate" in extra:
+        bamprefix = "Aligned.sortedByCoord.out."
+    else:
+        bamprefix = "Aligned.out."
+
+    if snakemake.output.get("bam"):
+        shell("ln -s {outprefix}{bamprefix}bam {snakemake.output.bam:q}")
+    elif snakemake.output.get("bam"):
+        shell("ln -s {outprefix}{bamprefix}sam {snakemake.output.sam:q}")
+
     shell(
         "STAR "
         " --runThreadN {snakemake.threads}"
@@ -57,13 +67,3 @@ with tempfile.TemporaryDirectory() as tmpdir:
         " --outFileNamePrefix {outprefix}"
         " {log}"
     )
-
-    if "SortedByCoordinate" in extra:
-        bamprefix = "Aligned.sortedByCoord.out."
-    else:
-        bamprefix = "Aligned.out."
-
-    if snakemake.output.get("bam"):
-        shell("mv {outprefix}{bamprefix}bam {snakemake.output.bam:q}")
-    elif snakemake.output.get("bam"):
-        shell("mv {outprefix}{bamprefix}sam {snakemake.output.sam:q}")

--- a/bio/star/align/wrapper.py
+++ b/bio/star/align/wrapper.py
@@ -55,7 +55,7 @@ with tempfile.TemporaryDirectory() as tmpdir:
         " {extra}"
         " --outTmpDir {tmpdir}/STARtmp"
         " --outFileNamePrefix {outprefix}"
-        "--outStd Log "
+        " --outStd Log "
         " {log}"
     )
 

--- a/bio/star/align/wrapper.py
+++ b/bio/star/align/wrapper.py
@@ -54,13 +54,13 @@ if outprefix == os.path.dirname(snakemake.output[0]):
 with tempfile.TemporaryDirectory() as tmpdir:
     shell(
         "STAR "
-        "{extra} "
-        "--runThreadN {snakemake.threads} "
-        "--genomeDir {index} "
-        "--readFilesIn {input_str} "
-        "{readcmd} "
-        "--outFileNamePrefix {outprefix} "
-        "--outStd Log "
-        "--outTmpDir {tmpdir}/STARtmp "
-        "{log}"
+        " --runThreadN {snakemake.threads}"
+        " --genomeDir {index}"
+        " --readFilesIn {input_str}"
+        " {readcmd}"
+        " {extra}"
+        " --outTmpDir {tmpdir}/STARtmp"
+        " --outFileNamePrefix {outprefix}"
+        " --outStd Log"
+        " {log}"
     )

--- a/bio/star/align/wrapper.py
+++ b/bio/star/align/wrapper.py
@@ -42,6 +42,10 @@ if "SortedByCoordinate" in extra:
 else:
     bamprefix = "Aligned.out."
 
+index = snakemake.input.get("idx")
+if not index:
+    index = snakemake.params.get("idx", "")
+
 outprefix = snakemake.output[0].split(bamprefix)[0]
 
 if outprefix == os.path.dirname(snakemake.output[0]):
@@ -52,7 +56,7 @@ with tempfile.TemporaryDirectory() as tmpdir:
         "STAR "
         "{extra} "
         "--runThreadN {snakemake.threads} "
-        "--genomeDir {snakemake.params.index} "
+        "--genomeDir {index} "
         "--readFilesIn {input_str} "
         "{readcmd} "
         "--outFileNamePrefix {outprefix} "

--- a/bio/star/index/environment.yaml
+++ b/bio/star/index/environment.yaml
@@ -2,4 +2,4 @@ channels:
   - bioconda
   - conda-forge
 dependencies:
-  - star ==2.7.8a
+  - star =2.7

--- a/bio/star/index/meta.yaml
+++ b/bio/star/index/meta.yaml
@@ -3,6 +3,7 @@ description: Index fasta sequences with STAR
 authors:
   - Thibault Dayris
   - Tomás Di Domenico
+  - Filipe G. Vieira
 input:
   - A (multi)fasta formatted file
 output:

--- a/bio/star/index/test/Snakefile
+++ b/bio/star/index/test/Snakefile
@@ -1,15 +1,14 @@
 rule star_index:
     input:
-        fasta = "{genome}.fasta"
+        fasta="{genome}.fasta",
     output:
-        directory("{genome}")
+        directory("{genome}"),
     message:
         "Testing STAR index"
-    threads:
-        1
+    threads: 1
     params:
-        extra = ""
+        extra="",
     log:
-        "logs/star_index_{genome}.log"
+        "logs/star_index_{genome}.log",
     wrapper:
         "master/bio/star/index"

--- a/bio/star/index/wrapper.py
+++ b/bio/star/index/wrapper.py
@@ -5,7 +5,7 @@ __copyright__ = "Copyright 2019, Dayris Thibault"
 __email__ = "thibault.dayris@gustaveroussy.fr"
 __license__ = "MIT"
 
-import tempdir
+import tempfile
 from snakemake.shell import shell
 from snakemake.utils import makedirs
 

--- a/bio/star/index/wrapper.py
+++ b/bio/star/index/wrapper.py
@@ -5,6 +5,7 @@ __copyright__ = "Copyright 2019, Dayris Thibault"
 __email__ = "thibault.dayris@gustaveroussy.fr"
 __license__ = "MIT"
 
+import tempdir
 from snakemake.shell import shell
 from snakemake.utils import makedirs
 
@@ -15,21 +16,23 @@ sjdb_overhang = snakemake.params.get("sjdbOverhang", "100")
 
 gtf = snakemake.input.get("gtf")
 if gtf is not None:
-    gtf = "--sjdbGTFfile " + gtf
-    sjdb_overhang = "--sjdbOverhang " + sjdb_overhang
+    gtf = f"--sjdbGTFfile {gtf}"
+    sjdb_overhang = f"--sjdbOverhang {sjdb_overhang}"
 else:
     gtf = sjdb_overhang = ""
 
 makedirs(snakemake.output)
 
-shell(
-    "STAR "  # Tool
-    "--runMode genomeGenerate "  # Indexation mode
-    "{extra} "  # Optional parameters
-    "--runThreadN {snakemake.threads} "  # Number of threads
-    "--genomeDir {snakemake.output} "  # Path to output
-    "--genomeFastaFiles {snakemake.input.fasta} "  # Path to fasta files
-    "{sjdb_overhang} "  # Read-len - 1
-    "{gtf} "  # Highly recommended GTF
-    "{log}"  # Logging
-)
+with tempfile.TemporaryDirectory() as tmpdir:
+    shell(
+        "STAR"
+        " --runThreadN {snakemake.threads}"  # Number of threads
+        " --runMode genomeGenerate"  # Indexation mode
+        " --genomeFastaFiles {snakemake.input.fasta}"  # Path to fasta files
+        " {sjdb_overhang}"  # Read-len - 1
+        " {gtf}"  # Highly recommended GTF
+        " {extra}"  # Optional parameters
+        " --outTmpDir {tmpdir}/STARtmp"  # Temp dir
+        " --genomeDir {snakemake.output}"  # Path to output
+        " {log}"  # Logging
+    )

--- a/meta/bio/star_arriba/test/Snakefile
+++ b/meta/bio/star_arriba/test/Snakefile
@@ -23,8 +23,8 @@ rule star_align:
         idx="resources/star_genome",
     output:
         # see STAR manual for additional output files
-        "star/{sample}/Aligned.out.bam",
-        "star/{sample}/ReadsPerGene.out.tab",
+        bam="star/{sample}/Aligned.out.bam",
+        reads_per_gene="star/{sample}/ReadsPerGene.out.tab",
     log:
         "logs/star/{sample}.log",
     params:

--- a/meta/bio/star_arriba/test/Snakefile
+++ b/meta/bio/star_arriba/test/Snakefile
@@ -1,57 +1,57 @@
 rule star_index:
     input:
         fasta="resources/genome.fasta",
-        annotation="resources/genome.gtf"
+        annotation="resources/genome.gtf",
     output:
-        directory("resources/star_genome")
+        directory("resources/star_genome"),
     threads: 4
     params:
-        extra="--sjdbGTFfile resources/genome.gtf --sjdbOverhang 100"
+        extra="--sjdbGTFfile resources/genome.gtf --sjdbOverhang 100",
     log:
-        "logs/star_index_genome.log"
+        "logs/star_index_genome.log",
     cache: True
     wrapper:
         "master/bio/star/index"
+
 
 rule star_align:
     input:
         # use a list for multiple fastq files for one sample
         # usually technical replicates across lanes/flowcells
         fq1="reads/{sample}_R1.1.fastq",
-        fq2="reads/{sample}_R2.1.fastq", #optional
-        index="resources/star_genome"
+        fq2="reads/{sample}_R2.1.fastq",  #optional
+        idx="resources/star_genome",
     output:
         # see STAR manual for additional output files
         "star/{sample}/Aligned.out.bam",
-        "star/{sample}/ReadsPerGene.out.tab"
+        "star/{sample}/ReadsPerGene.out.tab",
     log:
-        "logs/star/{sample}.log"
+        "logs/star/{sample}.log",
     params:
-        # path to STAR reference genome index
-        index="resources/star_genome",
         # specific parameters to work well with arriba
         extra="--quantMode GeneCounts --sjdbGTFfile resources/genome.gtf"
-            " --outSAMtype BAM Unsorted --chimSegmentMin 10 --chimOutType WithinBAM SoftClip"
-            " --chimJunctionOverhangMin 10 --chimScoreMin 1 --chimScoreDropMax 30 --chimScoreJunctionNonGTAG 0"
-            " --chimScoreSeparation 1 --alignSJstitchMismatchNmax 5 -1 5 5 --chimSegmentReadGapMax 3"
+        " --outSAMtype BAM Unsorted --chimSegmentMin 10 --chimOutType WithinBAM SoftClip"
+        " --chimJunctionOverhangMin 10 --chimScoreMin 1 --chimScoreDropMax 30 --chimScoreJunctionNonGTAG 0"
+        " --chimScoreSeparation 1 --alignSJstitchMismatchNmax 5 -1 5 5 --chimSegmentReadGapMax 3",
     threads: 12
     wrapper:
         "master/bio/star/align"
+
 
 rule arriba:
     input:
         bam="star/{sample}/Aligned.out.bam",
         genome="resources/genome.fasta",
-        annotation="resources/genome.gtf"
+        annotation="resources/genome.gtf",
     output:
         fusions="results/arriba/{sample}.fusions.tsv",
-        discarded="results/arriba/{sample}.fusions.discarded.tsv"
+        discarded="results/arriba/{sample}.fusions.discarded.tsv",
     params:
         # A tsv containing identified artifacts, such as read-through fusions of neighbouring genes, see https://arriba.readthedocs.io/en/latest/input-files/#blacklist
         blacklist="arriba_blacklist.tsv",
-        extra="-T -P -i 1,2" # -i describes the wanted contigs, remove if you want to use all hg38 chromosomes
+        extra="-T -P -i 1,2",  # -i describes the wanted contigs, remove if you want to use all hg38 chromosomes
     log:
-        "logs/arriba/{sample}.log"
+        "logs/arriba/{sample}.log",
     threads: 1
     wrapper:
         "master/bio/arriba"

--- a/test.py
+++ b/test.py
@@ -2599,7 +2599,7 @@ def test_star_align():
 
     run(
         "bio/star/align",
-        ["snakemake", "--cores", "1", "star/a/Aligned.out.sam", "--use-conda", "-F"],
+        ["snakemake", "--cores", "1", "star/se/a/Aligned.out.sam", "--use-conda", "-F"],
     )
     run(
         "bio/star/align",


### PR DESCRIPTION
<!-- Ensure that the PR title follows conventional commit style (<type>: <description>)-->
<!-- Possible types are here: https://github.com/commitizen/conventional-commit-types/blob/master/index.json -->

### Description

Add a temp dir and made output file names more flexible. Now, all of STAR output is saved to a temp dir and only those files specified as outputs by the user are copied over to the final location

### QC
<!-- Make sure that you can tick the boxes below. -->

For all wrappers added by this PR, I made sure that

* [x] there is a test case which covers any introduced changes,
* [x] `input:` and `output:` file paths in the resulting rule can be changed arbitrarily,
* [x] either the wrapper can only use a single core, or the example rule contains a `threads: x` statement with `x` being a reasonable default,
* [x] rule names in the test case are in [snake_case](https://en.wikipedia.org/wiki/Snake_case) and somehow tell what the rule is about or match the tools purpose or name (e.g., `map_reads` for a step that maps reads),
* [x] all `environment.yaml` specifications follow [the respective best practices](https://stackoverflow.com/a/64594513/2352071),
* [x] wherever possible, command line arguments are inferred and set automatically (e.g. based on file extensions in `input:` or `output:`),
* [x] all fields of the example rules in the `Snakefile`s and their entries are explained via comments (`input:`/`output:`/`params:` etc.),
* [x] `stderr` and/or `stdout` are logged correctly (`log:`), depending on the wrapped tool,
* [x] temporary files are either written to a unique hidden folder in the working directory, or (better) stored where the Python function `tempfile.gettempdir()` points to (see [here](https://docs.python.org/3/library/tempfile.html#tempfile.gettempdir); this also means that using any Python `tempfile` default behavior works),
* [x] the `meta.yaml` contains a link to the documentation of the respective tool or command,
* [x] `Snakefile`s pass the linting (`snakemake --lint`),
* [x] `Snakefile`s are formatted with [snakefmt](https://github.com/snakemake/snakefmt),
* [x] Python wrapper scripts are formatted with [black](https://black.readthedocs.io).
