### PR TITLE
feat: added ref as an optional input file

### DIFF
--- a/bio/picard/collectrnaseqmetrics/meta.yaml
+++ b/bio/picard/collectrnaseqmetrics/meta.yaml
@@ -1,15 +1,17 @@
 name: picard CollectRnaSeqMetrics
 description: |
         Run picard CollectRnaSeqMetrics to generate QC metrics for RNA-seq data.
+url: https://broadinstitute.github.io/picard/command-line-overview.html#CollectRnaSeqMetrics
 authors:
   - Brett Copeland
+  - Filipe G. Vieira
 input:
   - BAM file of RNA-seq data aligned to genome
   - REF_FLAT formatted file of transcriptome annotations
+  - reference FASTA (optional)
 output:
   - RNA-Seq metrics text file
 notes: |
   * The `java_opts` param allows for additional arguments to be passed to the java compiler, e.g. "-XX:ParallelGCThreads=10" (not for `-XmX` or `-Djava.io.tmpdir`, since they are handled automatically).
   * The `extra` param allows for additional program arguments.
   * `--TMP_DIR` is automatically set by `resources.tmpdir`
-  * For more information, see https://broadinstitute.github.io/picard/command-line-overview.html#CollectRnaSeqMetrics

--- a/bio/picard/collectrnaseqmetrics/test/Snakefile
+++ b/bio/picard/collectrnaseqmetrics/test/Snakefile
@@ -2,6 +2,8 @@ rule alignment_summary:
     input:
         # BAM aligned, splicing-aware, to reference genome
         bam="mapped/a.bam",
+	# Reference genome
+        #ref="ref.fasta",
         # Annotation file containing transcript, gene, and exon data
         refflat="annotation.refFlat",
     output:
@@ -14,10 +16,6 @@ rule alignment_summary:
         extra="--VALIDATION_STRINGENCY STRICT",
     log:
         "logs/picard/rnaseq-metrics/a.log",
-    # optional specification of memory usage of the JVM that snakemake will respect with global
-    # resource restrictions (https://snakemake.readthedocs.io/en/latest/snakefiles/rules.html#resources)
-    # and which can be used to request RAM during cluster job submission as `{resources.mem_mb}`:
-    # https://snakemake.readthedocs.io/en/latest/executing/cluster.html#job-properties
     resources:
         mem_mb=1024,
     wrapper:

--- a/bio/picard/collectrnaseqmetrics/wrapper.py
+++ b/bio/picard/collectrnaseqmetrics/wrapper.py
@@ -15,14 +15,20 @@ extra = snakemake.params.get("extra", "")
 java_opts = get_java_opts(snakemake)
 
 
+ref = snakemake.input.get("ref", "")
+if ref:
+    ref = f"--REFERENCE_SEQUENCE {ref}"
+
+
 with tempfile.TemporaryDirectory() as tmpdir:
     shell(
         "picard CollectRnaSeqMetrics"
         " {java_opts} {extra}"
         " --INPUT {snakemake.input.bam}"
-        " --TMP_DIR {tmpdir}"
-        " --OUTPUT {snakemake.output}"
+        " {ref}"
         " --REF_FLAT {snakemake.input.refflat}"
         " --STRAND_SPECIFICITY {strand}"
+        " --TMP_DIR {tmpdir}"
+        " --OUTPUT {snakemake.output}"
         " {log}"
     )


### PR DESCRIPTION
<!-- Ensure that the PR title follows conventional commit style (<type>: <description>)-->
<!-- Possible types are here: https://github.com/commitizen/conventional-commit-types/blob/master/index.json -->

### Description

<!-- Add a description of your PR here-->

### QC
<!-- Make sure that you can tick the boxes below. -->

For all wrappers added by this PR, I made sure that

* [x] there is a test case which covers any introduced changes,
* [x] `input:` and `output:` file paths in the resulting rule can be changed arbitrarily,
* [x] either the wrapper can only use a single core, or the example rule contains a `threads: x` statement with `x` being a reasonable default,
* [x] rule names in the test case are in [snake_case](https://en.wikipedia.org/wiki/Snake_case) and somehow tell what the rule is about or match the tools purpose or name (e.g., `map_reads` for a step that maps reads),
* [x] all `environment.yaml` specifications follow [the respective best practices](https://stackoverflow.com/a/64594513/2352071),
* [x] wherever possible, command line arguments are inferred and set automatically (e.g. based on file extensions in `input:` or `output:`),
* [x] all fields of the example rules in the `Snakefile`s and their entries are explained via comments (`input:`/`output:`/`params:` etc.),
* [x] `stderr` and/or `stdout` are logged correctly (`log:`), depending on the wrapped tool,
* [x] temporary files are either written to a unique hidden folder in the working directory, or (better) stored where the Python function `tempfile.gettempdir()` points to (see [here](https://docs.python.org/3/library/tempfile.html#tempfile.gettempdir); this also means that using any Python `tempfile` default behavior works),
* [x] the `meta.yaml` contains a link to the documentation of the respective tool or command,
* [x] `Snakefile`s pass the linting (`snakemake --lint`),
* [x] `Snakefile`s are formatted with [snakefmt](https://github.com/snakemake/snakefmt),
* [x] Python wrapper scripts are formatted with [black](https://black.readthedocs.io).
