### PR TITLE
feat: delly automated conversion of output file

### DIFF
--- a/bio/delly/environment.yaml
+++ b/bio/delly/environment.yaml
@@ -3,4 +3,6 @@ channels:
   - bioconda
   - nodefaults
 dependencies:
-  - delly ==0.9.1
+  - delly =0.9
+  - bcftools =1.14
+  - snakemake-wrapper-utils =0.3

--- a/bio/delly/environment.yaml
+++ b/bio/delly/environment.yaml
@@ -3,6 +3,6 @@ channels:
   - bioconda
   - nodefaults
 dependencies:
-  - delly =0.9
-  - bcftools =1.14
-  - snakemake-wrapper-utils =0.3
+  - delly =1.1
+  - bcftools =1.15
+  - snakemake-wrapper-utils =0.5

--- a/bio/delly/meta.yaml
+++ b/bio/delly/meta.yaml
@@ -4,6 +4,12 @@ url: https://github.com/dellytools/delly
 authors:
   - Johannes Köster
   - Filipe G. Vieira
+input:
+  - BAM/CRAM file(s)
+  - reference genome
+  - BED file (optional)
+output:
+  - VCF/BCF with SVs.
 notes: |
-  * The `uncompressed_bcf` param sets output to uncompressed BCF (ignored if output is vcf or vcf.gz)
+  * The `uncompressed_bcf` param sets output to uncompressed BCF (ignored if output is `vcf` or `vcf.gz`)
   * The `extra` param allows for additional program arguments

--- a/bio/delly/meta.yaml
+++ b/bio/delly/meta.yaml
@@ -2,3 +2,8 @@ name: delly
 description: Call variants with delly.
 authors:
   - Johannes Köster
+  - Filipe G. Vieira
+notes: |
+  * The `uncompressed_bcf` param sets output to uncompressed BCF (ignored if output is vcf or vcf.gz)
+  * The `extra` param allows for additional program arguments
+  * For more information see, https://github.com/dellytools/delly

--- a/bio/delly/meta.yaml
+++ b/bio/delly/meta.yaml
@@ -1,9 +1,9 @@
 name: delly
 description: Call variants with delly.
+url: https://github.com/dellytools/delly
 authors:
   - Johannes Köster
   - Filipe G. Vieira
 notes: |
   * The `uncompressed_bcf` param sets output to uncompressed BCF (ignored if output is vcf or vcf.gz)
   * The `extra` param allows for additional program arguments
-  * For more information see, https://github.com/dellytools/delly

--- a/bio/delly/test/Snakefile
+++ b/bio/delly/test/Snakefile
@@ -1,13 +1,13 @@
 rule delly_bcf:
     input:
         ref="genome.fasta",
-        samples=["mapped/a.bam"],
-        # optional exclude template (see https://github.com/dellytools/delly)
+        alns=["mapped/a.bam"],
+        # optional
         exclude="human.hg19.excl.tsv",
     output:
         "sv/calls.bcf",
     params:
-        uncompressed_bcf=False,
+        uncompressed_bcf=True,
         extra="",  # optional parameters for delly (except -g, -x)
     log:
         "logs/delly.log",
@@ -19,8 +19,8 @@ rule delly_bcf:
 rule delly_vcfgz:
     input:
         ref="genome.fasta",
-        samples=["mapped/a.bam"],
-        # optional exclude template (see https://github.com/dellytools/delly)
+        alns=["mapped/a.bam"],
+        # optional
         exclude="human.hg19.excl.tsv",
     output:
         "sv/calls.vcf.gz",

--- a/bio/delly/test/Snakefile
+++ b/bio/delly/test/Snakefile
@@ -1,15 +1,33 @@
-rule delly:
+rule delly_bcf:
     input:
         ref="genome.fasta",
         samples=["mapped/a.bam"],
         # optional exclude template (see https://github.com/dellytools/delly)
-        exclude="human.hg19.excl.tsv"
+        exclude="human.hg19.excl.tsv",
     output:
-        "sv/calls.bcf"
+        "sv/calls.bcf",
     params:
-        extra=""  # optional parameters for delly (except -g, -x)
+        uncompressed_bcf=False,
+        extra="",  # optional parameters for delly (except -g, -x)
     log:
-        "logs/delly.log"
+        "logs/delly.log",
+    threads: 2  # It is best to use as many threads as samples
+    wrapper:
+        "master/bio/delly"
+
+
+rule delly_vcfgz:
+    input:
+        ref="genome.fasta",
+        samples=["mapped/a.bam"],
+        # optional exclude template (see https://github.com/dellytools/delly)
+        exclude="human.hg19.excl.tsv",
+    output:
+        "sv/calls.vcf.gz",
+    params:
+        extra="",  # optional parameters for delly (except -g, -x)
+    log:
+        "logs/delly.log",
     threads: 2  # It is best to use as many threads as samples
     wrapper:
         "master/bio/delly"

--- a/bio/delly/wrapper.py
+++ b/bio/delly/wrapper.py
@@ -4,34 +4,28 @@ __email__ = "koester@jimmy.harvard.edu"
 __license__ = "MIT"
 
 
-import tempfile
 from snakemake.shell import shell
 from snakemake_wrapper_utils.bcftools import get_bcftools_opts
 
 
-bcftools_opts = get_bcftools_opts(snakemake, parse_memory=False)
+bcftools_opts = get_bcftools_opts(snakemake, parse_ref=False, parse_memory=False)
 extra = snakemake.params.get("extra", "")
 log = snakemake.log_fmt_shell(stdout=True, stderr=True)
 
 
-exclude = (
-    "-x {}".format(snakemake.input.exclude)
-    if snakemake.input.get("exclude", "")
-    else ""
+exclude = snakemake.input.get("exclude", "")
+if exclude:
+    exclude = f"-x {exclude}"
+
+
+shell(
+    "(OMP_NUM_THREADS={snakemake.threads} delly call"
+    " -g {snakemake.input.ref}"
+    " {exclude}"
+    " {extra}"
+    " {snakemake.input.alns} | "
+    # Convert output to specified format
+    "bcftools view"
+    " {bcftools_opts}"
+    ") {log}"
 )
-
-
-with NamedTemporaryFile().name as tmpout:
-    shell(
-        "(OMP_NUM_THREADS={snakemake.threads} delly call"
-        " -g {snakemake.input.ref}"
-        " -o {tmpout}"
-        " {exclude}"
-        " {extra}"
-        " {snakemake.input[0]};"
-        # Convert output to specified format
-        "bcftools view"
-        " {bcftools_opts}"
-        " {tmpout}"
-        ") {log}"
-    )

--- a/bio/delly/wrapper.py
+++ b/bio/delly/wrapper.py
@@ -6,22 +6,18 @@ __license__ = "MIT"
 
 import tempfile
 from snakemake.shell import shell
-from snakemake_wrapper_utils.bcftools import infer_out_format
+from snakemake_wrapper_utils.bcftools import get_bcftools_opts
+
+
+bcftools_opts = get_bcftools_opts(snakemake, parse_memory=False)
+extra = snakemake.params.get("extra", "")
+log = snakemake.log_fmt_shell(stdout=True, stderr=True)
 
 
 exclude = (
     "-x {}".format(snakemake.input.exclude)
     if snakemake.input.get("exclude", "")
     else ""
-)
-
-extra = snakemake.params.get("extra", "")
-log = snakemake.log_fmt_shell(stdout=True, stderr=True)
-
-
-# Infer output format
-out_format = infer_out_format(
-    snakemake.output[0], snakemake.params.get("uncompressed_bcf", False)
 )
 
 
@@ -32,11 +28,10 @@ with NamedTemporaryFile().name as tmpout:
         " -o {tmpout}"
         " {exclude}"
         " {extra}"
-        " {snakemake.input.samples};"
+        " {snakemake.input[0]};"
         # Convert output to specified format
         "bcftools view"
-        " -O {out_format}"
-        " -o {snakemake.output[0]}"
+        " {bcftools_opts}"
         " {tmpout}"
         ") {log}"
     )

--- a/test.py
+++ b/test.py
@@ -3331,6 +3331,11 @@ def test_delly():
 
 
 @skip_if_not_modified
+def test_delly():
+    run("bio/delly", ["snakemake", "--cores", "1", "sv/calls.vcf.gz", "--use-conda", "-F"])
+
+
+@skip_if_not_modified
 def test_manta():
     run(
         "bio/manta",


### PR DESCRIPTION
<!-- Ensure that the PR title follows conventional commit style (<type>: <description>)-->
<!-- Possible types are here: https://github.com/commitizen/conventional-commit-types/blob/master/index.json -->

### Description

<!-- Add a description of your PR here-->
Automated conversion of output `BCF`.

### QC
<!-- Make sure that you can tick the boxes below. -->

For all wrappers added by this PR, I made sure that

* [x] there is a test case which covers any introduced changes,
* [x] `input:` and `output:` file paths in the resulting rule can be changed arbitrarily,
* [x] either the wrapper can only use a single core, or the example rule contains a `threads: x` statement with `x` being a reasonable default,
* [x] rule names in the test case are in [snake_case](https://en.wikipedia.org/wiki/Snake_case) and somehow tell what the rule is about or match the tools purpose or name (e.g., `map_reads` for a step that maps reads),
* [x] all `environment.yaml` specifications follow [the respective best practices](https://stackoverflow.com/a/64594513/2352071),
* [x] wherever possible, command line arguments are inferred and set automatically (e.g. based on file extensions in `input:` or `output:`),
* [x] all fields of the example rules in the `Snakefile`s and their entries are explained via comments (`input:`/`output:`/`params:` etc.),
* [x] `stderr` and/or `stdout` are logged correctly (`log:`), depending on the wrapped tool,
* [x] temporary files are either written to a unique hidden folder in the working directory, or (better) stored where the Python function `tempfile.gettempdir()` points to (see [here](https://docs.python.org/3/library/tempfile.html#tempfile.gettempdir); this also means that using any Python `tempfile` default behavior works),
* [x] the `meta.yaml` contains a link to the documentation of the respective tool or command,
* [x] `Snakefile`s pass the linting (`snakemake --lint`),
* [x] `Snakefile`s are formatted with [snakefmt](https://github.com/snakemake/snakefmt),
* [x] Python wrapper scripts are formatted with [black](https://black.readthedocs.io).
