### PR TITLE
fix: version of pbmm2.

### DIFF
--- a/bio/pbmm2/align/environment.yaml
+++ b/bio/pbmm2/align/environment.yaml
@@ -3,4 +3,4 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - pbmm2 ==1.4.0
+  - pbmm2 ==1.3.0


### PR DESCRIPTION
<!-- Ensure that the PR title follows conventional commit style (<type>: <description>)-->
<!-- Possible types are here: https://github.com/commitizen/conventional-commit-types/blob/master/index.json -->

### Description

pbmm2 version 1.4.0 does not exist in the present, so i fixed the environment file. there are other problems with this wrapper, but this is just a very annoying typo.