### PR TITLE
fix: Nextflow profile

### DIFF
--- a/utils/nextflow/environment.yaml
+++ b/utils/nextflow/environment.yaml
@@ -2,4 +2,4 @@ channels:
   - bioconda
   - conda-forge
 dependencies:
-  - nextflow =20.10
+  - nextflow

--- a/utils/nextflow/wrapper.py
+++ b/utils/nextflow/wrapper.py
@@ -8,6 +8,7 @@ from snakemake.shell import shell
 
 revision = snakemake.params.get("revision")
 profile = snakemake.params.get("profile", [])
+extra = snakemake.params.get("extra", "")
 if isinstance(profile, str):
     profile = [profile]
 
@@ -38,4 +39,4 @@ log = snakemake.log_fmt_shell(stdout=False, stderr=True)
 args = " ".join(args)
 pipeline = snakemake.params.pipeline
 
-shell("nextflow run {pipeline} {args} {log}")
+shell("nextflow run {pipeline} {args} {extra} {log}")

--- a/utils/nextflow/wrapper.py
+++ b/utils/nextflow/wrapper.py
@@ -32,7 +32,12 @@ for name, files in snakemake.input.items():
         files = ",".join(files)
     add_parameter(name, files)
 for name, value in snakemake.params.items():
-    if name != "pipeline" and name != "revision" and name != "profile" and name != "extra":
+    if (
+        name != "pipeline"
+        and name != "revision"
+        and name != "profile"
+        and name != "extra"
+    ):
         add_parameter(name, value)
 
 log = snakemake.log_fmt_shell(stdout=False, stderr=True)

--- a/utils/nextflow/wrapper.py
+++ b/utils/nextflow/wrapper.py
@@ -31,7 +31,7 @@ for name, files in snakemake.input.items():
         files = ",".join(files)
     add_parameter(name, files)
 for name, value in snakemake.params.items():
-    if name != "pipeline" and name != "revision" name != "profile":
+    if name != "pipeline" and name != "revision" and name != "profile":
         add_parameter(name, value)
 
 log = snakemake.log_fmt_shell(stdout=False, stderr=True)

--- a/utils/nextflow/wrapper.py
+++ b/utils/nextflow/wrapper.py
@@ -32,7 +32,7 @@ for name, files in snakemake.input.items():
         files = ",".join(files)
     add_parameter(name, files)
 for name, value in snakemake.params.items():
-    if name != "pipeline" and name != "revision" and name != "profile":
+    if name != "pipeline" and name != "revision" and name != "profile" and name != "extra":
         add_parameter(name, value)
 
 log = snakemake.log_fmt_shell(stdout=False, stderr=True)

--- a/utils/nextflow/wrapper.py
+++ b/utils/nextflow/wrapper.py
@@ -31,7 +31,7 @@ for name, files in snakemake.input.items():
         files = ",".join(files)
     add_parameter(name, files)
 for name, value in snakemake.params.items():
-    if name != "pipeline" and name != "revision":
+    if name != "pipeline" and name != "revision" name != "profile":
         add_parameter(name, value)
 
 log = snakemake.log_fmt_shell(stdout=False, stderr=True)


### PR DESCRIPTION
<!-- Ensure that the PR title follows conventional commit style (<type>: <description>)-->
<!-- Possible types are here: https://github.com/commitizen/conventional-commit-types/blob/master/index.json -->

### Description

- Fixed bug where Nextflow *-profile* option was inserted also second time with double hyphens (--profile ..) to nextflow call. 
- Added snakemake *extra* parameter to pass other single hyphen options to nextflow (e.g. -resume []).
- Removed nextflow version from environment file.

All these have been tested by running nf-core/mag pipeline.

### QC
<!-- Make sure that you can tick the boxes below. -->

For all wrappers added by this PR, I made sure that

* [ ] there is a test case which covers any introduced changes,
* [ ] `input:` and `output:` file paths in the resulting rule can be changed arbitrarily,
* [ ] either the wrapper can only use a single core, or the example rule contains a `threads: x` statement with `x` being a reasonable default,
* [ ] rule names in the test case are in [snake_case](https://en.wikipedia.org/wiki/Snake_case) and somehow tell what the rule is about or match the tools purpose or name (e.g., `map_reads` for a step that maps reads),
* [ ] all `environment.yaml` specifications follow [the respective best practices](https://stackoverflow.com/a/64594513/2352071),
* [ ] wherever possible, command line arguments are inferred and set automatically (e.g. based on file extensions in `input:` or `output:`),
* [ ] all fields of the example rules in the `Snakefile`s and their entries are explained via comments (`input:`/`output:`/`params:` etc.),
* [ ] `stderr` and/or `stdout` are logged correctly (`log:`), depending on the wrapped tool,
* [ ] temporary files are either written to a unique hidden folder in the working directory, or (better) stored where the Python function `tempfile.gettempdir()` points to (see [here](https://docs.python.org/3/library/tempfile.html#tempfile.gettempdir); this also means that using any Python `tempfile` default behavior works),
* [ ] the `meta.yaml` contains a link to the documentation of the respective tool or command,
* [ ] `Snakefile`s pass the linting (`snakemake --lint`),
* [ ] `Snakefile`s are formatted with [snakefmt](https://github.com/snakemake/snakefmt),
* [ ] Python wrapper scripts are formatted with [black](https://black.readthedocs.io).
