### PR TITLE
fix: issue 339

### DIFF
--- a/bio/picard/collectmultiplemetrics/meta.yaml
+++ b/bio/picard/collectmultiplemetrics/meta.yaml
@@ -52,6 +52,7 @@ description: >
 authors:
   - David Laehnemann
   - Antonie Vietor
+  - Filipe G. Vieira
 input:
   - BAM file (.bam)
   - FASTA reference sequence file (.fasta or .fa)

--- a/bio/picard/collectmultiplemetrics/wrapper.py
+++ b/bio/picard/collectmultiplemetrics/wrapper.py
@@ -47,7 +47,7 @@ for file in snakemake.output:
             "Unknown type of metrics file requested, for possible metrics files, see https://snakemake-wrappers.readthedocs.io/en/stable/wrappers/picard/collectmultiplemetrics.html"
         )
 
-programs = " --PROGRAM " + " --PROGRAM ".join(progs)
+programs = " PROGRAM=null --PROGRAM " + " --PROGRAM ".join(progs)
 
 out = str(snakemake.wildcards.sample)  # as default
 output_file = str(snakemake.output[0])

--- a/bio/picard/collectmultiplemetrics/wrapper.py
+++ b/bio/picard/collectmultiplemetrics/wrapper.py
@@ -47,7 +47,7 @@ for file in snakemake.output:
             "Unknown type of metrics file requested, for possible metrics files, see https://snakemake-wrappers.readthedocs.io/en/stable/wrappers/picard/collectmultiplemetrics.html"
         )
 
-programs = " PROGRAM=null --PROGRAM " + " --PROGRAM ".join(progs)
+programs = " --PROGRAM null --PROGRAM " + " --PROGRAM ".join(progs)
 
 out = str(snakemake.wildcards.sample)  # as default
 output_file = str(snakemake.output[0])


### PR DESCRIPTION
<!-- Ensure that the PR title follows conventional commit style (<type>: <description>)-->
<!-- Possible types are here: https://github.com/commitizen/conventional-commit-types/blob/master/index.json -->

### Description

<!-- Add a description of your PR here-->
Fixing issue #339 .

### QC
<!-- Make sure that you can tick the boxes below. -->

For all wrappers added by this PR, I made sure that

* [x] there is a test case which covers any introduced changes,
* [x] `input:` and `output:` file paths in the resulting rule can be changed arbitrarily,
* [x] either the wrapper can only use a single core, or the example rule contains a `threads: x` statement with `x` being a reasonable default,
* [x] rule names in the test case are in [snake_case](https://en.wikipedia.org/wiki/Snake_case) and somehow tell what the rule is about or match the tools purpose or name (e.g., `map_reads` for a step that maps reads),
* [x] all `environment.yaml` specifications follow [the respective best practices](https://stackoverflow.com/a/64594513/2352071),
* [x] wherever possible, command line arguments are inferred and set automatically (e.g. based on file extensions in `input:` or `output:`),
* [x] all fields of the example rules in the `Snakefile`s and their entries are explained via comments (`input:`/`output:`/`params:` etc.),
* [x] `stderr` and/or `stdout` are logged correctly (`log:`), depending on the wrapped tool,
* [x] temporary files are either written to a unique hidden folder in the working directory, or (better) stored where the Python function `tempfile.gettempdir()` points to (see [here](https://docs.python.org/3/library/tempfile.html#tempfile.gettempdir); this also means that using any Python `tempfile` default behavior works),
* [x] the `meta.yaml` contains a link to the documentation of the respective tool or command,
* [x] `Snakefile`s pass the linting (`snakemake --lint`),
* [x] `Snakefile`s are formatted with [snakefmt](https://github.com/snakemake/snakefmt),
* [x] Python wrapper scripts are formatted with [black](https://black.readthedocs.io).
