### PR TITLE
fix: restrict bwa wrappers' picard installation to picard-slim (e.g. removes r-base dependency)

### DIFF
--- a/bio/bwa-mem2/mem/environment.yaml
+++ b/bio/bwa-mem2/mem/environment.yaml
@@ -5,4 +5,4 @@ channels:
 dependencies:
   - bwa-mem2 ==2.2.1
   - samtools ==1.12
-  - picard ==2.23
+  - picard-slim ==2.23

--- a/bio/bwa-mem2/mem/environment.yaml
+++ b/bio/bwa-mem2/mem/environment.yaml
@@ -5,4 +5,4 @@ channels:
 dependencies:
   - bwa-mem2 ==2.2.1
   - samtools ==1.12
-  - picard-slim ==2.23
+  - picard-slim =2.27

--- a/bio/bwa/mem/environment.yaml
+++ b/bio/bwa/mem/environment.yaml
@@ -5,4 +5,4 @@ channels:
 dependencies:
   - bwa ==0.7.17
   - samtools =1.12
-  - picard-slim =2.25
+  - picard-slim =2.27

--- a/bio/bwa/mem/environment.yaml
+++ b/bio/bwa/mem/environment.yaml
@@ -5,4 +5,4 @@ channels:
 dependencies:
   - bwa ==0.7.17
   - samtools =1.12
-  - picard =2.25
+  - picard-slim =2.25

--- a/bio/bwa/sampe/environment.yaml
+++ b/bio/bwa/sampe/environment.yaml
@@ -4,4 +4,4 @@ channels:
 dependencies:
   - bwa ==0.7.17
   - samtools ==1.9
-  - picard-slim ==2.20.1
+  - picard-slim =2.27

--- a/bio/bwa/sampe/environment.yaml
+++ b/bio/bwa/sampe/environment.yaml
@@ -4,4 +4,4 @@ channels:
 dependencies:
   - bwa ==0.7.17
   - samtools ==1.9
-  - picard ==2.20.1
+  - picard-slim ==2.20.1

--- a/bio/bwa/samse/environment.yaml
+++ b/bio/bwa/samse/environment.yaml
@@ -4,4 +4,4 @@ channels:
 dependencies:
   - bwa ==0.7.17
   - samtools ==1.9
-  - picard-slim ==2.20.1
+  - picard-slim =2.27

--- a/bio/bwa/samse/environment.yaml
+++ b/bio/bwa/samse/environment.yaml
@@ -4,4 +4,4 @@ channels:
 dependencies:
   - bwa ==0.7.17
   - samtools ==1.9
-  - picard ==2.20.1
+  - picard-slim ==2.20.1

--- a/bio/bwa/samxe/environment.yaml
+++ b/bio/bwa/samxe/environment.yaml
@@ -4,4 +4,4 @@ channels:
 dependencies:
   - bwa ==0.7.17
   - samtools ==1.9
-  - picard-slim ==2.20.1
+  - picard-slim =2.27

--- a/bio/bwa/samxe/environment.yaml
+++ b/bio/bwa/samxe/environment.yaml
@@ -4,4 +4,4 @@ channels:
 dependencies:
   - bwa ==0.7.17
   - samtools ==1.9
-  - picard ==2.20.1
+  - picard-slim ==2.20.1


### PR DESCRIPTION
### Description

Previously, the bwa wrappers pulled in the full `picard` bioconda package, which includes extensive extra dependencies that are not necessary for the functionality of the wrapper. `picard-slim` instead excludes as many extra dependencies, such as `r-base`.

### QC
For all wrappers added by this PR, I made sure that

* [x] there is a test case which covers any introduced changes,
* [x] `input:` and `output:` file paths in the resulting rule can be changed arbitrarily,
* [x] either the wrapper can only use a single core, or the example rule contains a `threads: x` statement with `x` being a reasonable default,
* [x] rule names in the test case are in [snake_case](https://en.wikipedia.org/wiki/Snake_case) and somehow tell what the rule is about or match the tools purpose or name (e.g., `map_reads` for a step that maps reads),
* [x] all `environment.yaml` specifications follow [the respective best practices](https://stackoverflow.com/a/64594513/2352071),
* [x] wherever possible, command line arguments are inferred and set automatically (e.g. based on file extensions in `input:` or `output:`),
* [x] all fields of the example rules in the `Snakefile`s and their entries are explained via comments (`input:`/`output:`/`params:` etc.),
* [x] `stderr` and/or `stdout` are logged correctly (`log:`), depending on the wrapped tool,
* [x] temporary files are either written to a unique hidden folder in the working directory, or (better) stored where the Python function `tempfile.gettempdir()` points to (see [here](https://docs.python.org/3/library/tempfile.html#tempfile.gettempdir); this also means that using any Python `tempfile` default behavior works),
* [x] the `meta.yaml` contains a link to the documentation of the respective tool or command,
* [x] `Snakefile`s pass the linting (`snakemake --lint`),
* [x] `Snakefile`s are formatted with [snakefmt](https://github.com/snakemake/snakefmt),
* [x] Python wrapper scripts are formatted with [black](https://black.readthedocs.io).
