### PR TITLE
feat: fixed minimap2 bioconda strict channels, updated version, and added test

### DIFF
--- a/bio/minimap2/aligner/environment.yaml
+++ b/bio/minimap2/aligner/environment.yaml
@@ -1,7 +1,8 @@
 channels:
-  - bioconda
   - conda-forge
+  - bioconda
   - defaults
 dependencies:
-  - minimap2 ==2.17
-  - samtools ==1.12
+  - minimap2 =2
+  - samtools
+  - snakemake-wrapper-utils =0.4

--- a/bio/minimap2/aligner/environment.yaml
+++ b/bio/minimap2/aligner/environment.yaml
@@ -1,7 +1,7 @@
 channels:
   - conda-forge
   - bioconda
-  - defaults
+  - nodefaults
 dependencies:
   - minimap2 =2.24
   - samtools

--- a/bio/minimap2/aligner/environment.yaml
+++ b/bio/minimap2/aligner/environment.yaml
@@ -3,6 +3,6 @@ channels:
   - bioconda
   - defaults
 dependencies:
-  - minimap2 =2
+  - minimap2 =2.24
   - samtools
   - snakemake-wrapper-utils =0.4

--- a/bio/minimap2/aligner/meta.yaml
+++ b/bio/minimap2/aligner/meta.yaml
@@ -1,5 +1,6 @@
 name: minimap2
 description: A versatile pairwise aligner for genomic and spliced nucleotide sequences.
+url: https://lh3.github.io/minimap2
 authors:
   - Tom Poorten
   - Michael Hall
@@ -13,4 +14,3 @@ notes: |
   * The `extra` param allows for additional arguments for minimap2.
   * The `sort` param allows to enable sorting (if output not PAF), and can be either 'none', 'queryname' or 'coordinate'.
   * The `sort_extra` allows for extra arguments for samtools/picard
-  * For more inforamtion see, https://lh3.github.io/minimap2

--- a/bio/minimap2/aligner/test/Snakefile
+++ b/bio/minimap2/aligner/test/Snakefile
@@ -32,12 +32,29 @@ rule minimap2_sam:
         "master/bio/minimap2/aligner"
 
 
-rule minimap2_bam:
+rule minimap2_sam_sorted:
     input:
         target="target/{input1}.mmi",  # can be either genome index or genome fasta
         query=["query/reads1.fasta", "query/reads2.fasta"],
     output:
-        "aligned/{input1}_aln.bam",
+        "aligned/{input1}_aln.sorted.sam",
+    log:
+        "logs/minimap2/{input1}.log",
+    params:
+        extra="-x map-pb",  # optional
+        sorting="queryname",  # optional: Enable sorting. Possible values: 'none', 'queryname' or 'coordinate'
+        sort_extra="",  # optional: extra arguments for samtools/picard
+    threads: 3
+    wrapper:
+        "master/bio/minimap2/aligner"
+
+
+rule minimap2_bam_sorted:
+    input:
+        target="target/{input1}.mmi",  # can be either genome index or genome fasta
+        query=["query/reads1.fasta", "query/reads2.fasta"],
+    output:
+        "aligned/{input1}_aln.sorted.bam",
     log:
         "logs/minimap2/{input1}.log",
     params:

--- a/bio/minimap2/aligner/test/Snakefile
+++ b/bio/minimap2/aligner/test/Snakefile
@@ -1,47 +1,49 @@
 rule minimap2_paf:
     input:
-        target="target/{input1}.mmi", # can be either genome index or genome fasta
-        query=["query/reads1.fasta", "query/reads2.fasta"]
+        target="target/{input1}.mmi",  # can be either genome index or genome fasta
+        query=["query/reads1.fasta", "query/reads2.fasta"],
     output:
-        "aligned/{input1}_aln.paf"
+        "aligned/{input1}_aln.paf",
     log:
-        "logs/minimap2/{input1}.log"
+        "logs/minimap2/{input1}.log",
     params:
-        extra="-x map-pb",           # optional
-        sorting="coordinate",           # optional: Enable sorting. Possible values: 'none', 'queryname' or 'coordinate'
-        sort_extra=""                # optional: extra arguments for samtools/picard
+        extra="-x map-pb",  # optional
+        sorting="coordinate",  # optional: Enable sorting. Possible values: 'none', 'queryname' or 'coordinate'
+        sort_extra="",  # optional: extra arguments for samtools/picard
     threads: 3
     wrapper:
         "master/bio/minimap2/aligner"
+
 
 rule minimap2_sam:
     input:
-        target="target/{input1}.mmi", # can be either genome index or genome fasta
-        query=["query/reads1.fasta", "query/reads2.fasta"]
+        target="target/{input1}.mmi",  # can be either genome index or genome fasta
+        query=["query/reads1.fasta", "query/reads2.fasta"],
     output:
-        "aligned/{input1}_aln.sam"
+        "aligned/{input1}_aln.sam",
     log:
-        "logs/minimap2/{input1}.log"
+        "logs/minimap2/{input1}.log",
     params:
-        extra="-x map-pb",           # optional
-        sorting="none",                 # optional: Enable sorting. Possible values: 'none', 'queryname' or 'coordinate'
-        sort_extra=""                # optional: extra arguments for samtools/picard
+        extra="-x map-pb",  # optional
+        sorting="none",  # optional: Enable sorting. Possible values: 'none', 'queryname' or 'coordinate'
+        sort_extra="",  # optional: extra arguments for samtools/picard
     threads: 3
     wrapper:
         "master/bio/minimap2/aligner"
 
+
 rule minimap2_bam:
     input:
-        target="target/{input1}.mmi", # can be either genome index or genome fasta
-        query=["query/reads1.fasta", "query/reads2.fasta"]
+        target="target/{input1}.mmi",  # can be either genome index or genome fasta
+        query=["query/reads1.fasta", "query/reads2.fasta"],
     output:
-        "aligned/{input1}_aln.bam"
+        "aligned/{input1}_aln.bam",
     log:
-        "logs/minimap2/{input1}.log"
+        "logs/minimap2/{input1}.log",
     params:
-        extra="-x map-pb",           # optional
-        sorting="coordinate",           # optional: Enable sorting. Possible values: 'none', 'queryname' or 'coordinate'
-        sort_extra=""                # optional: extra arguments for samtools/picard
+        extra="-x map-pb",  # optional
+        sorting="coordinate",  # optional: Enable sorting. Possible values: 'none', 'queryname' or 'coordinate'
+        sort_extra="",  # optional: extra arguments for samtools/picard
     threads: 3
     wrapper:
         "master/bio/minimap2/aligner"

--- a/bio/minimap2/aligner/wrapper.py
+++ b/bio/minimap2/aligner/wrapper.py
@@ -3,23 +3,20 @@ __copyright__ = "Copyright 2017, Tom Poorten"
 __email__ = "tom.poorten@gmail.com"
 __license__ = "MIT"
 
+
 from os import path
 from snakemake.shell import shell
+from snakemake_wrapper_utils.samtools import infer_out_format
+from snakemake_wrapper_utils.samtools import get_samtools_opts
 
 
-inputQuery = " ".join(snakemake.input.query)
-
-# Extract output format
-out_name, out_ext = path.splitext(snakemake.output[0])
-out_ext = out_ext[1:].upper()
-
-# Extract arguments.
+samtools_opts = get_samtools_opts(snakemake, parse_output=False)
 extra = snakemake.params.get("extra", "")
-
+log = snakemake.log_fmt_shell(stdout=False, stderr=True)
 sort = snakemake.params.get("sorting", "none")
 sort_extra = snakemake.params.get("sort_extra", "")
 
-log = snakemake.log_fmt_shell(stdout=False, stderr=True)
+out_ext = infer_out_format(snakemake.output[0])
 
 pipe_cmd = ""
 if out_ext != "PAF":
@@ -31,7 +28,7 @@ if out_ext != "PAF":
 
         if out_ext != "SAM":
             # Simply convert to output format using samtools view.
-            pipe_cmd = "| samtools view -h --output-fmt {} -".format(out_ext)
+            pipe_cmd = f"| samtools view -h {samtools_opts} -"
 
     elif sort in ["coordinate", "queryname"]:
 
@@ -40,13 +37,19 @@ if out_ext != "PAF":
             sort_extra += " -n"
 
         # Sort alignments.
-        pipe_cmd = "| samtools sort {} --output-fmt {} -".format(sort_extra, out_ext)
+        pipe_cmd = f"| samtools sort {sort_extra} {samtools_opts} -"
 
     else:
-        raise ValueError("Unexpected value for params.sort ({})".format(sort))
+        raise ValueError(f"Unexpected value for params.sort: {sort}")
 
 
 shell(
-    "(minimap2 -t {snakemake.threads} {extra} "
-    "{snakemake.input.target} {inputQuery} {pipe_cmd} > {snakemake.output[0]}) {log}"
+    "minimap2"
+    " -t {snakemake.threads}"
+    " {extra} "
+    " {snakemake.input.target}"
+    " {snakemake.input.query}"
+    " {pipe_cmd}"
+    " > {snakemake.output[0]}"
+    " {log}"
 )

--- a/bio/minimap2/aligner/wrapper.py
+++ b/bio/minimap2/aligner/wrapper.py
@@ -28,7 +28,7 @@ if out_ext != "PAF":
 
         if out_ext != "SAM":
             # Simply convert to output format using samtools view.
-            pipe_cmd = f"| samtools view -h {samtools_opts} -"
+            pipe_cmd = f"| samtools view -h {samtools_opts}"
 
     elif sort in ["coordinate", "queryname"]:
 
@@ -37,19 +37,19 @@ if out_ext != "PAF":
             sort_extra += " -n"
 
         # Sort alignments.
-        pipe_cmd = f"| samtools sort {sort_extra} {samtools_opts} -"
+        pipe_cmd = f"| samtools sort {sort_extra} {samtools_opts}"
 
     else:
         raise ValueError(f"Unexpected value for params.sort: {sort}")
 
 
 shell(
-    "minimap2"
+    "(minimap2"
     " -t {snakemake.threads}"
     " {extra} "
     " {snakemake.input.target}"
     " {snakemake.input.query}"
     " {pipe_cmd}"
     " > {snakemake.output[0]}"
-    " {log}"
+    ") {log}"
 )

--- a/bio/minimap2/index/environment.yaml
+++ b/bio/minimap2/index/environment.yaml
@@ -1,6 +1,6 @@
 channels:
   - conda-forge
   - bioconda
-  - defaults
+  - nodefaults
 dependencies:
   - minimap2 =2.24

--- a/bio/minimap2/index/environment.yaml
+++ b/bio/minimap2/index/environment.yaml
@@ -1,6 +1,6 @@
 channels:
-  - bioconda
   - conda-forge
+  - bioconda
   - defaults
 dependencies:
-  - minimap2 ==2.17
+  - minimap2 =2

--- a/bio/minimap2/index/environment.yaml
+++ b/bio/minimap2/index/environment.yaml
@@ -3,4 +3,4 @@ channels:
   - bioconda
   - defaults
 dependencies:
-  - minimap2 =2
+  - minimap2 =2.24

--- a/bio/minimap2/index/meta.yaml
+++ b/bio/minimap2/index/meta.yaml
@@ -1,4 +1,9 @@
 name: minimap2 index
 description: creates a minimap2 index
+url: https://lh3.github.io/minimap2
 authors:
   - Tom Poorten
+input:
+  - reference genome in FASTA format
+output:
+  - indexed reference genome

--- a/test.py
+++ b/test.py
@@ -2035,10 +2035,18 @@ def test_minimap2_aligner_sam():
 
 
 @skip_if_not_modified
-def test_minimap2_aligner_bam():
+def test_minimap2_aligner_sam_sorted():
     run(
         "bio/minimap2/aligner",
-        ["snakemake", "--cores", "1", "aligned/genome_aln.bam", "--use-conda", "-F"],
+        ["snakemake", "--cores", "1", "aligned/genome_aln.sorted.sam", "--use-conda", "-F"],
+    )
+
+
+@skip_if_not_modified
+def test_minimap2_aligner_bam_sorted():
+    run(
+        "bio/minimap2/aligner",
+        ["snakemake", "--cores", "1", "aligned/genome_aln.sorted.bam", "--use-conda", "-F"],
     )
 
 


### PR DESCRIPTION
<!-- Ensure that the PR title follows conventional commit style (<type>: <description>)-->
<!-- Possible types are here: https://github.com/commitizen/conventional-commit-types/blob/master/index.json -->

### Description

<!-- Add a description of your PR here-->

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] I confirm that:

For all wrappers added by this PR, 

* there is a test case which covers any introduced changes,
* `input:` and `output:` file paths in the resulting rule can be changed arbitrarily,
* either the wrapper can only use a single core, or the example rule contains a `threads: x` statement with `x` being a reasonable default,
* rule names in the test case are in [snake_case](https://en.wikipedia.org/wiki/Snake_case) and somehow tell what the rule is about or match the tools purpose or name (e.g., `map_reads` for a step that maps reads),
* all `environment.yaml` specifications follow [the respective best practices](https://stackoverflow.com/a/64594513/2352071),
* wherever possible, command line arguments are inferred and set automatically (e.g. based on file extensions in `input:` or `output:`),
* all fields of the example rules in the `Snakefile`s and their entries are explained via comments (`input:`/`output:`/`params:` etc.),
* `stderr` and/or `stdout` are logged correctly (`log:`), depending on the wrapped tool,
* temporary files are either written to a unique hidden folder in the working directory, or (better) stored where the Python function `tempfile.gettempdir()` points to (see [here](https://docs.python.org/3/library/tempfile.html#tempfile.gettempdir); this also means that using any Python `tempfile` default behavior works),
* the `meta.yaml` contains a link to the documentation of the respective tool or command,
* `Snakefile`s pass the linting (`snakemake --lint`),
* `Snakefile`s are formatted with [snakefmt](https://github.com/snakemake/snakefmt),
* Python wrapper scripts are formatted with [black](https://black.readthedocs.io).
