### PR TITLE
perf: updated cutadapt version, formated files, and improved docs.

### DIFF
--- a/bio/cutadapt/pe/environment.yaml
+++ b/bio/cutadapt/pe/environment.yaml
@@ -1,6 +1,6 @@
 channels:
-  - bioconda
   - conda-forge
+  - bioconda
   - defaults
 dependencies:
   - cutadapt =4.1

--- a/bio/cutadapt/pe/environment.yaml
+++ b/bio/cutadapt/pe/environment.yaml
@@ -3,4 +3,4 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - cutadapt =4
+  - cutadapt =4.1

--- a/bio/cutadapt/pe/environment.yaml
+++ b/bio/cutadapt/pe/environment.yaml
@@ -3,4 +3,4 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - cutadapt ==3.4
+  - cutadapt =4

--- a/bio/cutadapt/pe/meta.yaml
+++ b/bio/cutadapt/pe/meta.yaml
@@ -1,6 +1,7 @@
 name: cutadapt-pe
 description: |
   Trim paired-end reads using cutadapt.
+url: https://github.com/marcelm/cutadapt
 authors:
   - Julian de Ruiter
   - David Laehnemann
@@ -9,3 +10,6 @@ input:
 output:
   - two trimmed (paired-end) fastq files
   - text file containing trimming statistics
+notes: |
+  * The `extra` param allows for additional program arguments.
+  * The `adapters` param allows for separatelly specifying adapter options (optional).

--- a/bio/cutadapt/pe/test/Snakefile
+++ b/bio/cutadapt/pe/test/Snakefile
@@ -1,17 +1,17 @@
 rule cutadapt:
     input:
-        ["reads/{sample}.1.fastq", "reads/{sample}.2.fastq"]
+        ["reads/{sample}.1.fastq", "reads/{sample}.2.fastq"],
     output:
         fastq1="trimmed/{sample}.1.fastq",
         fastq2="trimmed/{sample}.2.fastq",
-        qc="trimmed/{sample}.qc.txt"
+        qc="trimmed/{sample}.qc.txt",
     params:
         # https://cutadapt.readthedocs.io/en/stable/guide.html#adapter-types
         adapters="-a AGAGCACACGTCTGAACTCCAGTCAC -g AGATCGGAAGAGCACACGT -A AGAGCACACGTCTGAACTCCAGTCAC -G AGATCGGAAGAGCACACGT",
         # https://cutadapt.readthedocs.io/en/stable/guide.html#
-        extra="--minimum-length 1 -q 20"
+        extra="--minimum-length 1 -q 20",
     log:
-        "logs/cutadapt/{sample}.log"
-    threads: 4 # set desired number of threads here
+        "logs/cutadapt/{sample}.log",
+    threads: 4  # set desired number of threads here
     wrapper:
         "master/bio/cutadapt/pe"

--- a/bio/cutadapt/pe/wrapper.py
+++ b/bio/cutadapt/pe/wrapper.py
@@ -22,11 +22,11 @@ assert (
 
 shell(
     "cutadapt"
+    " --cores {snakemake.threads}"
     " {adapters}"
     " {extra}"
     " -o {snakemake.output.fastq1}"
     " -p {snakemake.output.fastq2}"
-    " -j {snakemake.threads}"
     " {snakemake.input}"
     " > {snakemake.output.qc} {log}"
 )

--- a/bio/cutadapt/se/environment.yaml
+++ b/bio/cutadapt/se/environment.yaml
@@ -1,6 +1,6 @@
 channels:
-  - bioconda
   - conda-forge
+  - bioconda
   - defaults
 dependencies:
   - cutadapt =4.1

--- a/bio/cutadapt/se/environment.yaml
+++ b/bio/cutadapt/se/environment.yaml
@@ -3,4 +3,4 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - cutadapt =4
+  - cutadapt =4.1

--- a/bio/cutadapt/se/environment.yaml
+++ b/bio/cutadapt/se/environment.yaml
@@ -3,4 +3,4 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - cutadapt ==3.4
+  - cutadapt =4

--- a/bio/cutadapt/se/meta.yaml
+++ b/bio/cutadapt/se/meta.yaml
@@ -1,6 +1,7 @@
 name: cutadapt-se
 description: |
   Trim single-end reads using cutadapt.
+url: https://github.com/marcelm/cutadapt
 authors:
   - Julian de Ruiter
 input:
@@ -8,3 +9,6 @@ input:
 output:
   - trimmed fastq file
   - text file containing trimming statistics
+notes: |
+  * The `extra` param allows for additional program arguments.
+  * The `adapters` param allows for separatelly specifying adapter options (optional).

--- a/bio/cutadapt/se/test/Snakefile
+++ b/bio/cutadapt/se/test/Snakefile
@@ -1,14 +1,14 @@
 rule cutadapt:
     input:
-        "reads/{sample}.fastq"
+        "reads/{sample}.fastq",
     output:
         fastq="trimmed/{sample}.fastq",
-        qc="trimmed/{sample}.qc.txt"
+        qc="trimmed/{sample}.qc.txt",
     params:
         adapters="-a AGATCGGAAGAGCACACGTCTGAACTCCAGTCAC",
-        extra="-q 20"
+        extra="-q 20",
     log:
-        "logs/cutadapt/{sample}.log"
-    threads: 4 # set desired number of threads here
+        "logs/cutadapt/{sample}.log",
+    threads: 4  # set desired number of threads here
     wrapper:
         "master/bio/cutadapt/se"

--- a/bio/cutadapt/se/wrapper.py
+++ b/bio/cutadapt/se/wrapper.py
@@ -22,9 +22,9 @@ assert (
 
 shell(
     "cutadapt"
+    " --cores {snakemake.threads}"
     " {adapters}"
     " {extra}"
-    " -j {snakemake.threads}"
     " -o {snakemake.output.fastq}"
     " {snakemake.input[0]}"
     " > {snakemake.output.qc} {log}"


### PR DESCRIPTION
<!-- Ensure that the PR title follows conventional commit style (<type>: <description>)-->
<!-- Possible types are here: https://github.com/commitizen/conventional-commit-types/blob/master/index.json -->

### Description

<!-- Add a description of your PR here-->
Updated cutadapt version to v4, formated files with `black` and `snakefmt`, and improved docs.

### QC
<!-- Make sure that you can tick the boxes below. -->

For all wrappers added by this PR, I made sure that

* [x] there is a test case which covers any introduced changes,
* [x] `input:` and `output:` file paths in the resulting rule can be changed arbitrarily,
* [x] either the wrapper can only use a single core, or the example rule contains a `threads: x` statement with `x` being a reasonable default,
* [x] rule names in the test case are in [snake_case](https://en.wikipedia.org/wiki/Snake_case) and somehow tell what the rule is about or match the tools purpose or name (e.g., `map_reads` for a step that maps reads),
* [x] all `environment.yaml` specifications follow [the respective best practices](https://stackoverflow.com/a/64594513/2352071),
* [x] wherever possible, command line arguments are inferred and set automatically (e.g. based on file extensions in `input:` or `output:`),
* [x] all fields of the example rules in the `Snakefile`s and their entries are explained via comments (`input:`/`output:`/`params:` etc.),
* [x] `stderr` and/or `stdout` are logged correctly (`log:`), depending on the wrapped tool,
* [ ] temporary files are either written to a unique hidden folder in the working directory, or (better) stored where the Python function `tempfile.gettempdir()` points to (see [here](https://docs.python.org/3/library/tempfile.html#tempfile.gettempdir); this also means that using any Python `tempfile` default behavior works),
* [x] the `meta.yaml` contains a link to the documentation of the respective tool or command,
* [x] `Snakefile`s pass the linting (`snakemake --lint`),
* [x] `Snakefile`s are formatted with [snakefmt](https://github.com/snakemake/snakefmt),
* [x] Python wrapper scripts are formatted with [black](https://black.readthedocs.io).
