### PR TITLE
feat: added samtools wrapper utils

### DIFF
--- a/bio/samtools/calmd/environment.yaml
+++ b/bio/samtools/calmd/environment.yaml
@@ -2,4 +2,5 @@ channels:
   - bioconda
   - conda-forge
 dependencies:
-  - samtools ==1.11
+  - samtools =1.14
+  - snakemake-wrapper-utils =0.3

--- a/bio/samtools/calmd/meta.yaml
+++ b/bio/samtools/calmd/meta.yaml
@@ -1,4 +1,7 @@
 name: samtools calmd
-description: Calculates MD and NM tags. For more information see `SAMtools documentation <http://www.htslib.org/doc/samtools-calmd.html>`_.
+description: Calculates MD and NM tags.
 authors:
   - Filipe G. Vieira
+notes: |
+  * The `extra` param allows for additional program arguments (not `-@/--threads` or `-O/--output-fmt`).
+  * For more information see, http://www.htslib.org/doc/samtools-calmd.html

--- a/bio/samtools/calmd/test/Snakefile
+++ b/bio/samtools/calmd/test/Snakefile
@@ -7,7 +7,7 @@ rule samtools_calmd:
     log:
         "{sample}.calmd.log",
     params:
-        "-E",  # optional params string
+        extra="-E",  # optional params string
     threads: 2
     wrapper:
         "master/bio/samtools/calmd"

--- a/bio/samtools/calmd/test/Snakefile
+++ b/bio/samtools/calmd/test/Snakefile
@@ -1,11 +1,11 @@
 rule samtools_calmd:
     input:
-        aln = "{sample}.bam", # Can be 'sam', 'bam', or 'cram'
-        ref = "genome.fasta"
+        aln="{sample}.bam",  # Can be 'sam', 'bam', or 'cram'
+        ref="genome.fasta",
     output:
-        "{sample}.calmd.bam"
+        "{sample}.calmd.bam",
     params:
-        "-E" # optional params string
+        "-E",  # optional params string
     threads: 2
     wrapper:
         "master/bio/samtools/calmd"

--- a/bio/samtools/calmd/test/Snakefile
+++ b/bio/samtools/calmd/test/Snakefile
@@ -4,6 +4,8 @@ rule samtools_calmd:
         ref="genome.fasta",
     output:
         "{sample}.calmd.bam",
+    log:
+        "{sample}.calmd.log",
     params:
         "-E",  # optional params string
     threads: 2

--- a/bio/samtools/calmd/wrapper.py
+++ b/bio/samtools/calmd/wrapper.py
@@ -3,14 +3,15 @@ __copyright__ = "Copyright 2020, Filipe G. Vieira"
 __license__ = "MIT"
 
 
-from os import path
 from snakemake.shell import shell
+from snakemake_wrapper_utils.samtools import get_samtools_opts
 
+samtools_opts = get_samtools_opts(
+    snakemake, parse_write_index=False, parse_output=False
+)
+extra = snakemake.params.get("extra", "")
 log = snakemake.log_fmt_shell(stdout=False, stderr=True)
 
-out_name, out_ext = path.splitext(snakemake.output[0])
-out_ext = out_ext[1:].upper()
-
 shell(
-    "samtools calmd --threads {snakemake.threads} {snakemake.params} --output-fmt {out_ext} {snakemake.input.aln} {snakemake.input.ref} > {snakemake.output[0]} {log}"
+    "samtools calmd {samtools_opts} {extra} {snakemake.input.aln} {snakemake.input.ref} > {snakemake.output[0]} {log}"
 )

--- a/bio/samtools/depth/environment.yaml
+++ b/bio/samtools/depth/environment.yaml
@@ -2,4 +2,5 @@ channels:
   - bioconda
   - conda-forge
 dependencies:
-  - samtools ==1.10
+  - samtools =1.14
+  - snakemake-wrapper-utils =0.3

--- a/bio/samtools/depth/meta.yaml
+++ b/bio/samtools/depth/meta.yaml
@@ -1,4 +1,7 @@
 name: samtools depth
-description: Compute the read depth at each position or region using samtools. For more information see `SAMtools documentation <http://www.htslib.org/doc/samtools-depth.html>`_.
+description: Compute the read depth at each position or region using samtools.
 authors:
   - Dayne Filer
+notes: |
+  * The `extra` param allows for additional program arguments (not `-@/--threads` or `-o`).
+  * For more information see, http://www.htslib.org/doc/samtools-depth.html

--- a/bio/samtools/depth/meta.yaml
+++ b/bio/samtools/depth/meta.yaml
@@ -2,6 +2,7 @@ name: samtools depth
 description: Compute the read depth at each position or region using samtools.
 authors:
   - Dayne Filer
+  - Filipe G. Vieira
 notes: |
   * The `extra` param allows for additional program arguments (not `-@/--threads` or `-o`).
   * For more information see, http://www.htslib.org/doc/samtools-depth.html

--- a/bio/samtools/depth/test/Snakefile
+++ b/bio/samtools/depth/test/Snakefile
@@ -4,6 +4,8 @@ rule samtools_depth:
         bed="regionToCalcDepth.bed",  # optional
     output:
         "depth.txt",
+    log:
+        "depth.log",
     params:
         # optional bed file passed to -b
         extra="",  # optional additional parameters as string

--- a/bio/samtools/depth/test/Snakefile
+++ b/bio/samtools/depth/test/Snakefile
@@ -1,11 +1,11 @@
 rule samtools_depth:
     input:
         bams=["mapped/A.bam", "mapped/B.bam"],
-        bed="regionToCalcDepth.bed", # optional
+        bed="regionToCalcDepth.bed",  # optional
     output:
-        "depth.txt"
+        "depth.txt",
     params:
         # optional bed file passed to -b
-        extra="" # optional additional parameters as string
+        extra="",  # optional additional parameters as string
     wrapper:
         "master/bio/samtools/depth"

--- a/bio/samtools/depth/wrapper.py
+++ b/bio/samtools/depth/wrapper.py
@@ -6,17 +6,17 @@ __email__ = "dayne.filer@gmail.com"
 __license__ = "MIT"
 
 from snakemake.shell import shell
+from snakemake_wrapper_utils.samtools import get_samtools_opts
 
+samtools_opts = get_samtools_opts(
+    snakemake, parse_write_index=False, parse_output_format=False
+)
+extra = snakemake.params.get("extra", "")
 log = snakemake.log_fmt_shell(stdout=True, stderr=True)
-
-params = snakemake.params.get("extra", "")
 
 # check for optional bed file
 bed = snakemake.input.get("bed", "")
 if bed:
     bed = "-b " + bed
 
-shell(
-    "samtools depth {params} {bed} "
-    "-o {snakemake.output[0]} {snakemake.input.bams} {log}"
-)
+shell("samtools depth {samtools_opts} {extra} {bed} {snakemake.input.bams} {log}")

--- a/bio/samtools/faidx/environment.yaml
+++ b/bio/samtools/faidx/environment.yaml
@@ -2,4 +2,5 @@ channels:
   - bioconda
   - conda-forge
 dependencies:
-  - samtools ==1.10
+  - samtools =1.14
+  - snakemake-wrapper-utils =0.3

--- a/bio/samtools/faidx/meta.yaml
+++ b/bio/samtools/faidx/meta.yaml
@@ -2,6 +2,7 @@ name: samtools faidx
 description: index reference sequence in FASTA format from reference sequence.
 authors:
   - Michael Chambers
+  - Filipe G. Vieira
 input:
   - reference sequence file (.fa)
 output:

--- a/bio/samtools/faidx/meta.yaml
+++ b/bio/samtools/faidx/meta.yaml
@@ -1,8 +1,11 @@
 name: samtools faidx
-description: index reference sequence in FASTA format from reference sequence. For more information see `SAMtools documentation <http://www.htslib.org/doc/samtools-faidx.html>`_.
+description: index reference sequence in FASTA format from reference sequence.
 authors:
   - Michael Chambers
 input:
   - reference sequence file (.fa)
 output:
   - indexed reference sequence file (.fai)
+notes: |
+  * The `extra` param allows for additional program arguments (not `-o`).
+  * For more information see, http://www.htslib.org/doc/samtools-faidx.html

--- a/bio/samtools/faidx/test/Snakefile
+++ b/bio/samtools/faidx/test/Snakefile
@@ -1,9 +1,9 @@
 rule samtools_index:
     input:
-        "{sample}.fa"
+        "{sample}.fa",
     output:
-        "{sample}.fa.fai"
+        "{sample}.fa.fai",
     params:
-        "" # optional params string
+        "",  # optional params string
     wrapper:
         "master/bio/samtools/faidx"

--- a/bio/samtools/faidx/test/Snakefile
+++ b/bio/samtools/faidx/test/Snakefile
@@ -3,7 +3,9 @@ rule samtools_index:
         "{sample}.fa",
     output:
         "{sample}.fa.fai",
+    log:
+        "{sample}.log",
     params:
-        "",  # optional params string
+        extra="",  # optional params string
     wrapper:
         "master/bio/samtools/faidx"

--- a/bio/samtools/faidx/wrapper.py
+++ b/bio/samtools/faidx/wrapper.py
@@ -11,6 +11,6 @@ samtools_opts = get_samtools_opts(
     snakemake, parse_threads=False, parse_write_index=False, parse_output_format=False
 )
 extra = snakemake.params.get("extra", "")
-log = snakemake.log_fmt_shell(stdout=False, stderr=True)
+log = snakemake.log_fmt_shell(stdout=True, stderr=True)
 
 shell("samtools faidx {samtools_opts} {extra} {snakemake.input[0]} {log}")

--- a/bio/samtools/faidx/wrapper.py
+++ b/bio/samtools/faidx/wrapper.py
@@ -5,9 +5,12 @@ __license__ = "MIT"
 
 
 from snakemake.shell import shell
+from snakemake_wrapper_utils.samtools import get_samtools_opts
 
+samtools_opts = get_samtools_opts(
+    snakemake, parse_threads=False, parse_write_index=False, parse_output_format=False
+)
+extra = snakemake.params.get("extra", "")
 log = snakemake.log_fmt_shell(stdout=False, stderr=True)
 
-shell(
-    "samtools faidx {snakemake.params} {snakemake.input[0]} > {snakemake.output[0]} {log}"
-)
+shell("samtools faidx {samtools_opts} {extra} {snakemake.input[0]} {log}")

--- a/bio/samtools/fastq/interleaved/environment.yaml
+++ b/bio/samtools/fastq/interleaved/environment.yaml
@@ -3,3 +3,4 @@ channels:
   - bioconda
 dependencies:
   - samtools =1.14
+  - snakemake-wrapper-utils =0.3

--- a/bio/samtools/fastq/interleaved/meta.yaml
+++ b/bio/samtools/fastq/interleaved/meta.yaml
@@ -7,4 +7,5 @@ authors:
   - Victoria Sack
   - Filipe G. Vieira
 notes: |
+  * The `extra` param allows for additional program arguments (not `-@/--threads` or `-o`).
   * For more information see, http://www.htslib.org/doc/samtools-fasta.html

--- a/bio/samtools/fastq/interleaved/wrapper.py
+++ b/bio/samtools/fastq/interleaved/wrapper.py
@@ -6,15 +6,12 @@ __license__ = "MIT"
 
 import os
 from snakemake.shell import shell
+from snakemake_wrapper_utils.samtools import get_samtools_opts
 
+samtools_opts = get_samtools_opts(
+    snakemake, parse_write_index=False, parse_output_format=False
+)
+extra = snakemake.params.get("extra", "")
 log = snakemake.log_fmt_shell(stdout=False, stderr=True)
 
-prefix = os.path.splitext(snakemake.output[0])[0]
-
-shell(
-    "samtools fastq {snakemake.params} "
-    " -@ {snakemake.threads} "
-    " {snakemake.input[0]}"
-    " > {snakemake.output[0]} "
-    "{log}"
-)
+shell("samtools fastq {samtools_opts} {extra} {snakemake.input[0]} {log}")

--- a/bio/samtools/fastq/separate/meta.yaml
+++ b/bio/samtools/fastq/separate/meta.yaml
@@ -9,5 +9,5 @@ authors:
   - Victoria Sack
   - Filipe G. Vieira
 notes: |
-  * Samtools -@/--threads takes one integer as input. This is the number of additional threads and not raw threads.
+  * The `extra` param allows for additional program arguments.
   * For more information see, http://www.htslib.org/doc/samtools-fasta.html

--- a/bio/samtools/fastx/environment.yaml
+++ b/bio/samtools/fastx/environment.yaml
@@ -4,4 +4,5 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - samtools==1.12
+  - samtools =1.14
+  - snakemake-wrapper-utils =0.3

--- a/bio/samtools/fastx/meta.yaml
+++ b/bio/samtools/fastx/meta.yaml
@@ -2,6 +2,7 @@ name: samtools fastx
 description: Converts a SAM, BAM or CRAM into FASTQ or FASTA format.
 authors:
   - William Rowell
+  - Filipe G. Vieira
 input:
   - bam or sam file (.bam, .sam)
 output:

--- a/bio/samtools/fastx/meta.yaml
+++ b/bio/samtools/fastx/meta.yaml
@@ -6,3 +6,6 @@ input:
   - bam or sam file (.bam, .sam)
 output:
   - fastq file (.fastq) or fasta file (.fasta)
+notes: |
+  * The `extra` param allows for additional program arguments (not `-@/--threads` or `-o`).
+  * For more information see, http://www.htslib.org/doc/samtools-fasta.html

--- a/bio/samtools/fastx/test/Snakefile
+++ b/bio/samtools/fastx/test/Snakefile
@@ -7,10 +7,10 @@ rule samtools_fastq:
         "{prefix}.log",
     message:
         ""
-    threads:  # Samtools takes additional threads through its option -@
-        2     # This value - 1 will be sent to -@
+    # Samtools takes additional threads through its option -@
+    threads: 2  # This value - 1 will be sent to -@
     params:
-        outputtype = "fasta",
-        extra = ""
+        outputtype="fasta",
+        extra="",
     wrapper:
         "master/bio/samtools/fastx/"

--- a/bio/samtools/fastx/wrapper.py
+++ b/bio/samtools/fastx/wrapper.py
@@ -5,19 +5,15 @@ __license__ = "MIT"
 
 
 from snakemake.shell import shell
+from snakemake_wrapper_utils.samtools import get_samtools_opts
 
+samtools_opts = get_samtools_opts(
+    snakemake, parse_write_index=False, parse_output_format=False
+)
+extra = snakemake.params.get("extra", "")
 log = snakemake.log_fmt_shell(stdout=False, stderr=True)
 
-extra = snakemake.params.get("extra", "")
-# Samtools takes additional threads through its option -@
-# One thread for samtools merge
-# Other threads are *additional* threads passed to the '-@' argument
-threads = "" if snakemake.threads <= 1 else " -@ {} ".format(snakemake.threads - 1)
 
 shell(
-    """
-    (samtools {snakemake.params.outputtype} \
-        {threads} {extra} \
-        {snakemake.input} > {snakemake.output}) {log}
-    """
+    "samtools {snakemake.params.outputtype} {samtools_opts} {extra} {snakemake.input} {log}"
 )

--- a/bio/samtools/fastx/wrapper.py
+++ b/bio/samtools/fastx/wrapper.py
@@ -11,7 +11,7 @@ samtools_opts = get_samtools_opts(
     snakemake, parse_write_index=False, parse_output_format=False
 )
 extra = snakemake.params.get("extra", "")
-log = snakemake.log_fmt_shell(stdout=False, stderr=True)
+log = snakemake.log_fmt_shell(stdout=True, stderr=True)
 
 
 shell(

--- a/bio/samtools/fixmate/environment.yaml
+++ b/bio/samtools/fixmate/environment.yaml
@@ -4,4 +4,5 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - samtools ==1.10
+  - samtools =1.14
+  - snakemake-wrapper-utils =0.3

--- a/bio/samtools/fixmate/meta.yaml
+++ b/bio/samtools/fixmate/meta.yaml
@@ -2,6 +2,7 @@ name: samtools fixmate
 description: Use samtools to correct mate information after BWA mapping.
 authors:
   - Thibault Dayris
+  - Filipe G. Vieira
 input:
   - bam or sam file (.bam,.sam)
 output:

--- a/bio/samtools/fixmate/meta.yaml
+++ b/bio/samtools/fixmate/meta.yaml
@@ -1,8 +1,11 @@
 name: samtools fixmate
-description: Use samtools to correct mate information after BWA mapping. For more information see `SAMtools documentation <http://www.htslib.org/doc/samtools-fixmate.html>`_.
+description: Use samtools to correct mate information after BWA mapping.
 authors:
   - Thibault Dayris
 input:
   - bam or sam file (.bam,.sam)
 output:
   - bam or sam file (.bam,.sam)
+notes: |
+  * The `extra` param allows for additional program arguments (not `-@/--threads` or `-O/--output-fmt`).
+  * For more information see, http://www.htslib.org/doc/samtools-fixmate.html

--- a/bio/samtools/fixmate/test/Snakefile
+++ b/bio/samtools/fixmate/test/Snakefile
@@ -3,6 +3,8 @@ rule samtools_fixmate:
         "mapped/{input}",
     output:
         "fixed/{input}",
+    log:
+        "{input}.log",
     message:
         "Fixing mate information in {wildcards.input}"
     threads: 1

--- a/bio/samtools/fixmate/test/Snakefile
+++ b/bio/samtools/fixmate/test/Snakefile
@@ -1,13 +1,12 @@
 rule samtools_fixmate:
     input:
-        "mapped/{input}"
+        "mapped/{input}",
     output:
-        "fixed/{input}"
+        "fixed/{input}",
     message:
         "Fixing mate information in {wildcards.input}"
-    threads:
-        1
+    threads: 1
     params:
-        extra = ""
+        extra="",
     wrapper:
         "master/bio/samtools/fixmate/"

--- a/bio/samtools/fixmate/wrapper.py
+++ b/bio/samtools/fixmate/wrapper.py
@@ -5,22 +5,16 @@ __copyright__ = "Copyright 2019, Dayris Thibault"
 __email__ = "thibault.dayris@gustaveroussy.fr"
 __license__ = "MIT"
 
-import os.path as op
-
 from snakemake.shell import shell
 from snakemake.utils import makedirs
+from snakemake_wrapper_utils.samtools import get_samtools_opts
 
+samtools_opts = get_samtools_opts(
+    snakemake, parse_write_index=False, parse_output=False
+)
+extra = snakemake.params.get("extra", "")
 log = snakemake.log_fmt_shell(stdout=True, stderr=True)
 
-extra = snakemake.params.get("extra", "")
-
-# Samtools' threads parameter lists ADDITIONAL threads.
-# that is why threads - 1 has to be given to the -@ parameter
-threads = "" if snakemake.threads <= 1 else " -@ {} ".format(snakemake.threads - 1)
-
-makedirs(op.dirname(snakemake.output[0]))
-
 shell(
-    "samtools fixmate {extra} {threads}"
-    " {snakemake.input[0]} {snakemake.output[0]} {log}"
+    "samtools fixmate {samtools_opts} {extra} {snakemake.input[0]} {snakemake.output[0]} {log}"
 )

--- a/bio/samtools/flagstat/environment.yaml
+++ b/bio/samtools/flagstat/environment.yaml
@@ -2,4 +2,5 @@ channels:
   - bioconda
   - conda-forge
 dependencies:
-  - samtools ==1.10
+  - samtools =1.14
+  - snakemake-wrapper-utils =0.3

--- a/bio/samtools/flagstat/meta.yaml
+++ b/bio/samtools/flagstat/meta.yaml
@@ -1,8 +1,11 @@
 name: samtools flagstat
-description: Use samtools to create a flagstat file from a bam or sam file. For more information see `SAMtools documentation <http://www.htslib.org/doc/samtools-flagstat.html>`_.
+description: Use samtools to create a flagstat file from a bam or sam file.
 authors:
   - Christopher Preusch
 input:
   - bam or sam file (.bam,.sam)
 output:
   - flagstat file (.flagstat)
+notes: |
+  * The `extra` param allows for additional program arguments (not `-@/--threads`).
+  * For more information see, http://www.htslib.org/doc/samtools-flagstat.html

--- a/bio/samtools/flagstat/meta.yaml
+++ b/bio/samtools/flagstat/meta.yaml
@@ -2,6 +2,7 @@ name: samtools flagstat
 description: Use samtools to create a flagstat file from a bam or sam file.
 authors:
   - Christopher Preusch
+  - Filipe G. Vieira
 input:
   - bam or sam file (.bam,.sam)
 output:

--- a/bio/samtools/flagstat/test/Snakefile
+++ b/bio/samtools/flagstat/test/Snakefile
@@ -1,7 +1,7 @@
 rule samtools_flagstat:
     input:
-        "mapped/{sample}.bam"
+        "mapped/{sample}.bam",
     output:
-        "mapped/{sample}.bam.flagstat"
+        "mapped/{sample}.bam.flagstat",
     wrapper:
         "master/bio/samtools/flagstat"

--- a/bio/samtools/flagstat/test/Snakefile
+++ b/bio/samtools/flagstat/test/Snakefile
@@ -3,5 +3,9 @@ rule samtools_flagstat:
         "mapped/{sample}.bam",
     output:
         "mapped/{sample}.bam.flagstat",
+    log:
+        "{sample}.log",
+    params:
+        extra="",  # optional params string
     wrapper:
         "master/bio/samtools/flagstat"

--- a/bio/samtools/flagstat/wrapper.py
+++ b/bio/samtools/flagstat/wrapper.py
@@ -5,7 +5,14 @@ __license__ = "MIT"
 
 
 from snakemake.shell import shell
+from snakemake_wrapper_utils.samtools import get_samtools_opts
 
+samtools_opts = get_samtools_opts(
+    snakemake, parse_write_index=False, parse_output=False, parse_output_format=False
+)
+extra = snakemake.params.get("extra", "")
 log = snakemake.log_fmt_shell(stdout=False, stderr=True)
 
-shell("samtools flagstat {snakemake.input[0]} > {snakemake.output[0]} {log}")
+shell(
+    "samtools flagstat {samtools_opts} {extra} {snakemake.input[0]} > {snakemake.output[0]} {log}"
+)

--- a/bio/samtools/idxstats/environment.yaml
+++ b/bio/samtools/idxstats/environment.yaml
@@ -2,4 +2,5 @@ channels:
   - bioconda
   - conda-forge
 dependencies:
-  - samtools ==1.10
+  - samtools =1.14
+  - snakemake-wrapper-utils =0.3

--- a/bio/samtools/idxstats/meta.yaml
+++ b/bio/samtools/idxstats/meta.yaml
@@ -1,9 +1,12 @@
 name: samtools idxstats
-description: Use samtools to retrieve and print stats form indexed bam, sam or cram files. For more information see `SAMtools documentation <http://www.htslib.org/doc/samtools-idxstats.html>`_.
+description: Use samtools to retrieve and print stats from indexed BAM, SAM or CRAM files.
 authors:
   - Antonie Vietor
 input:
-  - indexed sam, bam or cram file (.sam, .bam, .cram)
+  - indexed SAM, BAM or CRAM file (.SAM, .BAM, .CRAM)
   - corresponding index files
 output:
   - idxstat file (.idxstats)
+notes: |
+  * The `extra` param allows for additional program arguments (not `-@/--threads`).
+  * For more information see, http://www.htslib.org/doc/samtools-idxstats.html

--- a/bio/samtools/idxstats/meta.yaml
+++ b/bio/samtools/idxstats/meta.yaml
@@ -2,6 +2,7 @@ name: samtools idxstats
 description: Use samtools to retrieve and print stats from indexed BAM, SAM or CRAM files.
 authors:
   - Antonie Vietor
+  - Filipe G. Vieira
 input:
   - indexed SAM, BAM or CRAM file (.SAM, .BAM, .CRAM)
   - corresponding index files

--- a/bio/samtools/idxstats/test/Snakefile
+++ b/bio/samtools/idxstats/test/Snakefile
@@ -6,5 +6,7 @@ rule samtools_idxstats:
         "mapped/{sample}.bam.idxstats",
     log:
         "logs/samtools/idxstats/{sample}.log",
+    params:
+        extra="",  # optional params string
     wrapper:
         "master/bio/samtools/idxstats"

--- a/bio/samtools/idxstats/test/Snakefile
+++ b/bio/samtools/idxstats/test/Snakefile
@@ -1,10 +1,10 @@
 rule samtools_idxstats:
     input:
         bam="mapped/{sample}.bam",
-        idx="mapped/{sample}.bam.bai"
+        idx="mapped/{sample}.bam.bai",
     output:
-        "mapped/{sample}.bam.idxstats"
+        "mapped/{sample}.bam.idxstats",
     log:
-        "logs/samtools/idxstats/{sample}.log"
+        "logs/samtools/idxstats/{sample}.log",
     wrapper:
         "master/bio/samtools/idxstats"

--- a/bio/samtools/idxstats/wrapper.py
+++ b/bio/samtools/idxstats/wrapper.py
@@ -5,7 +5,14 @@ __license__ = "MIT"
 
 
 from snakemake.shell import shell
+from snakemake_wrapper_utils.samtools import get_samtools_opts
 
+samtools_opts = get_samtools_opts(
+    snakemake, parse_write_index=False, parse_output=False, parse_output_format=False
+)
+extra = snakemake.params.get("extra", "")
 log = snakemake.log_fmt_shell(stdout=False, stderr=True)
 
-shell("samtools idxstats {snakemake.input.bam} > {snakemake.output[0]} {log}")
+shell(
+    "samtools idxstats {samtools_opts} {extra} {snakemake.input.bam} > {snakemake.output[0]} {log}"
+)

--- a/bio/samtools/index/environment.yaml
+++ b/bio/samtools/index/environment.yaml
@@ -2,4 +2,4 @@ channels:
   - bioconda
   - conda-forge
 dependencies:
-  - samtools ==1.10
+  - samtools =1.14

--- a/bio/samtools/index/meta.yaml
+++ b/bio/samtools/index/meta.yaml
@@ -1,8 +1,11 @@
 name: samtools index
-description: Index bam file with samtools. For more information see `SAMtools documentation <http://www.htslib.org/doc/samtools-index.html>`_.
+description: Index bam file with samtools.
 authors:
   - Johannes Köster
 input:
   - bam file
 output:
   - bam file index (.bai)
+notes: |
+  * The `extra` param allows for additional program arguments.
+  * For more information see, http://www.htslib.org/doc/samtools-index.html

--- a/bio/samtools/index/meta.yaml
+++ b/bio/samtools/index/meta.yaml
@@ -2,6 +2,7 @@ name: samtools index
 description: Index bam file with samtools.
 authors:
   - Johannes Köster
+  - Filipe G. Vieira
 input:
   - bam file
 output:

--- a/bio/samtools/index/test/Snakefile
+++ b/bio/samtools/index/test/Snakefile
@@ -6,7 +6,7 @@ rule samtools_index:
     log:
         "logs/samtools_index/{sample}.log",
     params:
-        "",  # optional params string
+        extra="",  # optional params string
     threads: 4  # This value - 1 will be sent to -@
     wrapper:
         "master/bio/samtools/index"

--- a/bio/samtools/index/test/Snakefile
+++ b/bio/samtools/index/test/Snakefile
@@ -1,13 +1,12 @@
 rule samtools_index:
     input:
-        "mapped/{sample}.sorted.bam"
+        "mapped/{sample}.sorted.bam",
     output:
-        "mapped/{sample}.sorted.bam.bai"
+        "mapped/{sample}.sorted.bam.bai",
     log:
-        "logs/samtools_index/{sample}.log"
+        "logs/samtools_index/{sample}.log",
     params:
-        "" # optional params string
-    threads:  # Samtools takes additional threads through its option -@
-        4     # This value - 1 will be sent to -@
+        "",  # optional params string
+    threads: 4  # This value - 1 will be sent to -@
     wrapper:
         "master/bio/samtools/index"

--- a/bio/samtools/index/wrapper.py
+++ b/bio/samtools/index/wrapper.py
@@ -6,6 +6,7 @@ __license__ = "MIT"
 
 from snakemake.shell import shell
 
+extra = snakemake.params.get("extra", "")
 log = snakemake.log_fmt_shell(stdout=True, stderr=True)
 
 # Samtools takes additional threads through its option -@
@@ -14,5 +15,5 @@ log = snakemake.log_fmt_shell(stdout=True, stderr=True)
 threads = "" if snakemake.threads <= 1 else " -@ {} ".format(snakemake.threads - 1)
 
 shell(
-    "samtools index {threads} {snakemake.params} {snakemake.input[0]} {snakemake.output[0]} {log}"
+    "samtools index {threads} {extra} {snakemake.input[0]} {snakemake.output[0]} {log}"
 )

--- a/bio/samtools/merge/environment.yaml
+++ b/bio/samtools/merge/environment.yaml
@@ -2,4 +2,5 @@ channels:
   - bioconda
   - conda-forge
 dependencies:
-  - samtools ==1.10
+  - samtools =1.14
+  - snakemake-wrapper-utils =0.3

--- a/bio/samtools/merge/meta.yaml
+++ b/bio/samtools/merge/meta.yaml
@@ -2,6 +2,7 @@ name: samtools merge
 description: Merge two bam files with samtools.
 authors:
   - Johannes Köster
+  - Filipe G. Vieira
 input:
   - list of bam files to merge
 output:

--- a/bio/samtools/merge/meta.yaml
+++ b/bio/samtools/merge/meta.yaml
@@ -1,5 +1,5 @@
 name: samtools merge
-description: Merge two bam files with samtools. For more information see `SAMtools documentation <http://www.htslib.org/doc/samtools-merge.html>`_.
+description: Merge two bam files with samtools.
 authors:
   - Johannes Köster
 input:
@@ -7,4 +7,5 @@ input:
 output:
   - merged bam file
 notes: |
-  * Samtools -@/--threads takes one integer as input. This is the number of additional threads and not raw threads.
+  * The `extra` param allows for additional program arguments (not `-@/--threads`, `--write-index`, `-o` or `-O/--output-fmt`).
+  * For more information see, http://www.htslib.org/doc/samtools-merge.html

--- a/bio/samtools/merge/test/Snakefile
+++ b/bio/samtools/merge/test/Snakefile
@@ -3,9 +3,10 @@ rule samtools_merge:
         ["mapped/A.bam", "mapped/B.bam"],
     output:
         "merged.bam",
+    log:
+        "merged.log",
     params:
-        "",  # optional additional parameters as string
-    # Samtools takes additional threads through its option -@
-    threads: 8  # This value - 1 will be sent to -@
+        extra="",  # optional additional parameters as string
+    threads: 8
     wrapper:
         "master/bio/samtools/merge"

--- a/bio/samtools/merge/test/Snakefile
+++ b/bio/samtools/merge/test/Snakefile
@@ -1,11 +1,11 @@
 rule samtools_merge:
     input:
-        ["mapped/A.bam", "mapped/B.bam"]
+        ["mapped/A.bam", "mapped/B.bam"],
     output:
-        "merged.bam"
+        "merged.bam",
     params:
-        "" # optional additional parameters as string
-    threads:  # Samtools takes additional threads through its option -@
-        8     # This value - 1 will be sent to -@
+        "",  # optional additional parameters as string
+    # Samtools takes additional threads through its option -@
+    threads: 8  # This value - 1 will be sent to -@
     wrapper:
         "master/bio/samtools/merge"

--- a/bio/samtools/merge/wrapper.py
+++ b/bio/samtools/merge/wrapper.py
@@ -5,16 +5,10 @@ __license__ = "MIT"
 
 
 from snakemake.shell import shell
+from snakemake_wrapper_utils.samtools import get_samtools_opts
 
+samtools_opts = get_samtools_opts(snakemake)
+extra = snakemake.params.get("extra", "")
 log = snakemake.log_fmt_shell(stdout=True, stderr=True)
 
-# Samtools takes additional threads through its option -@
-# One thread for samtools merge
-# Other threads are *additional* threads passed to the '-@' argument
-threads = "" if snakemake.threads <= 1 else " -@ {} ".format(snakemake.threads - 1)
-
-shell(
-    "samtools merge {threads} {snakemake.params} "
-    "{snakemake.output[0]} {snakemake.input} "
-    "{log}"
-)
+shell("samtools merge {samtools_opts} {extra} {snakemake.input} {log}")

--- a/bio/samtools/mpileup/environment.yaml
+++ b/bio/samtools/mpileup/environment.yaml
@@ -2,5 +2,5 @@ channels:
   - bioconda
   - conda-forge
 dependencies:
-  - samtools ==1.10
-  - pigz ==2.3.4
+  - samtools =1.14
+  - pigz =2.6

--- a/bio/samtools/mpileup/meta.yaml
+++ b/bio/samtools/mpileup/meta.yaml
@@ -2,6 +2,7 @@ name: samtools mpileup
 description: Generate pileup using samtools.
 authors:
   - Patrik Smeds
+  - Filipe G. Vieira
 notes: |
   * The `extra` param allows for additional program arguments.
   * For more information see, http://www.htslib.org/doc/samtools-mpileup.html

--- a/bio/samtools/mpileup/meta.yaml
+++ b/bio/samtools/mpileup/meta.yaml
@@ -1,4 +1,7 @@
 name: samtools mpileup
-description: Generate pileup using samtools. For more information see `SAMtools documentation <http://www.htslib.org/doc/samtools-mpileup.html>`_.
+description: Generate pileup using samtools.
 authors:
   - Patrik Smeds
+notes: |
+  * The `extra` param allows for additional program arguments.
+  * For more information see, http://www.htslib.org/doc/samtools-mpileup.html

--- a/bio/samtools/mpileup/test/Snakefile
+++ b/bio/samtools/mpileup/test/Snakefile
@@ -2,11 +2,11 @@ rule mpilup:
     input:
         # single or list of bam files
         bam="mapped/{sample}.bam",
-        reference_genome="genome.fasta"
+        reference_genome="genome.fasta",
     output:
-        "mpileup/{sample}.mpileup.gz"
+        "mpileup/{sample}.mpileup.gz",
     log:
-        "logs/samtools/mpileup/{sample}.log"
+        "logs/samtools/mpileup/{sample}.log",
     params:
         extra="-d 10000",  # optional
     wrapper:

--- a/bio/samtools/mpileup/wrapper.py
+++ b/bio/samtools/mpileup/wrapper.py
@@ -8,25 +8,14 @@ __license__ = "MIT"
 
 from snakemake.shell import shell
 
-log = snakemake.log_fmt_shell(stdout=True, stderr=True)
-
-bam_input = snakemake.input.bam
-reference_genome = snakemake.input.reference_genome
-
 extra = snakemake.params.get("extra", "")
+log = snakemake.log_fmt_shell(stdout=False, stderr=True)
 
 if not snakemake.output[0].endswith(".gz"):
     raise Exception(
         'output file will be compressed and therefore filename should end with ".gz"'
     )
 
-log = snakemake.log_fmt_shell(stdout=False, stderr=True)
-
 shell(
-    "samtools mpileup "
-    "{extra} "
-    "-f {reference_genome} "
-    "{bam_input}  "
-    " | pigz > {snakemake.output} "
-    "{log}"
+    "(samtools mpileup {extra} -f {snakemake.input.reference_genome} {snakemake.input.bam} | pigz > {snakemake.output}) {log}"
 )

--- a/bio/samtools/sort/environment.yaml
+++ b/bio/samtools/sort/environment.yaml
@@ -2,4 +2,5 @@ channels:
   - bioconda
   - conda-forge
 dependencies:
-  - samtools ==1.10
+  - samtools =1.14
+  - snakemake-wrapper-utils =0.3

--- a/bio/samtools/sort/meta.yaml
+++ b/bio/samtools/sort/meta.yaml
@@ -1,6 +1,7 @@
 name: samtools sort
-description: Sort bam file with samtools. For more information see `SAMtools documentation <http://www.htslib.org/doc/samtools-sort.html>`_.
+description: Sort bam file with samtools.
 authors:
   - Johannes Köster
 notes: |
-  * Samtools -@/--threads takes one integer as input. This is the number of additional threads and not raw threads.
+  * The `extra` param allows for additional program arguments (not `-@/--threads`, `--write-index`, `-o` or `-O/--output-fmt`).
+  * For more information see, http://www.htslib.org/doc/samtools-sort.html

--- a/bio/samtools/sort/meta.yaml
+++ b/bio/samtools/sort/meta.yaml
@@ -2,6 +2,7 @@ name: samtools sort
 description: Sort bam file with samtools.
 authors:
   - Johannes Köster
+  - Filipe G. Vieira
 notes: |
   * The `extra` param allows for additional program arguments (not `-@/--threads`, `--write-index`, `-o` or `-O/--output-fmt`).
   * For more information see, http://www.htslib.org/doc/samtools-sort.html

--- a/bio/samtools/sort/test/Snakefile
+++ b/bio/samtools/sort/test/Snakefile
@@ -3,10 +3,10 @@ rule samtools_sort:
         "mapped/{sample}.bam",
     output:
         "mapped/{sample}.sorted.bam",
+    log:
+        "{sample}.log",
     params:
         extra="-m 4G",
-        tmp_dir="/tmp/",
-    # Samtools takes additional threads through its option -@
-    threads: 8  # This value - 1 will be sent to -@.
+    threads: 8
     wrapper:
         "master/bio/samtools/sort"

--- a/bio/samtools/sort/test/Snakefile
+++ b/bio/samtools/sort/test/Snakefile
@@ -1,12 +1,12 @@
 rule samtools_sort:
     input:
-        "mapped/{sample}.bam"
+        "mapped/{sample}.bam",
     output:
-        "mapped/{sample}.sorted.bam"
+        "mapped/{sample}.sorted.bam",
     params:
-        extra = "-m 4G",
-        tmp_dir = "/tmp/"
-    threads:  # Samtools takes additional threads through its option -@
-        8     # This value - 1 will be sent to -@.
+        extra="-m 4G",
+        tmp_dir="/tmp/",
+    # Samtools takes additional threads through its option -@
+    threads: 8  # This value - 1 will be sent to -@.
     wrapper:
         "master/bio/samtools/sort"

--- a/bio/samtools/sort/wrapper.py
+++ b/bio/samtools/sort/wrapper.py
@@ -6,6 +6,7 @@ __license__ = "MIT"
 
 import os
 import tempfile
+from pathlib import Path
 from snakemake.shell import shell
 from snakemake_wrapper_utils.samtools import get_samtools_opts
 

--- a/bio/samtools/stats/environment.yaml
+++ b/bio/samtools/stats/environment.yaml
@@ -2,4 +2,5 @@ channels:
   - bioconda
   - conda-forge
 dependencies:
-  - samtools ==1.10
+  - samtools =1.14
+  - snakemake-wrapper-utils =0.3

--- a/bio/samtools/stats/meta.yaml
+++ b/bio/samtools/stats/meta.yaml
@@ -1,4 +1,7 @@
 name: samtools stats
-description: Generate stats using samtools. For more information see `SAMtools documentation <http://www.htslib.org/doc/samtools-stats.html>`_.
+description: Generate stats using samtools.
 authors:
   - Julian de Ruiter
+notes: |
+  * The `extra` param allows for additional program arguments (not `-@/--threads`).
+  * For more information see, http://www.htslib.org/doc/samtools-stats.html

--- a/bio/samtools/stats/meta.yaml
+++ b/bio/samtools/stats/meta.yaml
@@ -2,6 +2,7 @@ name: samtools stats
 description: Generate stats using samtools.
 authors:
   - Julian de Ruiter
+  - Filipe G. Vieira
 notes: |
   * The `extra` param allows for additional program arguments (not `-@/--threads`).
   * For more information see, http://www.htslib.org/doc/samtools-stats.html

--- a/bio/samtools/stats/test/Snakefile
+++ b/bio/samtools/stats/test/Snakefile
@@ -1,12 +1,12 @@
 rule samtools_stats:
     input:
-        "mapped/{sample}.bam"
+        "mapped/{sample}.bam",
     output:
-        "samtools_stats/{sample}.txt"
+        "samtools_stats/{sample}.txt",
     params:
-        extra="",                       # Optional: extra arguments.
-        region="xx:1000000-2000000"      # Optional: region string.
+        extra="",  # Optional: extra arguments.
+        region="xx:1000000-2000000",  # Optional: region string.
     log:
-        "logs/samtools_stats/{sample}.log"
+        "logs/samtools_stats/{sample}.log",
     wrapper:
         "master/bio/samtools/stats"

--- a/bio/samtools/stats/wrapper.py
+++ b/bio/samtools/stats/wrapper.py
@@ -7,11 +7,16 @@ __license__ = "MIT"
 
 
 from snakemake.shell import shell
+from snakemake_wrapper_utils.samtools import get_samtools_opts
 
-
+samtools_opts = get_samtools_opts(
+    snakemake, parse_write_index=False, parse_output=False, parse_output_format=False
+)
 extra = snakemake.params.get("extra", "")
 region = snakemake.params.get("region", "")
 log = snakemake.log_fmt_shell(stdout=False, stderr=True)
 
 
-shell("samtools stats {extra} {snakemake.input} {region} > {snakemake.output} {log}")
+shell(
+    "samtools stats {samtools_opts} {extra} {snakemake.input} {region} > {snakemake.output} {log}"
+)

--- a/bio/samtools/view/environment.yaml
+++ b/bio/samtools/view/environment.yaml
@@ -2,5 +2,5 @@ channels:
   - bioconda
   - conda-forge
 dependencies:
-  - samtools ==1.12
-  - snakemake-wrapper-utils ==0.2.0
+  - samtools =1.14
+  - snakemake-wrapper-utils =0.3

--- a/bio/samtools/view/meta.yaml
+++ b/bio/samtools/view/meta.yaml
@@ -1,5 +1,5 @@
 name: samtools view
-description: Convert or filter SAM/BAM. For more information see `SAMtools documentation <http://www.htslib.org/doc/samtools-view.html>`_.
+description: Convert or filter SAM/BAM.
 authors:
   - Johannes Köster
   - Filipe G. Vieira
@@ -8,5 +8,5 @@ input:
 output:
   - SAM/BAM/CRAM file
 notes: |
-  * The `extra` param allows for additional program arguments (not `-@/--threads` or `-O/--output-fmt`).
+  * The `extra` param allows for additional program arguments (not `-@/--threads`, `--write-index`, `-o` or `-O/--output-fmt`).
   * For more information see, http://www.htslib.org/doc/samtools-view.html

--- a/bio/samtools/view/meta.yaml
+++ b/bio/samtools/view/meta.yaml
@@ -7,6 +7,7 @@ input:
   - SAM/BAM/CRAM file
 output:
   - SAM/BAM/CRAM file
+  - SAM/BAM/CRAM index file (optional)
 notes: |
   * The `extra` param allows for additional program arguments (not `-@/--threads`, `--write-index`, `-o` or `-O/--output-fmt`).
   * For more information see, http://www.htslib.org/doc/samtools-view.html

--- a/bio/samtools/view/test/Snakefile
+++ b/bio/samtools/view/test/Snakefile
@@ -1,11 +1,11 @@
 rule samtools_view:
     input:
-        "{sample}.sam"
+        "{sample}.sam",
     output:
-        "{sample}.bam"
+        "{sample}.bam",
     log:
-        "{sample}.log"
+        "{sample}.log",
     params:
-        extra="" # optional params string
+        extra="",  # optional params string
     wrapper:
         "master/bio/samtools/view"

--- a/bio/samtools/view/test/Snakefile
+++ b/bio/samtools/view/test/Snakefile
@@ -2,10 +2,12 @@ rule samtools_view:
     input:
         "{sample}.sam",
     output:
-        "{sample}.bam",
+        bam="{sample}.bam",
+        idx="{sample}.bai",
     log:
         "{sample}.log",
     params:
         extra="",  # optional params string
+    threads: 2
     wrapper:
         "master/bio/samtools/view"

--- a/bio/samtools/view/wrapper.py
+++ b/bio/samtools/view/wrapper.py
@@ -7,11 +7,9 @@ __license__ = "MIT"
 from snakemake.shell import shell
 from snakemake_wrapper_utils.samtools import get_samtools_opts
 
-
 samtools_opts = get_samtools_opts(snakemake)
+extra = snakemake.params.get("extra", "")
 log = snakemake.log_fmt_shell(stdout=True, stderr=True, append=True)
 
 
-shell(
-    "samtools view {snakemake.params.extra} {samtools_opts} -o {snakemake.output[0]} {snakemake.input[0]} {log}"
-)
+shell("samtools view {samtools_opts} {extra} {snakemake.input[0]} {log}")


### PR DESCRIPTION
<!-- Ensure that the PR title follows conventional commit style (<type>: <description>)-->
<!-- Possible types are here: https://github.com/commitizen/conventional-commit-types/blob/master/index.json -->

### Description

<!-- Add a description of your PR here-->

Added samtools_wrapper_utils, some tempdirs, bumped versions, extra doc, and code clean-up.

### QC
<!-- Make sure that you can tick the boxes below. -->

For all wrappers added by this PR, I made sure that

* [x] there is a test case which covers any introduced changes,
* [x] `input:` and `output:` file paths in the resulting rule can be changed arbitrarily,
* [x] either the wrapper can only use a single core, or the example rule contains a `threads: x` statement with `x` being a reasonable default,
* [x] rule names in the test case are in [snake_case](https://en.wikipedia.org/wiki/Snake_case) and somehow tell what the rule is about or match the tools purpose or name (e.g., `map_reads` for a step that maps reads),
* [x] all `environment.yaml` specifications follow [the respective best practices](https://stackoverflow.com/a/64594513/2352071),
* [x] wherever possible, command line arguments are inferred and set automatically (e.g. based on file extensions in `input:` or `output:`),
* [x] all fields of the example rules in the `Snakefile`s and their entries are explained via comments (`input:`/`output:`/`params:` etc.),
* [x] `stderr` and/or `stdout` are logged correctly (`log:`), depending on the wrapped tool,
* [x] temporary files are either written to a unique hidden folder in the working directory, or (better) stored where the Python function `tempfile.gettempdir()` points to (see [here](https://docs.python.org/3/library/tempfile.html#tempfile.gettempdir); this also means that using any Python `tempfile` default behavior works),
* [x] the `meta.yaml` contains a link to the documentation of the respective tool or command,
* [x] `Snakefile`s pass the linting (`snakemake --lint`),
* [x] `Snakefile`s are formatted with [snakefmt](https://github.com/snakemake/snakefmt),
* [x] Python wrapper scripts are formatted with [black](https://black.readthedocs.io).
