### PR TITLE
fix: update multiqc version to 1.12

### DIFF
--- a/bio/biobambam2/bamsormadup/wrapper.py
+++ b/bio/biobambam2/bamsormadup/wrapper.py
@@ -34,7 +34,7 @@ if metrics:
 with tempfile.TemporaryDirectory() as tmpdir:
     # This folder must not exist; it is created by BamSorMaDup
     tmpdir_bamsormadup = Path(tmpdir) / "bamsormadup_{:06d}".format(
-        random.randrange(10 ** 6)
+        random.randrange(10**6)
     )
 
     shell(

--- a/bio/gatk/applybqsrspark/wrapper.py
+++ b/bio/gatk/applybqsrspark/wrapper.py
@@ -21,7 +21,7 @@ log = snakemake.log_fmt_shell(stdout=True, stderr=True)
 
 with tempfile.TemporaryDirectory() as tmpdir:
     # This folder must not exist; it is created by GATK
-    tmpdir_shards = Path(tmpdir) / "shards_{:06d}".format(random.randrange(10 ** 6))
+    tmpdir_shards = Path(tmpdir) / "shards_{:06d}".format(random.randrange(10**6))
 
     shell(
         "gatk --java-options '{java_opts}' ApplyBQSRSpark"

--- a/bio/multiqc/environment.yaml
+++ b/bio/multiqc/environment.yaml
@@ -3,4 +3,4 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - multiqc =1.11
+  - multiqc =1.12


### PR DESCRIPTION
Hi,

I've been having constant problems with this wrapper. My Snakemake execution almost always hangs in the "Solving environment step". I was supportive of merging #422 but considering MultiQC is on version 1.12, I believe it would be better to drop this pinned version. I tried creating the environment from the file as it is in this PR and it correctly installs v1.12 of MultiQC.

Ping @fgvieira @thomasbtf, would you agree?

Thank you for any assistance you can provide.

Cheers,
Vini

Summary of changes:

  - Remove '= 1.11' from multiqc environment yaml

MultiQC has been updated to 1.12 and pinning v1.11 is hampering environment solving.

@thomasbtf @fgvieira would you be okay with this?

<!-- Ensure that the PR title follows conventional commit style (<type>: <description>)-->
<!-- Possible types are here: https://github.com/commitizen/conventional-commit-types/blob/master/index.json -->