### PR TITLE
feat: added wrapper-utils, and tempdirs

### DIFF
--- a/bio/bcftools/call/environment.yaml
+++ b/bio/bcftools/call/environment.yaml
@@ -3,4 +3,4 @@ channels:
   - conda-forge
 dependencies:
   - bcftools =1.14
-  - snakemake-wrapper-utils =0.3
+  - snakemake-wrapper-utils =0.4

--- a/bio/bcftools/call/environment.yaml
+++ b/bio/bcftools/call/environment.yaml
@@ -2,4 +2,5 @@ channels:
   - bioconda
   - conda-forge
 dependencies:
-  - bcftools =1.11
+  - bcftools =1.14
+  - snakemake-wrapper-utils =0.3

--- a/bio/bcftools/call/meta.yaml
+++ b/bio/bcftools/call/meta.yaml
@@ -1,5 +1,10 @@
 name: bcftools call
-description: Call variants with `bcftools call <https://samtools.github.io/bcftools/bcftools.html#call>`_.
+description: Call variants with `bcftools call`.
+url: http://www.htslib.org/doc/bcftools.html#call
 authors:
   - Johannes Köster
   - Michael Hall
+  - Filipe G. Vieira
+notes: |
+  * The `uncompressed_bcf` param allows to specify that a BCF output should be uncompressed (ignored otherwise).
+  * The `extra` param allows for additional program arguments (not `--threads`, `-o/--output`, or `-O/--output-type`).

--- a/bio/bcftools/call/test/Snakefile
+++ b/bio/bcftools/call/test/Snakefile
@@ -4,6 +4,7 @@ rule bcftools_call:
     output:
         calls="{sample}.calls.bcf",
     params:
+        uncompressed_bcf=False,
         caller="-m",  # valid options include -c/--consensus-caller or -m/--multiallelic-caller
         extra="--ploidy 1 --prior 0.001",
     log:

--- a/bio/bcftools/call/test/Snakefile
+++ b/bio/bcftools/call/test/Snakefile
@@ -4,8 +4,8 @@ rule bcftools_call:
     output:
         calls="{sample}.calls.bcf",
     params:
-        caller="-m", # valid options include -c/--consensus-caller or -m/--multiallelic-caller
-        options="--ploidy 1 --prior 0.001",
+        caller="-m",  # valid options include -c/--consensus-caller or -m/--multiallelic-caller
+        extra="--ploidy 1 --prior 0.001",
     log:
         "logs/bcftools_call/{sample}.log",
     wrapper:

--- a/bio/bcftools/call/wrapper.py
+++ b/bio/bcftools/call/wrapper.py
@@ -5,7 +5,11 @@ __license__ = "MIT"
 
 
 from snakemake.shell import shell
+from snakemake_wrapper_utils.bcftools import get_bcftools_opts
 
+
+bcftools_opts = get_bcftools_opts(snakemake, parse_memory=False)
+extra = snakemake.params.get("extra", "")
 log = snakemake.log_fmt_shell(stdout=True, stderr=True)
 
 
@@ -22,10 +26,12 @@ if caller_opt.strip() not in valid_caller_opts:
         "-c/--consensus-caller as caller option."
     )
 
-options = snakemake.params.get("options", "")
 
 shell(
-    "bcftools call {options} {caller_opt} --threads {snakemake.threads} "
-    "-o {snakemake.output.calls} {snakemake.input.pileup} "
-    "{log}"
+    "bcftools call"
+    " {bcftools_opt}"
+    " {caller_opt}"
+    " {extra}"
+    " {snakemake.input[0]}"
+    " {log}"
 )

--- a/bio/bcftools/call/wrapper.py
+++ b/bio/bcftools/call/wrapper.py
@@ -8,7 +8,7 @@ from snakemake.shell import shell
 from snakemake_wrapper_utils.bcftools import get_bcftools_opts
 
 
-bcftools_opts = get_bcftools_opts(snakemake, parse_memory=False)
+bcftools_opts = get_bcftools_opts(snakemake, parse_ref=False, parse_memory=False)
 extra = snakemake.params.get("extra", "")
 log = snakemake.log_fmt_shell(stdout=True, stderr=True)
 
@@ -29,7 +29,7 @@ if caller_opt.strip() not in valid_caller_opts:
 
 shell(
     "bcftools call"
-    " {bcftools_opt}"
+    " {bcftools_opts}"
     " {caller_opt}"
     " {extra}"
     " {snakemake.input[0]}"

--- a/bio/bcftools/concat/environment.yaml
+++ b/bio/bcftools/concat/environment.yaml
@@ -3,4 +3,4 @@ channels:
   - conda-forge
 dependencies:
   - bcftools =1.14
-  - snakemake-wrapper-utils =0.3
+  - snakemake-wrapper-utils =0.4

--- a/bio/bcftools/concat/environment.yaml
+++ b/bio/bcftools/concat/environment.yaml
@@ -2,5 +2,5 @@ channels:
   - bioconda
   - conda-forge
 dependencies:
-  - bcftools =1.12
-  - snakemake-wrapper-utils ==0.2.0
+  - bcftools =1.14
+  - snakemake-wrapper-utils =0.3

--- a/bio/bcftools/concat/meta.yaml
+++ b/bio/bcftools/concat/meta.yaml
@@ -1,5 +1,6 @@
 name: bcftools concat
-description: Concatenate vcf/bcf files with bcftools. For more information see `BCFtools documentation <https://www.htslib.org/doc/bcftools.html#concat>`_.
+description: Concatenate vcf/bcf files with bcftools.
+url: http://www.htslib.org/doc/bcftools.html#concat
 authors:
   - Johannes Köster
   - Filipe G. Vieira
@@ -9,5 +10,4 @@ output:
   - Concatenated VCF/BCF file
 notes: |
   * The `uncompressed_bcf` param allows to specify that a BCF output should be uncompressed (ignored otherwise).
-  * The `extra` param alllows for additional program arguments (not `--threads, `-O/--output-type`, `-m/--max-mem`, or `-T/--temp-dir`).
-  * For more information see, https://samtools.github.io/bcftools/bcftools.html
+  * The `extra` param alllows for additional program arguments (not `--threads`, `-o/--output`, or `-O/--output-type`).

--- a/bio/bcftools/concat/wrapper.py
+++ b/bio/bcftools/concat/wrapper.py
@@ -8,7 +8,7 @@ from snakemake.shell import shell
 from snakemake_wrapper_utils.bcftools import get_bcftools_opts
 
 
-bcftools_opts = get_bcftools_opts(snakemake, parse_memory=False)
+bcftools_opts = get_bcftools_opts(snakemake, parse_ref=False, parse_memory=False)
 extra = snakemake.params.get("extra", "")
 log = snakemake.log_fmt_shell(stdout=True, stderr=True)
 

--- a/bio/bcftools/concat/wrapper.py
+++ b/bio/bcftools/concat/wrapper.py
@@ -4,17 +4,13 @@ __email__ = "koester@jimmy.harvard.edu"
 __license__ = "MIT"
 
 
-from os import path
 from snakemake.shell import shell
 from snakemake_wrapper_utils.bcftools import get_bcftools_opts
 
 
 bcftools_opts = get_bcftools_opts(snakemake, parse_memory=False)
+extra = snakemake.params.get("extra", "")
 log = snakemake.log_fmt_shell(stdout=True, stderr=True)
 
 
-shell(
-    "bcftools concat {snakemake.params.extra} {bcftools_opts} -o {snakemake.output[0]} "
-    "{snakemake.input.calls} "
-    "{log}"
-)
+shell("bcftools concat {bcftools_opts} {extra} {snakemake.input[0]} {log}")

--- a/bio/bcftools/filter/environment.yaml
+++ b/bio/bcftools/filter/environment.yaml
@@ -3,4 +3,4 @@ channels:
   - conda-forge
 dependencies:
   - bcftools =1.14
-  - snakemake-wrapper-utils =0.3
+  - snakemake-wrapper-utils =0.4

--- a/bio/bcftools/filter/environment.yaml
+++ b/bio/bcftools/filter/environment.yaml
@@ -1,7 +1,6 @@
 channels:
   - bioconda
   - conda-forge
-  - defaults
 dependencies:
-  - bcftools ==1.12
-  - snakemake-wrapper-utils ==0.2
+  - bcftools =1.14
+  - snakemake-wrapper-utils =0.3

--- a/bio/bcftools/filter/meta.yaml
+++ b/bio/bcftools/filter/meta.yaml
@@ -1,14 +1,14 @@
 name: bcftools filter
 description: filter vcf/bcf file.
+url: http://www.htslib.org/doc/bcftools.html#filter
 authors:
   - Patrik Smeds
   - Nikos Tsardakas Renhuldt
+  - Filipe G. Vieira
 input:
   - VCF/BCF file
 output:
   - Filtered VCF/BCF file
 notes: |
   * The `uncompressed_bcf` param allows to specify that a BCF output should be uncompressed (ignored otherwise).
-  * The `bcftools_use_mem` param controls whether to pass the resources.mem_mb to bcftools
-  * The `extra` param allows for additional program arguments (not `--threads, `-O/--output-type`, `-m/--max-mem`, or `-T/--temp-dir`).
-  * For more information see, https://samtools.github.io/bcftools/bcftools.html
+  * The `extra` param allows for additional program arguments (not `--threads`, `-o/--output`, or `-O/--output-type`).

--- a/bio/bcftools/filter/wrapper.py
+++ b/bio/bcftools/filter/wrapper.py
@@ -8,7 +8,7 @@ from snakemake.shell import shell
 from snakemake_wrapper_utils.bcftools import get_bcftools_opts
 
 
-bcftools_opts = get_bcftools_opts(snakemake, parse_memory=False)
+bcftools_opts = get_bcftools_opts(snakemake, parse_ref=False, parse_memory=False)
 extra = snakemake.params.get("extra", "")
 log = snakemake.log_fmt_shell(stdout=False, stderr=True)
 filter = snakemake.params.get("filter", "")

--- a/bio/bcftools/filter/wrapper.py
+++ b/bio/bcftools/filter/wrapper.py
@@ -7,18 +7,22 @@ __license__ = "MIT"
 from snakemake.shell import shell
 from snakemake_wrapper_utils.bcftools import get_bcftools_opts
 
+
 bcftools_opts = get_bcftools_opts(snakemake, parse_memory=False)
+extra = snakemake.params.get("extra", "")
 log = snakemake.log_fmt_shell(stdout=False, stderr=True)
+filter = snakemake.params.get("filter", "")
+
 
 if len(snakemake.output) > 1:
     raise Exception("Only one output file expected, got: " + str(len(snakemake.output)))
 
-filter = snakemake.params.get("filter", "")
-extra = snakemake.params.get("extra", "")
 
 shell(
-    "bcftools filter {filter} {extra} {snakemake.input[0]} "
-    "{bcftools_opts} "
-    "-o {snakemake.output[0]} "
-    "{log}"
+    "bcftools filter"
+    " {bcftools_opts}"
+    " {filter}"
+    " {extra}"
+    " {snakemake.input[0]}"
+    " {log}"
 )

--- a/bio/bcftools/index/environment.yaml
+++ b/bio/bcftools/index/environment.yaml
@@ -3,4 +3,4 @@ channels:
   - conda-forge
 dependencies:
   - bcftools =1.14
-  - snakemake-wrapper-utils =0.3
+  - snakemake-wrapper-utils =0.4

--- a/bio/bcftools/index/environment.yaml
+++ b/bio/bcftools/index/environment.yaml
@@ -2,4 +2,5 @@ channels:
   - bioconda
   - conda-forge
 dependencies:
-  - bcftools =1.11
+  - bcftools =1.14
+  - snakemake-wrapper-utils =0.3

--- a/bio/bcftools/index/meta.yaml
+++ b/bio/bcftools/index/meta.yaml
@@ -1,4 +1,8 @@
 name: bcftools index
-description: Index vcf/bcf file. For more information see `BCFtools documentation <https://www.htslib.org/doc/bcftools.html#index>`_.
+description: Index vcf/bcf file.
+url: http://www.htslib.org/doc/bcftools.html#index
 authors:
   - Jan Forster
+  - Filipe G. Vieira
+notes: |
+  * The `extra` param allows for additional program arguments (not `--threads`, `-o/--output`).

--- a/bio/bcftools/index/test/Snakefile
+++ b/bio/bcftools/index/test/Snakefile
@@ -3,6 +3,8 @@ rule bcftools_index:
         "a.bcf",
     output:
         "a.bcf.csi",
+    log:
+        "index/a.log",
     params:
         extra="",  # optional parameters for bcftools index
     wrapper:

--- a/bio/bcftools/index/test/Snakefile
+++ b/bio/bcftools/index/test/Snakefile
@@ -1,9 +1,9 @@
 rule bcftools_index:
     input:
-        "a.bcf"
+        "a.bcf",
     output:
-        "a.bcf.csi"
+        "a.bcf.csi",
     params:
-        extra=""  # optional parameters for bcftools index
+        extra="",  # optional parameters for bcftools index
     wrapper:
         "master/bio/bcftools/index"

--- a/bio/bcftools/index/wrapper.py
+++ b/bio/bcftools/index/wrapper.py
@@ -9,10 +9,10 @@ from snakemake_wrapper_utils.bcftools import get_bcftools_opts
 
 
 bcftools_opts = get_bcftools_opts(
-    snakemake, parse_output_format=False, parse_memory=False
+    snakemake, parse_ref=False, parse_output_format=False, parse_memory=False
 )
 extra = snakemake.params.get("extra", "")
 log = snakemake.log_fmt_shell(stdout=True, stderr=True)
 
 
-shell("bcftools index {bcftools_opt} {extra} {snakemake.input[0]} {log}")
+shell("bcftools index {bcftools_opts} {extra} {snakemake.input[0]} {log}")

--- a/bio/bcftools/index/wrapper.py
+++ b/bio/bcftools/index/wrapper.py
@@ -15,4 +15,17 @@ extra = snakemake.params.get("extra", "")
 log = snakemake.log_fmt_shell(stdout=True, stderr=True)
 
 
+if "--tbi" in extra or "--csi" in extra:
+    raise ValueError(
+        "You have specified index format (`--tbi/--csi`) in `params.extra`; this is automatically infered from the first output file."
+    )
+
+if snakemake.output[0].endswith(".tbi"):
+    extra += " --tbi"
+elif snakemake.output[0].endswith(".csi"):
+    extra += " --csi"
+else:
+    raise ValueError("invalid index file format ('.tbi', '.csi').")
+
+
 shell("bcftools index {bcftools_opts} {extra} {snakemake.input[0]} {log}")

--- a/bio/bcftools/index/wrapper.py
+++ b/bio/bcftools/index/wrapper.py
@@ -5,10 +5,14 @@ __license__ = "MIT"
 
 
 from snakemake.shell import shell
+from snakemake_wrapper_utils.bcftools import get_bcftools_opts
 
+
+bcftools_opts = get_bcftools_opts(
+    snakemake, parse_output_format=False, parse_memory=False
+)
+extra = snakemake.params.get("extra", "")
 log = snakemake.log_fmt_shell(stdout=True, stderr=True)
 
-## Extract arguments
-extra = snakemake.params.get("extra", "")
 
-shell("bcftools index {extra} {snakemake.input[0]} {log}")
+shell("bcftools index {bcftools_opt} {extra} {snakemake.input[0]} {log}")

--- a/bio/bcftools/merge/environment.yaml
+++ b/bio/bcftools/merge/environment.yaml
@@ -3,4 +3,4 @@ channels:
   - conda-forge
 dependencies:
   - bcftools =1.14
-  - snakemake-wrapper-utils =0.3
+  - snakemake-wrapper-utils =0.4

--- a/bio/bcftools/merge/environment.yaml
+++ b/bio/bcftools/merge/environment.yaml
@@ -2,4 +2,5 @@ channels:
   - bioconda
   - conda-forge
 dependencies:
-  - bcftools =1.11
+  - bcftools =1.14
+  - snakemake-wrapper-utils =0.3

--- a/bio/bcftools/merge/meta.yaml
+++ b/bio/bcftools/merge/meta.yaml
@@ -1,4 +1,9 @@
 name: bcftools merge
-description: Merge vcf/bcf files with bcftools. For more information see `BCFtools documentation <https://www.htslib.org/doc/bcftools.html#merge>`_.
+description: Merge vcf/bcf files with bcftools.
+url: http://www.htslib.org/doc/bcftools.html#merge
 authors:
   - Patrik Smeds
+  - Filipe G. Vieira
+notes: |
+  * The `uncompressed_bcf` param allows to specify that a BCF output should be uncompressed (ignored otherwise).
+  * The `extra` param allows for additional program arguments (not `--threads`, `-o/--output`, or `-O/--output-type`).

--- a/bio/bcftools/merge/test/Snakefile
+++ b/bio/bcftools/merge/test/Snakefile
@@ -4,6 +4,7 @@ rule bcftools_merge:
     output:
         "all.bcf",
     params:
+        uncompressed_bcf=False,
         extra="",  # optional parameters for bcftools concat (except -o)
     wrapper:
         "master/bio/bcftools/merge"

--- a/bio/bcftools/merge/test/Snakefile
+++ b/bio/bcftools/merge/test/Snakefile
@@ -3,6 +3,8 @@ rule bcftools_merge:
         calls=["a.bcf", "b.bcf"],
     output:
         "all.bcf",
+    log:
+        "all.log"
     params:
         uncompressed_bcf=False,
         extra="",  # optional parameters for bcftools concat (except -o)

--- a/bio/bcftools/merge/test/Snakefile
+++ b/bio/bcftools/merge/test/Snakefile
@@ -1,9 +1,9 @@
 rule bcftools_merge:
     input:
-        calls=["a.bcf", "b.bcf"]
+        calls=["a.bcf", "b.bcf"],
     output:
-        "all.bcf"
+        "all.bcf",
     params:
-        ""  # optional parameters for bcftools concat (except -o)
+        extra="",  # optional parameters for bcftools concat (except -o)
     wrapper:
         "master/bio/bcftools/merge"

--- a/bio/bcftools/merge/wrapper.py
+++ b/bio/bcftools/merge/wrapper.py
@@ -8,8 +8,8 @@ from snakemake.shell import shell
 from snakemake_wrapper_utils.bcftools import get_bcftools_opts
 
 
-bcftools_opts = get_bcftools_opts(snakemake, parse_memory=False)
+bcftools_opts = get_bcftools_opts(snakemake, parse_ref=False, parse_memory=False)
 extra = snakemake.params.get("extra", "")
 log = snakemake.log_fmt_shell(stdout=True, stderr=True)
 
-shell("bcftools merge {bcftools_opt} {extra} {snakemake.input[0]} {log}")
+shell("bcftools merge {bcftools_opts} {extra} {snakemake.input[0]} {log}")

--- a/bio/bcftools/merge/wrapper.py
+++ b/bio/bcftools/merge/wrapper.py
@@ -5,11 +5,11 @@ __license__ = "MIT"
 
 
 from snakemake.shell import shell
+from snakemake_wrapper_utils.bcftools import get_bcftools_opts
 
+
+bcftools_opts = get_bcftools_opts(snakemake, parse_memory=False)
+extra = snakemake.params.get("extra", "")
 log = snakemake.log_fmt_shell(stdout=True, stderr=True)
 
-shell(
-    "bcftools merge {snakemake.params} -o {snakemake.output[0]} "
-    "{snakemake.input.calls} "
-    "{log}"
-)
+shell("bcftools merge {bcftools_opt} {extra} {snakemake.input[0]} {log}")

--- a/bio/bcftools/merge/wrapper.py
+++ b/bio/bcftools/merge/wrapper.py
@@ -12,4 +12,4 @@ bcftools_opts = get_bcftools_opts(snakemake, parse_ref=False, parse_memory=False
 extra = snakemake.params.get("extra", "")
 log = snakemake.log_fmt_shell(stdout=True, stderr=True)
 
-shell("bcftools merge {bcftools_opts} {extra} {snakemake.input[0]} {log}")
+shell("bcftools merge {bcftools_opts} {extra} {snakemake.input} {log}")

--- a/bio/bcftools/mpileup/environment.yaml
+++ b/bio/bcftools/mpileup/environment.yaml
@@ -3,4 +3,4 @@ channels:
   - conda-forge
 dependencies:
   - bcftools =1.14
-  - snakemake-wrapper-utils =0.3
+  - snakemake-wrapper-utils =0.4

--- a/bio/bcftools/mpileup/environment.yaml
+++ b/bio/bcftools/mpileup/environment.yaml
@@ -2,4 +2,5 @@ channels:
   - bioconda
   - conda-forge
 dependencies:
-  - bcftools =1.11
+  - bcftools =1.14
+  - snakemake-wrapper-utils =0.3

--- a/bio/bcftools/mpileup/meta.yaml
+++ b/bio/bcftools/mpileup/meta.yaml
@@ -6,4 +6,4 @@ authors:
   - Filipe G. Vieira
 notes: |
   * The `uncompressed_bcf` param allows to specify that a BCF output should be uncompressed (ignored otherwise).
-  * The `extra` param allows for additional program arguments (not `--threads`, `-o/--output`, or `-O/--output-type`).
+  * The `extra` param allows for additional program arguments (not `--threads`, `-f/--fasta-ref`, `-o/--output`, or `-O/--output-type`).

--- a/bio/bcftools/mpileup/meta.yaml
+++ b/bio/bcftools/mpileup/meta.yaml
@@ -1,4 +1,9 @@
 name: bcftools mpileup
-description: Generate VCF or BCF containing genotype likelihoods for one or multiple alignment (BAM or CRAM) files with `bcftools mpileup <https://samtools.github.io/bcftools/bcftools.html#mpileup>`_.
+description: Generate VCF or BCF containing genotype likelihoods for one or multiple alignment (BAM or CRAM) files.
+url: http://www.htslib.org/doc/bcftools.html#mpileup
 authors:
   - Michael Hall
+  - Filipe G. Vieira
+notes: |
+  * The `uncompressed_bcf` param allows to specify that a BCF output should be uncompressed (ignored otherwise).
+  * The `extra` param allows for additional program arguments (not `--threads`, `-o/--output`, or `-O/--output-type`).

--- a/bio/bcftools/mpileup/test/Snakefile
+++ b/bio/bcftools/mpileup/test/Snakefile
@@ -1,12 +1,12 @@
 rule bcftools_mpileup:
     input:
         index="genome.fasta.fai",
-        ref="genome.fasta", # this can be left out if --no-reference is in options
+        ref="genome.fasta",  # this can be left out if --no-reference is in options
         alignments="mapped/{sample}.bam",
     output:
         pileup="pileups/{sample}.pileup.bcf",
     params:
-        options="--max-depth 100 --min-BQ 15",
+        extra="--max-depth 100 --min-BQ 15",
     log:
         "logs/bcftools_mpileup/{sample}.log",
     wrapper:

--- a/bio/bcftools/mpileup/test/Snakefile
+++ b/bio/bcftools/mpileup/test/Snakefile
@@ -1,8 +1,8 @@
 rule bcftools_mpileup:
     input:
-        index="genome.fasta.fai",
-        ref="genome.fasta",  # this can be left out if --no-reference is in options
         alignments="mapped/{sample}.bam",
+        ref="genome.fasta",  # this can be left out if --no-reference is in options
+        index="genome.fasta.fai",
     output:
         pileup="pileups/{sample}.pileup.bcf",
     params:

--- a/bio/bcftools/mpileup/test/Snakefile
+++ b/bio/bcftools/mpileup/test/Snakefile
@@ -6,6 +6,7 @@ rule bcftools_mpileup:
     output:
         pileup="pileups/{sample}.pileup.bcf",
     params:
+        uncompressed_bcf=False,
         extra="--max-depth 100 --min-BQ 15",
     log:
         "logs/bcftools_mpileup/{sample}.log",

--- a/bio/bcftools/mpileup/wrapper.py
+++ b/bio/bcftools/mpileup/wrapper.py
@@ -5,7 +5,11 @@ __license__ = "MIT"
 
 
 from snakemake.shell import shell
+from snakemake_wrapper_utils.bcftools import get_bcftools_opts
 
+
+bcftools_opts = get_bcftools_opts(snakemake, parse_memory=False)
+extra = snakemake.params.get("extra", "")
 log = snakemake.log_fmt_shell(stdout=True, stderr=True)
 
 
@@ -13,21 +17,15 @@ class MissingReferenceError(Exception):
     pass
 
 
-options = snakemake.params.get("options", "")
-
-# determine if a fasta reference is provided or not and add to options
-if "--no-reference" not in options:
+# determine if a fasta reference is provided or not and add to extra
+if "--no-reference" not in extra:
     ref = snakemake.input.get("ref", "")
     if not ref:
         raise MissingReferenceError(
             "The --no-reference option was not given, but no fasta reference was "
             "provided."
         )
-    options += " --fasta-ref {}".format(ref)
+    extra += f" --fasta-ref {ref}"
 
-shell(
-    "bcftools mpileup {options} --threads {snakemake.threads} "
-    "--output {snakemake.output.pileup} "
-    "{snakemake.input.alignments} "
-    "{log}"
-)
+
+shell("bcftools mpileup {extra} {snakemake.input[0]} {log}")

--- a/bio/bcftools/mpileup/wrapper.py
+++ b/bio/bcftools/mpileup/wrapper.py
@@ -9,7 +9,9 @@ from snakemake_wrapper_utils.bcftools import get_bcftools_opts
 
 
 extra = snakemake.params.get("extra", "")
-bcftools_opts = get_bcftools_opts(snakemake, parse_ref=("--no-reference" not in extra), parse_memory=False)
+bcftools_opts = get_bcftools_opts(
+    snakemake, parse_ref=("--no-reference" not in extra), parse_memory=False
+)
 log = snakemake.log_fmt_shell(stdout=True, stderr=True)
 
 

--- a/bio/bcftools/mpileup/wrapper.py
+++ b/bio/bcftools/mpileup/wrapper.py
@@ -8,8 +8,8 @@ from snakemake.shell import shell
 from snakemake_wrapper_utils.bcftools import get_bcftools_opts
 
 
-bcftools_opts = get_bcftools_opts(snakemake, parse_memory=False)
 extra = snakemake.params.get("extra", "")
+bcftools_opts = get_bcftools_opts(snakemake, parse_ref=("--no-reference" not in extra), parse_memory=False)
 log = snakemake.log_fmt_shell(stdout=True, stderr=True)
 
 
@@ -17,15 +17,4 @@ class MissingReferenceError(Exception):
     pass
 
 
-# determine if a fasta reference is provided or not and add to extra
-if "--no-reference" not in extra:
-    ref = snakemake.input.get("ref", "")
-    if not ref:
-        raise MissingReferenceError(
-            "The --no-reference option was not given, but no fasta reference was "
-            "provided."
-        )
-    extra += f" --fasta-ref {ref}"
-
-
-shell("bcftools mpileup {extra} {snakemake.input[0]} {log}")
+shell("bcftools mpileup {bcftools_opts} {extra} {snakemake.input[0]} {log}")

--- a/bio/bcftools/norm/environment.yaml
+++ b/bio/bcftools/norm/environment.yaml
@@ -3,4 +3,4 @@ channels:
   - conda-forge
 dependencies:
   - bcftools =1.14
-  - snakemake-wrapper-utils =0.3
+  - snakemake-wrapper-utils =0.4

--- a/bio/bcftools/norm/environment.yaml
+++ b/bio/bcftools/norm/environment.yaml
@@ -2,5 +2,5 @@ channels:
   - bioconda
   - conda-forge
 dependencies:
-  - bcftools =1.11
-  - snakemake-wrapper-utils =0.2
+  - bcftools =1.14
+  - snakemake-wrapper-utils =0.3

--- a/bio/bcftools/norm/meta.yaml
+++ b/bio/bcftools/norm/meta.yaml
@@ -6,4 +6,4 @@ authors:
   - Filipe G. Vieira
 notes: |
   * The `uncompressed_bcf` param allows to specify that a BCF output should be uncompressed (ignored otherwise).
-  * The `extra` param allows for additional program arguments (not `--threads`, `-o/--output`, or `-O/--output-type`).
+  * The `extra` param allows for additional program arguments (not `--threads`, `-f/--fasta-ref`, `-o/--output`, or `-O/--output-type`).

--- a/bio/bcftools/norm/meta.yaml
+++ b/bio/bcftools/norm/meta.yaml
@@ -1,5 +1,9 @@
 name: bcftools norm
-description: Left-align and normalize indels, check if REF alleles match the reference, split multiallelic sites into multiple rows; recover multiallelics from multiple rows. For more information see `BCFtools documentation <https://www.htslib.org/doc/bcftools.html#norm>`_.
+description: Left-align and normalize indels, check if REF alleles match the reference, split multiallelic sites into multiple rows; recover multiallelics from multiple rows.
+url: http://www.htslib.org/doc/bcftools.html#norm
 authors:
   - Dayne Filer
   - Filipe G. Vieira
+notes: |
+  * The `uncompressed_bcf` param allows to specify that a BCF output should be uncompressed (ignored otherwise).
+  * The `extra` param allows for additional program arguments (not `--threads`, `-o/--output`, or `-O/--output-type`).

--- a/bio/bcftools/norm/test/Snakefile
+++ b/bio/bcftools/norm/test/Snakefile
@@ -6,6 +6,7 @@ rule norm_vcf:
     log:
         "{prefix}.norm.log",
     params:
+        #        uncompressed_bcf=False,
         extra="--rm-dup none",  # optional
     wrapper:
         "master/bio/bcftools/norm"

--- a/bio/bcftools/norm/wrapper.py
+++ b/bio/bcftools/norm/wrapper.py
@@ -7,11 +7,9 @@ __license__ = "MIT"
 from snakemake.shell import shell
 from snakemake_wrapper_utils.bcftools import get_bcftools_opts
 
-bcftools_opts = get_bcftools_opts(snakemake, parse_memory=False, parse_temp_dir=False)
+bcftools_opts = get_bcftools_opts(snakemake, parse_memory=False)
 extra = snakemake.params.get("extra", "")
 log = snakemake.log_fmt_shell(stdout=True, stderr=True)
 
 
-shell(
-    "bcftools norm {bcftools_opts} {extra} {snakemake.input[0]} -o {snakemake.output[0]} {log}"
-)
+shell("bcftools norm {bcftools_opts} {extra} {snakemake.input[0]} {log}")

--- a/bio/bcftools/reheader/environment.yaml
+++ b/bio/bcftools/reheader/environment.yaml
@@ -3,4 +3,4 @@ channels:
   - conda-forge
 dependencies:
   - bcftools =1.14
-  - snakemake-wrapper-utils =0.3
+  - snakemake-wrapper-utils =0.4

--- a/bio/bcftools/reheader/environment.yaml
+++ b/bio/bcftools/reheader/environment.yaml
@@ -2,4 +2,5 @@ channels:
   - bioconda
   - conda-forge
 dependencies:
-  - bcftools =1.11
+  - bcftools =1.14
+  - snakemake-wrapper-utils =0.3

--- a/bio/bcftools/reheader/meta.yaml
+++ b/bio/bcftools/reheader/meta.yaml
@@ -1,4 +1,9 @@
 name: bcftools reheader
-description: Change header or sample names of vcf/bcf file. For more information see `BCFtools documentation <https://www.htslib.org/doc/bcftools.html#reheader>`_.
+description: Change header or sample names of vcf/bcf file.
+url: http://www.htslib.org/doc/bcftools.html#reheader
 authors:
   - Jan Forster
+  - Filipe G. Vieira
+notes: |
+  * The `uncompressed_bcf` param allows to specify that a BCF output should be uncompressed (ignored otherwise).
+  * The `extra` param allows for additional program arguments (not `--threads`, `-o/--output`, `-O/--output-type`, or `-T/--temp-prefix`).

--- a/bio/bcftools/reheader/test/Snakefile
+++ b/bio/bcftools/reheader/test/Snakefile
@@ -8,6 +8,7 @@ rule bcftools_reheader:
     output:
         "a.reheader.bcf",
     params:
+        uncompressed_bcf=False,
         extra="",  # optional parameters for bcftools reheader
         view_extra="",  # optional parameters for bcftools view
     wrapper:

--- a/bio/bcftools/reheader/test/Snakefile
+++ b/bio/bcftools/reheader/test/Snakefile
@@ -13,5 +13,6 @@ rule bcftools_reheader:
         uncompressed_bcf=False,
         extra="",  # optional parameters for bcftools reheader
         view_extra="",  # optional parameters for bcftools view
+    threads: 2
     wrapper:
         "master/bio/bcftools/reheader"

--- a/bio/bcftools/reheader/test/Snakefile
+++ b/bio/bcftools/reheader/test/Snakefile
@@ -4,11 +4,11 @@ rule bcftools_reheader:
         ## new header, can be omitted if "samples" is set
         header="header.txt",
         ## file containing new sample names, can be omitted if "header" is set
-        samples="samples.tsv"
+        samples="samples.tsv",
     output:
-        "a.reheader.bcf"
+        "a.reheader.bcf",
     params:
         extra="",  # optional parameters for bcftools reheader
-        view_extra="-O b"  # add output format for internal bcftools view call
+        view_extra="",  # optional parameters for bcftools view
     wrapper:
         "master/bio/bcftools/reheader"

--- a/bio/bcftools/reheader/test/Snakefile
+++ b/bio/bcftools/reheader/test/Snakefile
@@ -7,6 +7,8 @@ rule bcftools_reheader:
         samples="samples.tsv",
     output:
         "a.reheader.bcf",
+    log:
+        "reheader.log",
     params:
         uncompressed_bcf=False,
         extra="",  # optional parameters for bcftools reheader

--- a/bio/bcftools/reheader/wrapper.py
+++ b/bio/bcftools/reheader/wrapper.py
@@ -10,7 +10,7 @@ from snakemake.shell import shell
 from snakemake_wrapper_utils.bcftools import get_bcftools_opts
 
 
-bcftools_opts = get_bcftools_opts(snakemake, parse_memory=False)
+bcftools_opts = get_bcftools_opts(snakemake, parse_ref=False, parse_memory=False)
 extra = snakemake.params.get("extra", "")
 view_extra = snakemake.params.get("view_extra", "")
 log = snakemake.log_fmt_shell(stdout=False, stderr=True)
@@ -38,7 +38,7 @@ with tempfile.TemporaryDirectory() as tmpdir:
         " --temp-prefix {tmp_prefix}"
         " {snakemake.input[0]}"
         "| bcftools view"
-        " {bcftools_opt}"
+        " {bcftools_opts}"
         " {view_extra}"
         ") {log}"
     )

--- a/bio/bcftools/reheader/wrapper.py
+++ b/bio/bcftools/reheader/wrapper.py
@@ -31,7 +31,7 @@ with tempfile.TemporaryDirectory() as tmpdir:
 
     shell(
         "(bcftools reheader"
-        " --threads {threads}"
+        " --threads {snakemake.threads}"
         " {header}"
         " {samples}"
         " {extra}"

--- a/bio/bcftools/reheader/wrapper.py
+++ b/bio/bcftools/reheader/wrapper.py
@@ -4,34 +4,41 @@ __email__ = "j.forster@dkfz.de"
 __license__ = "MIT"
 
 
+import tempfile
+from pathlib import Path
 from snakemake.shell import shell
+from snakemake_wrapper_utils.bcftools import get_bcftools_opts
 
+
+bcftools_opts = get_bcftools_opts(snakemake, parse_memory=False)
+extra = snakemake.params.get("extra", "")
+view_extra = snakemake.params.get("view_extra", "")
 log = snakemake.log_fmt_shell(stdout=False, stderr=True)
+
 
 ## Extract arguments
 header = snakemake.input.get("header", "")
 if header:
-    header_cmd = "-h " + header
-else:
-    header_cmd = ""
+    header = f"-h {header}"
 
 samples = snakemake.input.get("samples", "")
 if samples:
-    samples_cmd = "-s " + samples
-else:
-    samples_cmd = ""
+    samples = f"-s {samples}"
 
-extra = snakemake.params.get("extra", "")
-view_extra = snakemake.params.get("view_extra", "")
 
-shell(
-    "bcftools reheader "
-    "{extra} "
-    "{header_cmd} "
-    "{samples_cmd} "
-    "{snakemake.input.vcf} "
-    "| bcftools view "
-    "{view_extra} "
-    "> {snakemake.output} "
-    "{log}"
-)
+with tempfile.TemporaryDirectory() as tmpdir:
+    tmp_prefix = Path(tmpdir) / "bcftools_reheader."
+
+    shell(
+        "(bcftools reheader"
+        " --threads {threads}"
+        " {header}"
+        " {samples}"
+        " {extra}"
+        " --temp-prefix {tmp_prefix}"
+        " {snakemake.input[0]}"
+        "| bcftools view"
+        " {bcftools_opt}"
+        " {view_extra}"
+        ") {log}"
+    )

--- a/bio/bcftools/sort/environment.yaml
+++ b/bio/bcftools/sort/environment.yaml
@@ -3,4 +3,4 @@ channels:
   - conda-forge
 dependencies:
   - bcftools =1.14
-  - snakemake-wrapper-utils =0.3
+  - snakemake-wrapper-utils =0.4

--- a/bio/bcftools/sort/environment.yaml
+++ b/bio/bcftools/sort/environment.yaml
@@ -2,4 +2,5 @@ channels:
   - bioconda
   - conda-forge
 dependencies:
-  - bcftools ==1.11
+  - bcftools =1.14
+  - snakemake-wrapper-utils =0.3

--- a/bio/bcftools/sort/meta.yaml
+++ b/bio/bcftools/sort/meta.yaml
@@ -1,4 +1,8 @@
 name: bcftools sort
-description: Sort vcf/bcf file. For more information see `BCFtools documentation <https://www.htslib.org/doc/bcftools.html#sort>`_.
+description: Sort vcf/bcf file.
+url: http://www.htslib.org/doc/bcftools.html#sort
 authors:
   - Filipe G. Vieira
+notes: |
+  * The `uncompressed_bcf` param allows to specify that a BCF output should be uncompressed (ignored otherwise).
+  * The `extra` param allows for additional program arguments (not `--threads`, `-o/--output`, `-O/--output-type`, `-m/--max-mem`, or `-T/--temp-dir`).

--- a/bio/bcftools/sort/test/Snakefile
+++ b/bio/bcftools/sort/test/Snakefile
@@ -6,7 +6,6 @@ rule bcftools_sort:
     log:
         "logs/bcftools/sort/{sample}.log",
     params:
-        tmp_dir="`mktemp -d`",
         # Set to True, in case you want uncompressed BCF output
         uncompressed_bcf=False,
         # Extra arguments

--- a/bio/bcftools/sort/test/Snakefile
+++ b/bio/bcftools/sort/test/Snakefile
@@ -1,17 +1,17 @@
 rule bcftools_sort:
     input:
-        "{sample}.bcf"
+        "{sample}.bcf",
     output:
-        "{sample}.sorted.bcf"
+        "{sample}.sorted.bcf",
     log:
-        "logs/bcftools/sort/{sample}.log"
+        "logs/bcftools/sort/{sample}.log",
     params:
-        tmp_dir = "`mktemp -d`",
+        tmp_dir="`mktemp -d`",
         # Set to True, in case you want uncompressed BCF output
-        uncompressed_bcf = False,
+        uncompressed_bcf=False,
         # Extra arguments
-        extras = ""
+        extras="",
     resources:
-        mem_mb = 8000
+        mem_mb=8000,
     wrapper:
         "master/bio/bcftools/sort"

--- a/bio/bcftools/sort/wrapper.py
+++ b/bio/bcftools/sort/wrapper.py
@@ -8,7 +8,7 @@ from snakemake.shell import shell
 from snakemake_wrapper_utils.bcftools import get_bcftools_opts
 
 
-bcftools_opts = get_bcftools_opts(snakemake)
+bcftools_opts = get_bcftools_opts(snakemake, parse_ref=False)
 extra = snakemake.params.get("extra", "")
 log = snakemake.log_fmt_shell(stdout=True, stderr=True)
 

--- a/bio/bcftools/sort/wrapper.py
+++ b/bio/bcftools/sort/wrapper.py
@@ -3,52 +3,22 @@ __copyright__ = "Copyright 2020, Filipe G. Vieira"
 __license__ = "MIT"
 
 
-from os import path
+import tempfile
 from snakemake.shell import shell
+from snakemake_wrapper_utils.bcftools import get_bcftools_opts
 
+
+bcftools_opts = get_bcftools_opts(snakemake)
 extra = snakemake.params.get("extra", "")
 log = snakemake.log_fmt_shell(stdout=True, stderr=True)
 
 
-max_mem = snakemake.resources.get("mem_mb", "")
-if max_mem:
-    max_mem = "--max-mem {}M".format(max_mem)
-else:
-    max_mem = snakemake.resources.get("mem_gb", "")
-    if max_mem:
-        max_mem = "--max-mem {}G".format(max_mem)
-    else:
-        max_mem = ""
-
-
-tmp_dir = snakemake.params.get("tmp_dir", "")
-if tmp_dir:
-    tmp_dir = "--temp-dir {}".format(tmp_dir)
-else:
-    tmp_dir = ""
-
-
-uncompressed_bcf = snakemake.params.get("uncompressed_bcf", False)
-
-
-out_name, out_ext = path.splitext(snakemake.output[0])
-if out_ext == ".vcf":
-    out_format = "v"
-elif out_ext == ".bcf":
-    if uncompressed_bcf:
-        out_format = "u"
-    else:
-        out_format = "b"
-elif out_ext == ".gz":
-    out_name, out_ext = path.splitext(out_name)
-    if out_ext == ".vcf":
-        out_format = "z"
-    else:
-        raise ValueError("output file with invalid extension (.vcf, .vcf.gz, .bcf).")
-else:
-    raise ValueError("output file with invalid extension (.vcf, .vcf.gz, .bcf).")
-
-
-shell(
-    "bcftools sort {max_mem} {tmp_dir} {extra} --output-type {out_format} --output-file {snakemake.output[0]} {snakemake.input[0]} {log}"
-)
+with tempfile.TemporaryDirectory() as tmpdir:
+    shell(
+        "bcftools sort"
+        " {bcftools_opts}"
+        " {extra}"
+        " --temp-dir {tmpdir}"
+        " {snakemake.input[0]}"
+        " {log}"
+    )

--- a/bio/bcftools/stats/environment.yaml
+++ b/bio/bcftools/stats/environment.yaml
@@ -2,4 +2,5 @@ channels:
   - bioconda
   - conda-forge
 dependencies:
-  - bcftools ==1.12
+  - bcftools =1.14
+  - snakemake-wrapper-utils =0.3

--- a/bio/bcftools/stats/environment.yaml
+++ b/bio/bcftools/stats/environment.yaml
@@ -3,4 +3,4 @@ channels:
   - conda-forge
 dependencies:
   - bcftools =1.14
-  - snakemake-wrapper-utils =0.3
+  - snakemake-wrapper-utils =0.4

--- a/bio/bcftools/stats/meta.yaml
+++ b/bio/bcftools/stats/meta.yaml
@@ -9,5 +9,5 @@ input:
 output:
   - stats text file
 notes: |
-  * The `extra` param allows for additional program arguments (not `--threads`, or `-o/--output`).
+  * The `extra` param allows for additional program arguments (not `--threads`, `-f/--fasta-ref`, or `-o/--output`).
   * For more information see, http://www.htslib.org/doc/bcftools.html#stats

--- a/bio/bcftools/stats/meta.yaml
+++ b/bio/bcftools/stats/meta.yaml
@@ -1,9 +1,13 @@
 name: bcftools stats
 description: Generate VCF stats using bcftools stats.
-url: https://github.com/samtools/bcftools
+url: http://www.htslib.org/doc/bcftools.html#stats
 authors:
   - William Rowell
+  - Filipe G. Vieira
 input:
   - BCF, VCF, or VCF.gz input
 output:
   - stats text file
+notes: |
+  * The `extra` param allows for additional program arguments (not `--threads`, or `-o/--output`).
+  * For more information see, http://www.htslib.org/doc/bcftools.html#stats

--- a/bio/bcftools/stats/test/Snakefile
+++ b/bio/bcftools/stats/test/Snakefile
@@ -1,11 +1,11 @@
 rule bcf_stats:
     input:
-        "{prefix}"
+        "{prefix}",
     output:
-        "{prefix}.stats.txt"
+        "{prefix}.stats.txt",
     log:
-        "{prefix}.bcftools.stats.log"
+        "{prefix}.bcftools.stats.log",
     params:
-        ""
+        "",
     wrapper:
         "master/bio/bcftools/stats"

--- a/bio/bcftools/stats/wrapper.py
+++ b/bio/bcftools/stats/wrapper.py
@@ -5,14 +5,21 @@ __license__ = "MIT"
 
 
 from snakemake.shell import shell
+from snakemake_wrapper_utils.bcftools import get_bcftools_opts
 
-# bcftools takes additional decompression threads through --threads
-# Other threads are *additional* threads passed to the '--threads' argument
-threads = (
-    "" if snakemake.threads <= 1 else " --threads {} ".format(snakemake.threads - 1)
+
+bcftools_opts = get_bcftools_opts(
+    snakemake, parse_output=False, parse_output_format=False, parse_memory=False
 )
-log = snakemake.log_fmt_shell(stdout=False, stderr=True)
+extra = snakemake.params.get("extra", "")
+log = snakemake.log_fmt_shell(stdout=True, stderr=True)
+
 
 shell(
-    "bcftools stats {threads} {snakemake.params} {snakemake.input} > {snakemake.output} {log}"
+    "bcftools stats"
+    " {bcftools_opts}"
+    " {extra}"
+    " {snakemake.input[0]}"
+    " > {snakemake.output[0]}"
+    " {log}"
 )

--- a/bio/bcftools/view/environment.yaml
+++ b/bio/bcftools/view/environment.yaml
@@ -3,4 +3,4 @@ channels:
   - conda-forge
 dependencies:
   - bcftools =1.14
-  - snakemake-wrapper-utils =0.3
+  - snakemake-wrapper-utils =0.4

--- a/bio/bcftools/view/environment.yaml
+++ b/bio/bcftools/view/environment.yaml
@@ -2,5 +2,5 @@ channels:
   - bioconda
   - conda-forge
 dependencies:
-  - bcftools ==1.12
-  - snakemake-wrapper-utils ==0.2
+  - bcftools =1.14
+  - snakemake-wrapper-utils =0.3

--- a/bio/bcftools/view/meta.yaml
+++ b/bio/bcftools/view/meta.yaml
@@ -1,14 +1,14 @@
 name: bcftools view
 description: View vcf/bcf file in a different format.
+url: http://www.htslib.org/doc/bcftools.html#view
 authors:
   - Johannes Köster
   - Nikos Tsardakas Renhuldt
+  - Filipe G. Vieira
 input:
   - VCF/BCF file
 output:
   - Filtered VCF/BCF file
 notes: |
   * The `uncompressed_bcf` param allows to specify that a BCF output should be uncompressed (ignored otherwise).
-  * The `bcftools_use_mem` param controls whether to pass the resources.mem_mb to bcftools
-  * The `extra` param allows for additional program arguments (not `--threads, `-O/--output-type`, `-m/--max-mem`, or `-T/--temp-dir`).
-  * For more information see, https://samtools.github.io/bcftools/bcftools.html
+  * The `extra` param allows for additional program arguments (not `--threads`, `-o/--output`, or `-O/--output-type`).

--- a/bio/bcftools/view/wrapper.py
+++ b/bio/bcftools/view/wrapper.py
@@ -7,14 +7,8 @@ __license__ = "MIT"
 from snakemake.shell import shell
 from snakemake_wrapper_utils.bcftools import get_bcftools_opts
 
-bcftools_opts = get_bcftools_opts(snakemake)
+bcftools_opts = get_bcftools_opts(snakemake, parse_memory=False)
 extra = snakemake.params.get("extra", "")
 log = snakemake.log_fmt_shell(stdout=True, stderr=True)
 
-shell(
-    "bcftools view {bcftools_opts} "
-    "{extra} "
-    "{snakemake.input[0]} "
-    "-o {snakemake.output} "
-    "{log}"
-)
+shell("bcftools view {bcftools_opts} {extra} {snakemake.input[0]} {log}")

--- a/bio/bcftools/view/wrapper.py
+++ b/bio/bcftools/view/wrapper.py
@@ -7,7 +7,7 @@ __license__ = "MIT"
 from snakemake.shell import shell
 from snakemake_wrapper_utils.bcftools import get_bcftools_opts
 
-bcftools_opts = get_bcftools_opts(snakemake, parse_memory=False)
+bcftools_opts = get_bcftools_opts(snakemake, parse_ref=False, parse_memory=False)
 extra = snakemake.params.get("extra", "")
 log = snakemake.log_fmt_shell(stdout=True, stderr=True)
 

--- a/bio/samtools/sort/wrapper.py
+++ b/bio/samtools/sort/wrapper.py
@@ -4,17 +4,16 @@ __email__ = "koester@jimmy.harvard.edu"
 __license__ = "MIT"
 
 
-import os
 import tempfile
 from pathlib import Path
 from snakemake.shell import shell
 from snakemake_wrapper_utils.samtools import get_samtools_opts
 
+
 samtools_opts = get_samtools_opts(snakemake)
 extra = snakemake.params.get("extra", "")
 log = snakemake.log_fmt_shell(stdout=True, stderr=True)
 
-out_name, out_ext = os.path.splitext(snakemake.output[0])
 
 with tempfile.TemporaryDirectory() as tmpdir:
     tmp_prefix = Path(tmpdir) / "samtools_fastq.sort_"


### PR DESCRIPTION
<!-- Ensure that the PR title follows conventional commit style (<type>: <description>)-->
<!-- Possible types are here: https://github.com/commitizen/conventional-commit-types/blob/master/index.json -->

### Description

<!-- Add a description of your PR here-->
Added `snakemake-wrapper-utils` and temp dirs (with `tempfile`).
Also updated some docs.

### QC
<!-- Make sure that you can tick the boxes below. -->

For all wrappers added by this PR, I made sure that

* [x] there is a test case which covers any introduced changes,
* [x] `input:` and `output:` file paths in the resulting rule can be changed arbitrarily,
* [x] either the wrapper can only use a single core, or the example rule contains a `threads: x` statement with `x` being a reasonable default,
* [x] rule names in the test case are in [snake_case](https://en.wikipedia.org/wiki/Snake_case) and somehow tell what the rule is about or match the tools purpose or name (e.g., `map_reads` for a step that maps reads),
* [x] all `environment.yaml` specifications follow [the respective best practices](https://stackoverflow.com/a/64594513/2352071),
* [x] wherever possible, command line arguments are inferred and set automatically (e.g. based on file extensions in `input:` or `output:`),
* [x] all fields of the example rules in the `Snakefile`s and their entries are explained via comments (`input:`/`output:`/`params:` etc.),
* [x] `stderr` and/or `stdout` are logged correctly (`log:`), depending on the wrapped tool,
* [x] temporary files are either written to a unique hidden folder in the working directory, or (better) stored where the Python function `tempfile.gettempdir()` points to (see [here](https://docs.python.org/3/library/tempfile.html#tempfile.gettempdir); this also means that using any Python `tempfile` default behavior works),
* [x] the `meta.yaml` contains a link to the documentation of the respective tool or command,
* [x] `Snakefile`s pass the linting (`snakemake --lint`),
* [x] `Snakefile`s are formatted with [snakefmt](https://github.com/snakemake/snakefmt),
* [x] Python wrapper scripts are formatted with [black](https://black.readthedocs.io).
