### PR TITLE
fix: better error handling for ensembl sequence download

### DIFF
--- a/bio/reference/ensembl-sequence/wrapper.py
+++ b/bio/reference/ensembl-sequence/wrapper.py
@@ -48,17 +48,12 @@ if chromosome:
             "invalid datatype, to select a single chromosome the datatype must be dna"
         )
 
+spec = spec.format(build=build, release=release)
+url_prefix = f"ftp://ftp.ensembl.org/pub/{branch}release-{release}/fasta/{species}/{datatype}/{species.capitalize()}.{spec}"
+
 success = False
 for suffix in suffixes:
-    url = "ftp://ftp.ensembl.org/pub/{branch}release-{release}/fasta/{species}/{datatype}/{species_cap}.{spec}.{suffix}".format(
-        release=release,
-        species=species,
-        datatype=datatype,
-        spec=spec.format(build=build, release=release),
-        suffix=suffix,
-        species_cap=species.capitalize(),
-        branch=branch,
-    )
+    url = f"{url_prefix}.{suffix}"
 
     try:
         shell("curl -sSf {url} > /dev/null 2> /dev/null")
@@ -70,9 +65,14 @@ for suffix in suffixes:
     break
 
 if not success:
+    if len(suffixes) > 1:
+        url = f"{url_prefix}.[{'|'.join(suffixes)}]"
+    else:
+        url = f"{url_prefix}.{suffixes[0]}"
     print(
-        "Unable to download requested sequence data from Ensembl. "
-        "Did you check that this combination of species, build, and release is actually provided?",
+        f"Unable to download requested sequence data from Ensembl ({url}). "
+        "Please check whether above URL is currently available (might be a temporal server issue). "
+        "Apart from that, did you check that this combination of species, build, and release is actually provided?",
         file=sys.stderr,
     )
     exit(1)


### PR DESCRIPTION
<!-- Ensure that the PR title follows conventional commit style (<type>: <description>)-->
<!-- Possible types are here: https://github.com/commitizen/conventional-commit-types/blob/master/index.json -->

### Description

<!-- Add a description of your PR here-->

### QC
<!-- Make sure that you can tick the boxes below. -->

For all wrappers added by this PR, I made sure that

* [x] there is a test case which covers any introduced changes,
* [x] `input:` and `output:` file paths in the resulting rule can be changed arbitrarily,
* [x] either the wrapper can only use a single core, or the example rule contains a `threads: x` statement with `x` being a reasonable default,
* [x] rule names in the test case are in [snake_case](https://en.wikipedia.org/wiki/Snake_case) and somehow tell what the rule is about or match the tools purpose or name (e.g., `map_reads` for a step that maps reads),
* [x] all `environment.yaml` specifications follow [the respective best practices](https://stackoverflow.com/a/64594513/2352071),
* [x] wherever possible, command line arguments are inferred and set automatically (e.g. based on file extensions in `input:` or `output:`),
* [x] all fields of the example rules in the `Snakefile`s and their entries are explained via comments (`input:`/`output:`/`params:` etc.),
* [x] `stderr` and/or `stdout` are logged correctly (`log:`), depending on the wrapped tool,
* [x] temporary files are either written to a unique hidden folder in the working directory, or (better) stored where the Python function `tempfile.gettempdir()` points to (see [here](https://docs.python.org/3/library/tempfile.html#tempfile.gettempdir); this also means that using any Python `tempfile` default behavior works),
* [x] the `meta.yaml` contains a link to the documentation of the respective tool or command,
* [x] `Snakefile`s pass the linting (`snakemake --lint`),
* [x] `Snakefile`s are formatted with [snakefmt](https://github.com/snakemake/snakefmt),
* [x] Python wrapper scripts are formatted with [black](https://black.readthedocs.io).
