### PR TITLE
fix: remove misleading kmer size parameter for kallisto index

### DIFF
--- a/bio/kallisto/index/test/Snakefile
+++ b/bio/kallisto/index/test/Snakefile
@@ -1,12 +1,12 @@
 rule kallisto_index:
     input:
-        fasta = "{transcriptome}.fasta"
+        fasta="{transcriptome}.fasta",
     output:
-        index = "{transcriptome}.idx"
+        index="{transcriptome}.idx",
     params:
-        extra = "--kmer-size=5"
+        extra="",  # optional parameters
     log:
-        "logs/kallisto_index_{transcriptome}.log"
+        "logs/kallisto_index_{transcriptome}.log",
     threads: 1
     wrapper:
         "master/bio/kallisto/index"

--- a/bio/kallisto/quant/test/Snakefile
+++ b/bio/kallisto/quant/test/Snakefile
@@ -1,13 +1,13 @@
 rule kallisto_quant:
     input:
-        fastq = ["reads/{exp}_R1.fastq", "reads/{exp}_R2.fastq"],
-        index = "index/transcriptome.idx"
+        fastq=["reads/{exp}_R1.fastq", "reads/{exp}_R2.fastq"],
+        index="index/transcriptome.idx",
     output:
-        directory('quant_results_{exp}')
+        directory("quant_results_{exp}"),
     params:
-        extra = ""
+        extra="",
     log:
-        "logs/kallisto_quant_{exp}.log"
+        "logs/kallisto_quant_{exp}.log",
     threads: 1
     wrapper:
         "master/bio/kallisto/quant"


### PR DESCRIPTION
<!-- Ensure that the PR title follows conventional commit style (<type>: <description>)-->
<!-- Possible types are here: https://github.com/commitizen/conventional-commit-types/blob/master/index.json -->

### Description

<!-- Add a description of your PR here-->

### QC
<!-- Make sure that you can tick the boxes below. -->

For all wrappers added by this PR, I made sure that

* [x] there is a test case which covers any introduced changes,
* [x] `input:` and `output:` file paths in the resulting rule can be changed arbitrarily,
* [x] either the wrapper can only use a single core, or the example rule contains a `threads: x` statement with `x` being a reasonable default,
* [x] rule names in the test case are in [snake_case](https://en.wikipedia.org/wiki/Snake_case) and somehow tell what the rule is about or match the tools purpose or name (e.g., `map_reads` for a step that maps reads),
* [x] all `environment.yaml` specifications follow [the respective best practices](https://stackoverflow.com/a/64594513/2352071),
* [x] wherever possible, command line arguments are inferred and set automatically (e.g. based on file extensions in `input:` or `output:`),
* [x] all fields of the example rules in the `Snakefile`s and their entries are explained via comments (`input:`/`output:`/`params:` etc.),
* [x] `stderr` and/or `stdout` are logged correctly (`log:`), depending on the wrapped tool,
* [x] temporary files are either written to a unique hidden folder in the working directory, or (better) stored where the Python function `tempfile.gettempdir()` points to (see [here](https://docs.python.org/3/library/tempfile.html#tempfile.gettempdir); this also means that using any Python `tempfile` default behavior works),
* [x] the `meta.yaml` contains a link to the documentation of the respective tool or command,
* [x] `Snakefile`s pass the linting (`snakemake --lint`),
* [x] `Snakefile`s are formatted with [snakefmt](https://github.com/snakemake/snakefmt),
* [x] Python wrapper scripts are formatted with [black](https://black.readthedocs.io).
