### PR TITLE
fix: fixed some known bugs, added docs, and reformat

### DIFF
--- a/bio/bowtie2/align/environment.yaml
+++ b/bio/bowtie2/align/environment.yaml
@@ -3,5 +3,6 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - bowtie2 ==2.4.4  # Keep consistent with version specified in bowtie2/build
-  - samtools ==1.10
+  - bowtie2 ==2.4  # Keep consistent with version specified in bowtie2/build
+  - samtools ==1.14
+  - snakemake-wrapper-utils =0.3

--- a/bio/bowtie2/align/environment.yaml
+++ b/bio/bowtie2/align/environment.yaml
@@ -3,6 +3,6 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - bowtie2 ==2.4  # Keep consistent with version specified in bowtie2/build
-  - samtools ==1.14
+  - bowtie2 =2.4  # Keep consistent with version specified in bowtie2/build
+  - samtools =1.14
   - snakemake-wrapper-utils =0.3

--- a/bio/bowtie2/align/meta.yaml
+++ b/bio/bowtie2/align/meta.yaml
@@ -1,6 +1,14 @@
 name: "bowtie2"
 description: Map reads with bowtie2.
+url: http://bowtie-bio.sourceforge.net/bowtie2/manual.shtml
 authors:
   - Johannes Köster
-note:
-  This wrapper uses an inner pipe. Make sure to use at least two threads in your Snakefile.
+  - Filipe G. Vieira
+input:
+  - FASTQ file(s)
+  - Bowtie2 indexed reference index
+output:
+  - SAM/BAM/CRAM file
+notes: |
+  * The `extra` param allows for additional program arguments.
+  * This wrapper uses an inner pipe. Make sure to use at least two threads in your Snakefile.

--- a/bio/bowtie2/align/test/Snakefile
+++ b/bio/bowtie2/align/test/Snakefile
@@ -15,7 +15,7 @@ rule bowtie2:
     log:
         "logs/bowtie2/{sample}.log",
     params:
-        extra="--large-index",  # optional parameters
+        extra="",  # optional parameters
     threads: 8  # Use at least two threads
     wrapper:
         "master/bio/bowtie2/align"

--- a/bio/bowtie2/align/test/Snakefile
+++ b/bio/bowtie2/align/test/Snakefile
@@ -1,13 +1,21 @@
 rule bowtie2:
     input:
-        sample=["reads/{sample}.1.fastq", "reads/{sample}.2.fastq"]
+        sample=["reads/{sample}.1.fastq", "reads/{sample}.2.fastq"],
+        idx=multiext(
+            "index/genome",
+            ".1.bt2",
+            ".2.bt2",
+            ".3.bt2",
+            ".4.bt2",
+            ".rev.1.bt2",
+            ".rev.2.bt2",
+        ),
     output:
-        "mapped/{sample}.bam"
+        "mapped/{sample}.bam",
     log:
-        "logs/bowtie2/{sample}.log"
+        "logs/bowtie2/{sample}.log",
     params:
-        index="index/genome",  # prefix of reference genome index (built with bowtie2-build)
-        extra=""  # optional parameters
+        extra="--large-index",  # optional parameters
     threads: 8  # Use at least two threads
     wrapper:
         "master/bio/bowtie2/align"

--- a/bio/bowtie2/align/wrapper.py
+++ b/bio/bowtie2/align/wrapper.py
@@ -36,6 +36,6 @@ shell(
     " {extra}"
     "| samtools view"
     " {samtools_opts}"
-    " {extra} -"
+    " -"
     ") {log}"
 )

--- a/bio/bowtie2/align/wrapper.py
+++ b/bio/bowtie2/align/wrapper.py
@@ -25,7 +25,7 @@ else:
     reads = "-1 {} -2 {}".format(*snakemake.input.sample)
 
 
-index = os.path.commonprefix(snakemake.input.idx)
+index = os.path.commonprefix(snakemake.input.idx).rstrip(".")
 
 
 shell(

--- a/bio/bowtie2/align/wrapper.py
+++ b/bio/bowtie2/align/wrapper.py
@@ -24,8 +24,7 @@ else:
     reads = "-1 {} -2 {}".format(*snakemake.input.sample)
 
 
-index = os.path.commonpath(snakemake.input.idx)
-
+index = os.path.commonprefix(snakemake.input.idx)
 
 
 shell(

--- a/bio/bowtie2/align/wrapper.py
+++ b/bio/bowtie2/align/wrapper.py
@@ -4,6 +4,7 @@ __email__ = "koester@jimmy.harvard.edu"
 __license__ = "MIT"
 
 
+import os
 from snakemake.shell import shell
 from snakemake_wrapper_utils.samtools import get_samtools_opts
 

--- a/bio/bowtie2/align/wrapper.py
+++ b/bio/bowtie2/align/wrapper.py
@@ -5,9 +5,13 @@ __license__ = "MIT"
 
 
 from snakemake.shell import shell
+from snakemake_wrapper_utils.samtools import get_samtools_opts
 
+
+samtools_opts = get_samtools_opts(snakemake)
 extra = snakemake.params.get("extra", "")
 log = snakemake.log_fmt_shell(stdout=True, stderr=True)
+
 
 n = len(snakemake.input.sample)
 assert (
@@ -19,8 +23,19 @@ if n == 1:
 else:
     reads = "-1 {} -2 {}".format(*snakemake.input.sample)
 
+
+index = os.path.commonpath(snakemake.input.idx)
+
+
+
 shell(
-    "(bowtie2 --threads {snakemake.threads} {extra} "
-    "-x {snakemake.params.index} {reads} "
-    "| samtools view -Sbh -o {snakemake.output[0]} -) {log}"
+    "(bowtie2"
+    " --threads {snakemake.threads}"
+    " {reads} "
+    " -x {index}"
+    " {extra}"
+    "| samtools view"
+    " {samtools_opts}"
+    " {extra} -"
+    ") {log}"
 )

--- a/bio/bowtie2/build/environment.yaml
+++ b/bio/bowtie2/build/environment.yaml
@@ -3,5 +3,5 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - bowtie2 ==2.4.4  # Keep consistent with version specified in bowtie2/align
-  - samtools ==1.10
+  - bowtie2 ==2.4  # Keep consistent with version specified in bowtie2/align
+  - samtools ==1.14

--- a/bio/bowtie2/build/environment.yaml
+++ b/bio/bowtie2/build/environment.yaml
@@ -4,4 +4,3 @@ channels:
   - defaults
 dependencies:
   - bowtie2 =2.4  # Keep consistent with version specified in bowtie2/align
-  - samtools =1.14

--- a/bio/bowtie2/build/environment.yaml
+++ b/bio/bowtie2/build/environment.yaml
@@ -3,5 +3,5 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - bowtie2 ==2.4  # Keep consistent with version specified in bowtie2/align
-  - samtools ==1.14
+  - bowtie2 =2.4  # Keep consistent with version specified in bowtie2/align
+  - samtools =1.14

--- a/bio/bowtie2/build/meta.yaml
+++ b/bio/bowtie2/build/meta.yaml
@@ -1,4 +1,12 @@
 name: "bowtie2_build"
 description: Map reads with bowtie2.
+url: http://bowtie-bio.sourceforge.net/bowtie2/manual.shtml
 authors:
   - Daniel Standage
+  - Filipe G. Vieira
+input:
+  - FASTA reference
+output:
+  - Bowtie2 reference index
+notes: |
+  * The `extra` param allows for additional program arguments.

--- a/bio/bowtie2/build/test/Snakefile
+++ b/bio/bowtie2/build/test/Snakefile
@@ -1,15 +1,20 @@
 rule bowtie2_build:
     input:
-        reference="genome.fasta"
+        ref="genome.fasta",
     output:
         multiext(
             "genome",
-            ".1.bt2", ".2.bt2", ".3.bt2", ".4.bt2", ".rev.1.bt2", ".rev.2.bt2",
+            ".1.bt2",
+            ".2.bt2",
+            ".3.bt2",
+            ".4.bt2",
+            ".rev.1.bt2",
+            ".rev.2.bt2",
         ),
     log:
-        "logs/bowtie2_build/build.log"
+        "logs/bowtie2_build/build.log",
     params:
-        extra=""  # optional parameters
+        extra="",  # optional parameters
     threads: 8
     wrapper:
         "master/bio/bowtie2/build"

--- a/bio/bowtie2/build/test/Snakefile
+++ b/bio/bowtie2/build/test/Snakefile
@@ -14,7 +14,7 @@ rule bowtie2_build:
     log:
         "logs/bowtie2_build/build.log",
     params:
-        extra="",  # optional parameters
+        extra="--large-index",  # optional parameters
     threads: 8
     wrapper:
         "master/bio/bowtie2/build"

--- a/bio/bowtie2/build/test/Snakefile
+++ b/bio/bowtie2/build/test/Snakefile
@@ -14,6 +14,29 @@ rule bowtie2_build:
     log:
         "logs/bowtie2_build/build.log",
     params:
+        extra="",  # optional parameters
+    threads: 8
+    wrapper:
+        "master/bio/bowtie2/build"
+
+
+
+rule bowtie2_build_large:
+    input:
+        ref="genome.fasta",
+    output:
+        multiext(
+            "genome",
+            ".1.bt2l",
+            ".2.bt2l",
+            ".3.bt2l",
+            ".4.bt2l",
+            ".rev.1.bt2l",
+            ".rev.2.bt2l",
+        ),
+    log:
+        "logs/bowtie2_build/build.log",
+    params:
         extra="--large-index",  # optional parameters
     threads: 8
     wrapper:

--- a/bio/bowtie2/build/wrapper.py
+++ b/bio/bowtie2/build/wrapper.py
@@ -4,12 +4,21 @@ __email__ = "daniel.standage@nbacc.dhs.gov"
 __license__ = "MIT"
 
 
+import os
 from snakemake.shell import shell
 
 extra = snakemake.params.get("extra", "")
 log = snakemake.log_fmt_shell(stdout=True, stderr=True)
-indexbase = snakemake.output[0].replace(".1.bt2", "")
+
+
+index = os.path.commonpath(snakemake.output)
+
+
 shell(
-    "bowtie2-build --threads {snakemake.threads} {snakemake.params.extra} "
-    "{snakemake.input.reference} {indexbase}"
+    "bowtie2-build"
+    " --threads {snakemake.threads}"
+    " {extra}"
+    " {snakemake.input.ref}"
+    " {index}"
+    " {log}"
 )

--- a/bio/bowtie2/build/wrapper.py
+++ b/bio/bowtie2/build/wrapper.py
@@ -11,7 +11,7 @@ extra = snakemake.params.get("extra", "")
 log = snakemake.log_fmt_shell(stdout=True, stderr=True)
 
 
-index = os.path.commonprefix(snakemake.output)
+index = os.path.commonprefix(snakemake.output).rstrip(".")
 
 
 shell(

--- a/bio/bowtie2/build/wrapper.py
+++ b/bio/bowtie2/build/wrapper.py
@@ -11,7 +11,7 @@ extra = snakemake.params.get("extra", "")
 log = snakemake.log_fmt_shell(stdout=True, stderr=True)
 
 
-index = os.path.commonpath(snakemake.output)
+index = os.path.commonprefix(snakemake.output)
 
 
 shell(

--- a/test.py
+++ b/test.py
@@ -1002,6 +1002,14 @@ def test_bowtie2_build():
 
 
 @skip_if_not_modified
+def test_bowtie2_build_large():
+    run(
+        "bio/bowtie2/build",
+        ["snakemake", "--cores", "1", "genome.1.bt2l", "--use-conda", "-F"],
+    )
+
+
+@skip_if_not_modified
 def test_bwa_mem():
     run(
         "bio/bwa/mem",


### PR DESCRIPTION
<!-- Ensure that the PR title follows conventional commit style (<type>: <description>)-->
<!-- Possible types are here: https://github.com/commitizen/conventional-commit-types/blob/master/index.json -->

### Description

<!-- Add a description of your PR here-->
Fixed several issues (#277, #355, #457, and maybe #372), added docs, and reformat.

### QC
<!-- Make sure that you can tick the boxes below. -->

For all wrappers added by this PR, I made sure that

* [x] there is a test case which covers any introduced changes,
* [x] `input:` and `output:` file paths in the resulting rule can be changed arbitrarily,
* [x] either the wrapper can only use a single core, or the example rule contains a `threads: x` statement with `x` being a reasonable default,
* [x] rule names in the test case are in [snake_case](https://en.wikipedia.org/wiki/Snake_case) and somehow tell what the rule is about or match the tools purpose or name (e.g., `map_reads` for a step that maps reads),
* [x] all `environment.yaml` specifications follow [the respective best practices](https://stackoverflow.com/a/64594513/2352071),
* [x] wherever possible, command line arguments are inferred and set automatically (e.g. based on file extensions in `input:` or `output:`),
* [x] all fields of the example rules in the `Snakefile`s and their entries are explained via comments (`input:`/`output:`/`params:` etc.),
* [x] `stderr` and/or `stdout` are logged correctly (`log:`), depending on the wrapped tool,
* [x] temporary files are either written to a unique hidden folder in the working directory, or (better) stored where the Python function `tempfile.gettempdir()` points to (see [here](https://docs.python.org/3/library/tempfile.html#tempfile.gettempdir); this also means that using any Python `tempfile` default behavior works),
* [x] the `meta.yaml` contains a link to the documentation of the respective tool or command,
* [x] `Snakefile`s pass the linting (`snakemake --lint`),
* [x] `Snakefile`s are formatted with [snakefmt](https://github.com/snakemake/snakefmt),
* [x] Python wrapper scripts are formatted with [black](https://black.readthedocs.io).
