### PR TITLE
chore: fix mamba setup

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,6 +37,8 @@ jobs:
 
       - name: Setup Snakemake environment
         run: |
+           # ensure that mamba is happy to write into the cache
+           sudo chown -R runner:docker /usr/share/miniconda/pkgs/cache
            conda install -c conda-forge mamba --quiet
            export PATH="/usr/share/miniconda/bin:$PATH"
            mamba create -c bioconda -c conda-forge --quiet -y --name snakemake snakemake-minimal pytest

--- a/.github/workflows/qc.yml
+++ b/.github/workflows/qc.yml
@@ -33,9 +33,11 @@ jobs:
 
       - name: Setup Snakemake environment
         run: |
-           conda install -c conda-forge mamba --quiet
-           export PATH="/usr/share/miniconda/bin:$PATH"
-           mamba create -c bioconda -c conda-forge --quiet -y --name snakemake snakemake-minimal
+          # ensure that mamba is happy to write into the cache
+          sudo chown -R runner:docker /usr/share/miniconda/pkgs/cache
+          conda install -c conda-forge mamba --quiet
+          export PATH="/usr/share/miniconda/bin:$PATH"
+          mamba create -c bioconda -c conda-forge --quiet -y --name snakemake snakemake-minimal
       
       - name: Fetch master
         run: |


### PR DESCRIPTION
<!-- Ensure that the PR title follows conventional commit style (<type>: <description>)-->
<!-- Possible types are here: https://github.com/commitizen/conventional-commit-types/blob/master/index.json -->

### Description

<!-- Add a description of your PR here-->

### QC
<!-- Make sure that you can tick the boxes below. -->

For all wrappers added by this PR, I made sure that

* [x] there is a test case which covers any introduced changes,
* [x] `input:` and `output:` file paths in the resulting rule can be changed arbitrarily,
* [x] either the wrapper can only use a single core, or the example rule contains a `threads: x` statement with `x` being a reasonable default,
* [x] rule names in the test case are in [snake_case](https://en.wikipedia.org/wiki/Snake_case) and somehow tell what the rule is about or match the tools purpose or name (e.g., `map_reads` for a step that maps reads),
* [x] all `environment.yaml` specifications follow [the respective best practices](https://stackoverflow.com/a/64594513/2352071),
* [x] wherever possible, command line arguments are inferred and set automatically (e.g. based on file extensions in `input:` or `output:`),
* [x] all fields of the example rules in the `Snakefile`s and their entries are explained via comments (`input:`/`output:`/`params:` etc.),
* [x] `stderr` and/or `stdout` are logged correctly (`log:`), depending on the wrapped tool,
* [x] temporary files are either written to a unique hidden folder in the working directory, or (better) stored where the Python function `tempfile.gettempdir()` points to (see [here](https://docs.python.org/3/library/tempfile.html#tempfile.gettempdir); this also means that using any Python `tempfile` default behavior works),
* [x] the `meta.yaml` contains a link to the documentation of the respective tool or command,
* [x] `Snakefile`s pass the linting (`snakemake --lint`),
* [x] `Snakefile`s are formatted with [snakefmt](https://github.com/snakemake/snakefmt),
* [x] Python wrapper scripts are formatted with [black](https://black.readthedocs.io).
