### PR TITLE
feat: Added specific param for strandness

### DIFF
--- a/bio/subread/featurecounts/meta.yaml
+++ b/bio/subread/featurecounts/meta.yaml
@@ -1,6 +1,7 @@
 name: subread featureCounts
 description: >
   FeatureCounts assign mapped reads or fragments (paired-end data) to genomic features such as genes, exons and promoters.
+url: http://subread.sourceforge.net/
 author:
   - Antonie Vietor
   - Filipe G. Vieira
@@ -14,6 +15,5 @@ output:
   - Summary file including summary statistics (tab separated)
   - Junction counts file including count number of reads supporting each exon-exon junction (tab separated)
 notes: |
+  * The `strand` param allows to specify the strandness of the library (0, 1, or 2)
   * The `extra` param allows for additional program arguments.
-  * For more information see, http://subread.sourceforge.net/ and https://bioconductor.org/packages/release/bioc/vignettes/Rsubread/inst/doc/SubreadUsersGuide.pdf
-  * For a tutorial see, http://bioinf.wehi.edu.au/featureCounts/

--- a/bio/subread/featurecounts/meta.yaml
+++ b/bio/subread/featurecounts/meta.yaml
@@ -15,5 +15,5 @@ output:
   - Summary file including summary statistics (tab separated)
   - Junction counts file including count number of reads supporting each exon-exon junction (tab separated)
 notes: |
-  * The `strand` param allows to specify the strandness of the library (0, 1, or 2)
+  * The `strand` param allows to specify the strandness of the library (0: unstranded, 1: stranded, and 2: reversely stranded)
   * The `extra` param allows for additional program arguments.

--- a/bio/subread/featurecounts/test/Snakefile
+++ b/bio/subread/featurecounts/test/Snakefile
@@ -1,6 +1,7 @@
 rule feature_counts:
     input:
-        samples="{sample}.bam",  # list of sam or bam files
+        # list of sam or bam files
+        samples="{sample}.bam",
         annotation="annotation.gtf",
         # optional input
         # chr_names="",           # implicitly sets the -A flag
@@ -14,6 +15,7 @@ rule feature_counts:
         ),
     threads: 2
     params:
+        strand=0,
         r_path="",  # implicitly sets the --Rpath flag
         extra="-O --fracOverlap 0.2 -J",
     log:

--- a/bio/subread/featurecounts/test/Snakefile
+++ b/bio/subread/featurecounts/test/Snakefile
@@ -4,8 +4,8 @@ rule feature_counts:
         samples="{sample}.bam",
         annotation="annotation.gtf",
         # optional input
-        # chr_names="",           # implicitly sets the -A flag
-        # fasta="genome.fasta"    # implicitly sets the -G flag
+        #chr_names="",           # implicitly sets the -A flag
+        #fasta="genome.fasta"    # implicitly sets the -G flag
     output:
         multiext(
             "results/{sample}",
@@ -15,7 +15,7 @@ rule feature_counts:
         ),
     threads: 2
     params:
-        strand=0,
+        strand=0,  # optional; strandness of the library (0: unstranded [default], 1: stranded, and 2: reversely stranded)
         r_path="",  # implicitly sets the --Rpath flag
         extra="-O --fracOverlap 0.2 -J",
     log:

--- a/bio/subread/featurecounts/wrapper.py
+++ b/bio/subread/featurecounts/wrapper.py
@@ -10,22 +10,30 @@ log = snakemake.log_fmt_shell(stdout=True, stderr=True)
 extra = snakemake.params.get("extra", "")
 
 # optional input files and directories
-fasta = snakemake.input.get("fasta", "")
-chr_names = snakemake.input.get("chr_names", "")
-r_path = snakemake.params.get("r_path", "")
+strand = snakemake.params.get("strand", 0)
 
+fasta = snakemake.input.get("fasta", "")
 if fasta:
-    extra += " -G {}".format(fasta)
+    fasta = f"-G {fasta}"
+
+chr_names = snakemake.input.get("chr_names", "")
 if chr_names:
-    extra += " -A {}".format(chr_names)
+    chr_names = f"-A {chr_names}"
+
+r_path = snakemake.params.get("r_path", "")
 if r_path:
-    extra += " --Rpath {}".format(r_path)
+    r_path = f"--Rpath {r_path}"
+
 
 with tempfile.TemporaryDirectory() as tmpdir:
     shell(
         "featureCounts"
         " -T {snakemake.threads}"
+        " -s {strand}"
         " -a {snakemake.input.annotation}"
+        " {fasta}"
+        " {chr_names}"
+        " {r_path}"
         " {extra}"
         " --tmpDir {tmpdir}"
         " -o {snakemake.output[0]}"


### PR DESCRIPTION
<!-- Ensure that the PR title follows conventional commit style (<type>: <description>)-->
<!-- Possible types are here: https://github.com/commitizen/conventional-commit-types/blob/master/index.json -->

### Description

<!-- Add a description of your PR here-->
Added `param` option to specify strandness (like in picard collectrnametrics)

### QC
<!-- Make sure that you can tick the boxes below. -->

For all wrappers added by this PR, I made sure that

* [x] there is a test case which covers any introduced changes,
* [x] `input:` and `output:` file paths in the resulting rule can be changed arbitrarily,
* [x] either the wrapper can only use a single core, or the example rule contains a `threads: x` statement with `x` being a reasonable default,
* [x] rule names in the test case are in [snake_case](https://en.wikipedia.org/wiki/Snake_case) and somehow tell what the rule is about or match the tools purpose or name (e.g., `map_reads` for a step that maps reads),
* [x] all `environment.yaml` specifications follow [the respective best practices](https://stackoverflow.com/a/64594513/2352071),
* [x] wherever possible, command line arguments are inferred and set automatically (e.g. based on file extensions in `input:` or `output:`),
* [x] all fields of the example rules in the `Snakefile`s and their entries are explained via comments (`input:`/`output:`/`params:` etc.),
* [x] `stderr` and/or `stdout` are logged correctly (`log:`), depending on the wrapped tool,
* [x] temporary files are either written to a unique hidden folder in the working directory, or (better) stored where the Python function `tempfile.gettempdir()` points to (see [here](https://docs.python.org/3/library/tempfile.html#tempfile.gettempdir); this also means that using any Python `tempfile` default behavior works),
* [x] the `meta.yaml` contains a link to the documentation of the respective tool or command,
* [x] `Snakefile`s pass the linting (`snakemake --lint`),
* [x] `Snakefile`s are formatted with [snakefmt](https://github.com/snakemake/snakefmt),
* [x] Python wrapper scripts are formatted with [black](https://black.readthedocs.io).
