### PR TITLE
feat: output aln is saved from stdout, to reduce I/O

### DIFF
--- a/bio/star/align/meta.yaml
+++ b/bio/star/align/meta.yaml
@@ -1,5 +1,6 @@
 name: "star"
 description: Map reads with STAR.
+url: https://github.com/alexdobin/STAR
 authors:
   - Johannes Köster
   - Tomás Di Domenico
@@ -9,4 +10,3 @@ notes: |
   * It is advisable to consider updating the limits setting before running STAR,
     such as executing `ulimit -n 10000`, to avoid an issue like this:
     https://github.com/alexdobin/STAR/issues/1344 
-  * For more information see, https://github.com/alexdobin/STAR

--- a/bio/star/align/test/Snakefile
+++ b/bio/star/align/test/Snakefile
@@ -11,7 +11,6 @@ rule star_pe_multi:
         # see STAR manual for additional output files
         aln="star/pe/{sample}/pe_aligned.sam",
         log="logs/pe/{sample}/Log.out",
-        log_final="logs/pe/{sample}/Log.final.out",
         sj="star/pe/{sample}/SJ.out.tab",
     log:
         "logs/pe/{sample}.log",
@@ -33,7 +32,6 @@ rule star_se:
         aln="star/se/{sample}/se_aligned.bam",
         log="logs/se/{sample}/Log.out",
         log_final="logs/se/{sample}/Log.final.out",
-        sj="star/se/{sample}/SJ.out.tab",
     log:
         "logs/se/{sample}.log",
     params:

--- a/bio/star/align/test/Snakefile
+++ b/bio/star/align/test/Snakefile
@@ -5,15 +5,17 @@ rule star_pe_multi:
         fq1=["reads/{sample}_R1.1.fastq", "reads/{sample}_R1.2.fastq"],
         # paired end reads needs to be ordered so each item in the two lists match
         fq2=["reads/{sample}_R2.1.fastq", "reads/{sample}_R2.2.fastq"],  #optional
-    output:
-        # see STAR manual for additional output files
-        sam="star/pe/{sample}/Aligned.out.sam",
-        log="star/pe/{sample}/Log.out",
-    log:
-        "logs/star/pe/{sample}.log",
-    params:
         # path to STAR reference genome index
         idx="index",
+    output:
+        # see STAR manual for additional output files
+        aln="star/pe/{sample}/pe_aligned.sam",
+        log="logs/pe/{sample}/Log.out",
+        log_final="logs/pe/{sample}/Log.final.out",
+        sj="star/pe/{sample}/SJ.out.tab",
+    log:
+        "logs/pe/{sample}.log",
+    params:
         # optional parameters
         extra="",
     threads: 8
@@ -24,17 +26,19 @@ rule star_pe_multi:
 rule star_se:
     input:
         fq1="reads/{sample}_R1.1.fastq",
-    output:
-        # see STAR manual for additional output files
-        sam="star/se/{sample}/Aligned.out.sam",
-        log="star/se/{sample}/Log.out",
-    log:
-        "logs/star/se/{sample}.log",
-    params:
         # path to STAR reference genome index
         idx="index",
+    output:
+        # see STAR manual for additional output files
+        aln="star/se/{sample}/se_aligned.bam",
+        log="logs/se/{sample}/Log.out",
+        log_final="logs/se/{sample}/Log.final.out",
+        sj="star/se/{sample}/SJ.out.tab",
+    log:
+        "logs/se/{sample}.log",
+    params:
         # optional parameters
-        extra="",
+        extra="--outSAMtype BAM Unsorted",
     threads: 8
     wrapper:
         "master/bio/star/align"

--- a/meta/bio/star_arriba/test/Snakefile
+++ b/meta/bio/star_arriba/test/Snakefile
@@ -23,7 +23,7 @@ rule star_align:
         idx="resources/star_genome",
     output:
         # see STAR manual for additional output files
-        bam="star/{sample}/Aligned.out.bam",
+        aln="star/{sample}/Aligned.out.bam",
         reads_per_gene="star/{sample}/ReadsPerGene.out.tab",
     log:
         "logs/star/{sample}.log",

--- a/test.py
+++ b/test.py
@@ -2701,11 +2701,11 @@ def test_star_align():
 
     run(
         "bio/star/align",
-        ["snakemake", "--cores", "1", "star/se/a/Aligned.out.sam", "--use-conda", "-F"],
+        ["snakemake", "--cores", "1", "star/se/a/se_aligned.bam", "--use-conda", "-F"],
     )
     run(
         "bio/star/align",
-        ["snakemake", "--cores", "1", "star/pe/a/Aligned.out.sam", "--use-conda", "-F"],
+        ["snakemake", "--cores", "1", "star/pe/a/pe_aligned.sam", "--use-conda", "-F"],
     )
 
 


### PR DESCRIPTION
<!-- Ensure that the PR title follows conventional commit style (<type>: <description>)-->
<!-- Possible types are here: https://github.com/commitizen/conventional-commit-types/blob/master/index.json -->

### Description

<!-- Add a description of your PR here-->
- Allow fastq files compressed with `bz2`
- Fix issue #495 
- Use `stdout` for alignment output, to avoid excessive I/O

### QC
<!-- Make sure that you can tick the boxes below. -->

For all wrappers added by this PR, I made sure that

* [x] there is a test case which covers any introduced changes,
* [x] `input:` and `output:` file paths in the resulting rule can be changed arbitrarily,
* [x] either the wrapper can only use a single core, or the example rule contains a `threads: x` statement with `x` being a reasonable default,
* [x] rule names in the test case are in [snake_case](https://en.wikipedia.org/wiki/Snake_case) and somehow tell what the rule is about or match the tools purpose or name (e.g., `map_reads` for a step that maps reads),
* [x] all `environment.yaml` specifications follow [the respective best practices](https://stackoverflow.com/a/64594513/2352071),
* [ ] wherever possible, command line arguments are inferred and set automatically (e.g. based on file extensions in `input:` or `output:`),
* [x] all fields of the example rules in the `Snakefile`s and their entries are explained via comments (`input:`/`output:`/`params:` etc.),
* [x] `stderr` and/or `stdout` are logged correctly (`log:`), depending on the wrapped tool,
* [x] temporary files are either written to a unique hidden folder in the working directory, or (better) stored where the Python function `tempfile.gettempdir()` points to (see [here](https://docs.python.org/3/library/tempfile.html#tempfile.gettempdir); this also means that using any Python `tempfile` default behavior works),
* [x] the `meta.yaml` contains a link to the documentation of the respective tool or command,
* [x] `Snakefile`s pass the linting (`snakemake --lint`),
* [x] `Snakefile`s are formatted with [snakefmt](https://github.com/snakemake/snakefmt),
* [x] Python wrapper scripts are formatted with [black](https://black.readthedocs.io).
