### PR TITLE
feat: added support for gzip output files

### DIFF
--- a/bio/reference/ensembl-annotation/meta.yaml
+++ b/bio/reference/ensembl-annotation/meta.yaml
@@ -2,3 +2,5 @@ name: ensembl-annotation
 description: Download annotation of genomic sites (e.g. transcripts) from ENSEMBL FTP servers, and store them in a single .gtf or .gff3 file.
 authors:
   - Johannes Köster
+output:
+  - Ensemble GTF or GFF3 anotation file

--- a/bio/reference/ensembl-annotation/test/Snakefile
+++ b/bio/reference/ensembl-annotation/test/Snakefile
@@ -1,14 +1,14 @@
 rule get_annotation:
     output:
-        "refs/annotation.gtf"
+        "refs/annotation.gtf",
     params:
         species="homo_sapiens",
         release="87",
         build="GRCh37",
         fmt="gtf",
-        flavor="" # optional, e.g. chr_patch_hapl_scaff, see Ensembl FTP.
+        flavor="",  # optional, e.g. chr_patch_hapl_scaff, see Ensembl FTP.
     log:
-        "logs/get_annotation.log"
+        "logs/get_annotation.log",
     cache: True  # save space and time with between workflow caching (see docs)
     wrapper:
         "master/bio/reference/ensembl-annotation"

--- a/bio/reference/ensembl-annotation/wrapper.py
+++ b/bio/reference/ensembl-annotation/wrapper.py
@@ -7,27 +7,37 @@ import subprocess
 import sys
 from snakemake.shell import shell
 
+
+log = snakemake.log_fmt_shell(stdout=False, stderr=True)
+
+
 species = snakemake.params.species.lower()
+build = snakemake.params.build
 release = int(snakemake.params.release)
 fmt = snakemake.params.fmt
-build = snakemake.params.build
-flavor = snakemake.params.get("flavor", "")
+
 
 branch = ""
 if release >= 81 and build == "GRCh37":
     # use the special grch37 branch for new releases
     branch = "grch37/"
 
+
+flavor = snakemake.params.get("flavor", "")
 if flavor:
     flavor += "."
 
-log = snakemake.log_fmt_shell(stdout=False, stderr=True)
 
 suffix = ""
-if fmt == "gtf":
+if fmt == "gtf" or fmt == "gtf.gz":
     suffix = "gtf.gz"
-elif fmt == "gff3":
+elif fmt == "gff3" or fmt == "gff3.gz":
     suffix = "gff3.gz"
+else:
+    raise ValueError(
+        "invalid format specified. Only 'gtf[.gz]' and 'gff3[.gz]' are currently supported."
+    )
+
 
 url = "ftp://ftp.ensembl.org/pub/{branch}release-{release}/{fmt}/{species}/{species_cap}.{build}.{release}.{flavor}{suffix}".format(
     release=release,
@@ -40,8 +50,12 @@ url = "ftp://ftp.ensembl.org/pub/{branch}release-{release}/{fmt}/{species}/{spec
     branch=branch,
 )
 
+
 try:
-    shell("(curl -L {url} | gzip -d > {snakemake.output[0]}) {log}")
+    if fmt.endswith(".gz"):
+        shell("(curl -L {url} > {snakemake.output[0]}) {log}")
+    else:
+        shell("(curl -L {url} | gzip -d > {snakemake.output[0]}) {log}")
 except subprocess.CalledProcessError as e:
     if snakemake.log:
         sys.stderr = open(snakemake.log[0], "a")


### PR DESCRIPTION
<!-- Ensure that the PR title follows conventional commit style (<type>: <description>)-->
<!-- Possible types are here: https://github.com/commitizen/conventional-commit-types/blob/master/index.json -->

### Description

<!-- Add a description of your PR here-->
Allow to output `gzipped` files

### QC
<!-- Make sure that you can tick the boxes below. -->

For all wrappers added by this PR, I made sure that

* [x] there is a test case which covers any introduced changes,
* [x] `input:` and `output:` file paths in the resulting rule can be changed arbitrarily,
* [x] either the wrapper can only use a single core, or the example rule contains a `threads: x` statement with `x` being a reasonable default,
* [x] rule names in the test case are in [snake_case](https://en.wikipedia.org/wiki/Snake_case) and somehow tell what the rule is about or match the tools purpose or name (e.g., `map_reads` for a step that maps reads),
* [x] all `environment.yaml` specifications follow [the respective best practices](https://stackoverflow.com/a/64594513/2352071),
* [x] wherever possible, command line arguments are inferred and set automatically (e.g. based on file extensions in `input:` or `output:`),
* [x] all fields of the example rules in the `Snakefile`s and their entries are explained via comments (`input:`/`output:`/`params:` etc.),
* [x] `stderr` and/or `stdout` are logged correctly (`log:`), depending on the wrapped tool,
* [x] temporary files are either written to a unique hidden folder in the working directory, or (better) stored where the Python function `tempfile.gettempdir()` points to (see [here](https://docs.python.org/3/library/tempfile.html#tempfile.gettempdir); this also means that using any Python `tempfile` default behavior works),
* [x] the `meta.yaml` contains a link to the documentation of the respective tool or command,
* [x] `Snakefile`s pass the linting (`snakemake --lint`),
* [x] `Snakefile`s are formatted with [snakefmt](https://github.com/snakemake/snakefmt),
* [x] Python wrapper scripts are formatted with [black](https://black.readthedocs.io).
