### PR TITLE
feat: added temp dir to featurecounts

### DIFF
--- a/bio/subread/featurecounts/meta.yaml
+++ b/bio/subread/featurecounts/meta.yaml
@@ -4,6 +4,7 @@ description: >
   For more information please see `featureCounts tutorial <http://bioinf.wehi.edu.au/featureCounts/>`_, `documentation of subread <https://bioconductor.org/packages/release/bioc/vignettes/Rsubread/inst/doc/SubreadUsersGuide.pdf>`_ and commandline help.
 author:
   - Antonie Vietor
+  - Filipe G. Vieira
 input:
   - a list of .sam or .bam files
   - GTF, GFF or SAF annotation file

--- a/bio/subread/featurecounts/meta.yaml
+++ b/bio/subread/featurecounts/meta.yaml
@@ -1,7 +1,6 @@
 name: subread featureCounts
 description: >
   FeatureCounts assign mapped reads or fragments (paired-end data) to genomic features such as genes, exons and promoters.
-  For more information please see `featureCounts tutorial <http://bioinf.wehi.edu.au/featureCounts/>`_, `documentation of subread <https://bioconductor.org/packages/release/bioc/vignettes/Rsubread/inst/doc/SubreadUsersGuide.pdf>`_ and commandline help.
 author:
   - Antonie Vietor
   - Filipe G. Vieira
@@ -11,6 +10,10 @@ input:
   - optional a tab separating file that determines the sorting order and contains the chromosome names in the first column
   - optional a fasta index file
 output:
-  - .featureCounts file including read counts (tab separated)
-  - .featureCounts.summary file including summary statistics (tab separated)
-  - .featureCounts.jcounts file including count number of reads supporting each exon-exon junction (tab separated)
+  - Feature counts file including read counts (tab separated)
+  - Summary file including summary statistics (tab separated)
+  - Junction counts file including count number of reads supporting each exon-exon junction (tab separated)
+notes: |
+  * The `extra` param allows for additional program arguments.
+  * For more information see, http://subread.sourceforge.net/ and https://bioconductor.org/packages/release/bioc/vignettes/Rsubread/inst/doc/SubreadUsersGuide.pdf
+  * For a tutorial see, http://bioinf.wehi.edu.au/featureCounts/

--- a/bio/subread/featurecounts/test/Snakefile
+++ b/bio/subread/featurecounts/test/Snakefile
@@ -1,17 +1,17 @@
 rule feature_counts:
     input:
-        sam="{sample}.bam", # list of sam or bam files
+        samples="{sample}.bam", # list of sam or bam files
         annotation="annotation.gtf",
         # optional input
         # chr_names="",           # implicitly sets the -A flag
         # fasta="genome.fasta"      # implicitly sets the -G flag
     output:
         multiext("results/{sample}",
+	         "",
                  ".featureCounts",
                  ".featureCounts.summary",
                  ".featureCounts.jcounts")
-    threads:
-        2
+    threads: 2
     params:
         tmp_dir="",   # implicitly sets the --tmpDir flag
         r_path="",    # implicitly sets the --Rpath flag

--- a/bio/subread/featurecounts/test/Snakefile
+++ b/bio/subread/featurecounts/test/Snakefile
@@ -7,13 +7,11 @@ rule feature_counts:
         # fasta="genome.fasta"      # implicitly sets the -G flag
     output:
         multiext("results/{sample}",
-	         "",
-                 ".featureCounts",
-                 ".featureCounts.summary",
-                 ".featureCounts.jcounts")
+                 "",
+                 ".summary",
+                 ".jcounts")
     threads: 2
     params:
-        tmp_dir="",   # implicitly sets the --tmpDir flag
         r_path="",    # implicitly sets the --Rpath flag
         extra="-O --fracOverlap 0.2"
     log:

--- a/bio/subread/featurecounts/test/Snakefile
+++ b/bio/subread/featurecounts/test/Snakefile
@@ -15,7 +15,7 @@ rule feature_counts:
     threads: 2
     params:
         r_path="",  # implicitly sets the --Rpath flag
-        extra="-O --fracOverlap 0.2",
+        extra="-O --fracOverlap 0.2 -J",
     log:
         "logs/{sample}.log",
     wrapper:

--- a/bio/subread/featurecounts/test/Snakefile
+++ b/bio/subread/featurecounts/test/Snakefile
@@ -1,20 +1,22 @@
 rule feature_counts:
     input:
-        samples="{sample}.bam", # list of sam or bam files
+        samples="{sample}.bam",  # list of sam or bam files
         annotation="annotation.gtf",
         # optional input
         # chr_names="",           # implicitly sets the -A flag
-        # fasta="genome.fasta"      # implicitly sets the -G flag
+        # fasta="genome.fasta"    # implicitly sets the -G flag
     output:
-        multiext("results/{sample}",
-                 "",
-                 ".summary",
-                 ".jcounts")
+        multiext(
+            "results/{sample}",
+            ".featureCounts",
+            ".featureCounts.summary",
+            ".featureCounts.jcounts",
+        ),
     threads: 2
     params:
-        r_path="",    # implicitly sets the --Rpath flag
-        extra="-O --fracOverlap 0.2"
+        r_path="",  # implicitly sets the --Rpath flag
+        extra="-O --fracOverlap 0.2",
     log:
-        "logs/{sample}.log"
+        "logs/{sample}.log",
     wrapper:
         "master/bio/subread/featurecounts"

--- a/bio/subread/featurecounts/wrapper.py
+++ b/bio/subread/featurecounts/wrapper.py
@@ -3,6 +3,7 @@ __copyright__ = "Copyright 2020, Antonie Vietor"
 __email__ = "antonie.v@gmx.de"
 __license__ = "MIT"
 
+import tempfile
 from snakemake.shell import shell
 
 log = snakemake.log_fmt_shell(stdout=True, stderr=True)
@@ -11,25 +12,23 @@ extra = snakemake.params.get("extra", "")
 # optional input files and directories
 fasta = snakemake.input.get("fasta", "")
 chr_names = snakemake.input.get("chr_names", "")
-tmp_dir = snakemake.params.get("tmp_dir", "")
 r_path = snakemake.params.get("r_path", "")
 
 if fasta:
     extra += " -G {}".format(fasta)
 if chr_names:
     extra += " -A {}".format(chr_names)
-if tmp_dir:
-    extra += " --tmpDir {}".format(tmp_dir)
 if r_path:
     extra += " --Rpath {}".format(r_path)
 
-shell(
-    "(featureCounts"
-    " {extra}"
-    " -T {snakemake.threads}"
-    " -J"
-    " -a {snakemake.input.annotation}"
-    " -o {snakemake.output[0]}"
-    " {snakemake.input.sam})"
-    " {log}"
-)
+with tempfile.TemporaryDirectory() as tmpdir:    
+    shell(
+        "featureCounts"
+        " -T {snakemake.threads}"
+        " -a {snakemake.input.annotation}"
+        " {extra}"
+        " --tmpDir {tmpdir}"
+        " -o {snakemake.output[0]}"
+        " {snakemake.input.samples}"
+        " {log}"
+    )

--- a/bio/subread/featurecounts/wrapper.py
+++ b/bio/subread/featurecounts/wrapper.py
@@ -21,7 +21,7 @@ if chr_names:
 if r_path:
     extra += " --Rpath {}".format(r_path)
 
-with tempfile.TemporaryDirectory() as tmpdir:    
+with tempfile.TemporaryDirectory() as tmpdir:
     shell(
         "featureCounts"
         " -T {snakemake.threads}"


### PR DESCRIPTION
<!-- Ensure that the PR title follows conventional commit style (<type>: <description>)-->
<!-- Possible types are here: https://github.com/commitizen/conventional-commit-types/blob/master/index.json -->

### Description

<!-- Add a description of your PR here-->

### QC
<!-- Make sure that you can tick the boxes below. -->

For all wrappers added by this PR, I made sure that

* [x] there is a test case which covers any introduced changes,
* [x] `input:` and `output:` file paths in the resulting rule can be changed arbitrarily,
* [x] either the wrapper can only use a single core, or the example rule contains a `threads: x` statement with `x` being a reasonable default,
* [x] rule names in the test case are in [snake_case](https://en.wikipedia.org/wiki/Snake_case) and somehow tell what the rule is about or match the tools purpose or name (e.g., `map_reads` for a step that maps reads),
* [x] all `environment.yaml` specifications follow [the respective best practices](https://stackoverflow.com/a/64594513/2352071),
* [x] wherever possible, command line arguments are inferred and set automatically (e.g. based on file extensions in `input:` or `output:`),
* [x] all fields of the example rules in the `Snakefile`s and their entries are explained via comments (`input:`/`output:`/`params:` etc.),
* [x] `stderr` and/or `stdout` are logged correctly (`log:`), depending on the wrapped tool,
* [x] temporary files are either written to a unique hidden folder in the working directory, or (better) stored where the Python function `tempfile.gettempdir()` points to (see [here](https://docs.python.org/3/library/tempfile.html#tempfile.gettempdir); this also means that using any Python `tempfile` default behavior works),
* [x] the `meta.yaml` contains a link to the documentation of the respective tool or command,
* [x] `Snakefile`s pass the linting (`snakemake --lint`),
* [x] `Snakefile`s are formatted with [snakefmt](https://github.com/snakemake/snakefmt),
* [x] Python wrapper scripts are formatted with [black](https://black.readthedocs.io).
