### PR TITLE
feat: make it possible to set input as files or dirs to multiqc

### DIFF
--- a/bio/multiqc/meta.yaml
+++ b/bio/multiqc/meta.yaml
@@ -1,6 +1,7 @@
 name: multiqc
 description: |
   Generate qc report using multiqc.
+url: https://multiqc.info/
 authors:
   - Julian de Ruiter
 input:

--- a/bio/multiqc/meta.yaml
+++ b/bio/multiqc/meta.yaml
@@ -4,6 +4,8 @@ description: |
 authors:
   - Julian de Ruiter
 input:
-  - input directory containing qc files
+  - input directory containing qc files, default behaviour is to extract folder path from the provided files or parent folder if a folder is provided.
+params:
+  - use_input_files_only: if this variable is set to True input will be used as it is, i.e no folder will be extract from provided file names
 output:
   - qc report (html)

--- a/bio/multiqc/test/Snakefile
+++ b/bio/multiqc/test/Snakefile
@@ -1,10 +1,23 @@
-rule multiqc:
+rule multiqc_dir:
     input:
         expand("samtools_stats/{sample}.txt", sample=["a", "b"])
     output:
         "qc/multiqc.html"
     params:
-        ""  # Optional: extra parameters for multiqc.
+        extrra=""  # Optional: extra parameters for multiqc.
+    log:
+        "logs/multiqc.log"
+    wrapper:
+        "master/bio/multiqc"
+
+rule multiqc_file:
+    input:
+        expand("samtools_stats/{sample}.txt", sample=["a"])
+    output:
+        "qc/multiqc_a.html"
+    params:
+        extra="",  # Optional: extra parameters for multiqc.
+        use_files_as_input=False, # Optional, use only a.txt and don't search folder samtools_stats for files
     log:
         "logs/multiqc.log"
     wrapper:

--- a/bio/multiqc/test/Snakefile
+++ b/bio/multiqc/test/Snakefile
@@ -4,7 +4,7 @@ rule multiqc_dir:
     output:
         "qc/multiqc.html"
     params:
-        extrra=""  # Optional: extra parameters for multiqc.
+        extra=""  # Optional: extra parameters for multiqc.
     log:
         "logs/multiqc.log"
     wrapper:

--- a/bio/multiqc/test/Snakefile
+++ b/bio/multiqc/test/Snakefile
@@ -17,7 +17,7 @@ rule multiqc_file:
         "qc/multiqc_a.html"
     params:
         extra="",  # Optional: extra parameters for multiqc.
-        use_files_as_input=False, # Optional, use only a.txt and don't search folder samtools_stats for files
+        use_input_files_only=True, # Optional, use only a.txt and don't search folder samtools_stats for files
     log:
         "logs/multiqc.log"
     wrapper:

--- a/bio/multiqc/wrapper.py
+++ b/bio/multiqc/wrapper.py
@@ -11,17 +11,26 @@ from os import path
 from snakemake.shell import shell
 
 
-input_dirs = set(path.dirname(fp) for fp in snakemake.input)
+extra = snakemake.params.get("extra", "")
+# Set this to False if multiqc should use the actual input directly
+# instead of parsing the folders where the provided files are located
+convert_file_input_to_dirs = snakemake.params.get("use_files_as_input", True)
+
+if convert_file_input_to_dirs:
+    input_data = set(path.dirname(fp) for fp in snakemake.input)
+else:
+    input_data = set(snakemake.input)
+
 output_dir = path.dirname(snakemake.output[0])
 output_name = path.basename(snakemake.output[0])
 log = snakemake.log_fmt_shell(stdout=True, stderr=True)
 
 shell(
     "multiqc"
-    " {snakemake.params}"
+    " {extra}"
     " --force"
     " -o {output_dir}"
     " -n {output_name}"
-    " {input_dirs}"
+    " {input_data}"
     " {log}"
 )

--- a/bio/multiqc/wrapper.py
+++ b/bio/multiqc/wrapper.py
@@ -14,9 +14,9 @@ from snakemake.shell import shell
 extra = snakemake.params.get("extra", "")
 # Set this to False if multiqc should use the actual input directly
 # instead of parsing the folders where the provided files are located
-convert_file_input_to_dirs = snakemake.params.get("use_files_as_input", True)
+use_input_files_only = snakemake.params.get("use_input_files_only", False)
 
-if convert_file_input_to_dirs:
+if not use_input_files_only:
     input_data = set(path.dirname(fp) for fp in snakemake.input)
 else:
     input_data = set(snakemake.input)

--- a/test.py
+++ b/test.py
@@ -2052,6 +2052,12 @@ def test_multiqc():
         ["snakemake", "--cores", "1", "qc/multiqc.html", "--use-conda", "-F"],
     )
 
+@skip_if_not_modified
+def test_multiqc_a():
+    run(
+        "bio/multiqc",
+        ["snakemake", "--cores", "1", "qc/multiqc_a.html", "--use-conda", "-F"],
+    )
 
 @skip_if_not_modified
 def test_muscle_clw():


### PR DESCRIPTION
make it possible to use the actual input from the rule as input to multiqc, instead of converting it to dirs that are then searched.

### Description
If multiqc search directories it's possible that unwanted files are included to the reports. This will make it possible to only use the provided files, when wanted.

For all wrappers added by this PR, I made sure that

* [x] there is a test case which covers any introduced changes,
* [x] `input:` and `output:` file paths in the resulting rule can be changed arbitrarily,
* [x] either the wrapper can only use a single core, or the example rule contains a `threads: x` statement with `x` being a reasonable default,
* [x] rule names in the test case are in [snake_case](https://en.wikipedia.org/wiki/Snake_case) and somehow tell what the rule is about or match the tools purpose or name (e.g., `map_reads` for a step that maps reads),
* [x] all `environment.yaml` specifications follow [the respective best practices](https://stackoverflow.com/a/64594513/2352071),
* [x] wherever possible, command line arguments are inferred and set automatically (e.g. based on file extensions in `input:` or `output:`),
* [x] all fields of the example rules in the `Snakefile`s and their entries are explained via comments (`input:`/`output:`/`params:` etc.),
* [x] `stderr` and/or `stdout` are logged correctly (`log:`), depending on the wrapped tool,
* [x] temporary files are either written to a unique hidden folder in the working directory, or (better) stored where the Python function `tempfile.gettempdir()` points to (see [here](https://docs.python.org/3/library/tempfile.html#tempfile.gettempdir); this also means that using any Python `tempfile` default behavior works),
* [x] the `meta.yaml` contains a link to the documentation of the respective tool or command,
* [x] `Snakefile`s pass the linting (`snakemake --lint`),
* [x] `Snakefile`s are formatted with [snakefmt](https://github.com/snakemake/snakefmt),
* [x] Python wrapper scripts are formatted with [black](https://black.readthedocs.io).
