### PR TITLE
feat: support branches (e.g. plants) in ensembl wrappers for sequence, annotation, and variation download

### DIFF
--- a/bio/reference/ensembl-annotation/test/Snakefile
+++ b/bio/reference/ensembl-annotation/test/Snakefile
@@ -6,6 +6,7 @@ rule get_annotation:
         release="87",
         build="GRCh37",
         flavor="",  # optional, e.g. chr_patch_hapl_scaff, see Ensembl FTP.
+        # branch="plants",  # optional: specify branch
     log:
         "logs/get_annotation.log",
     cache: True  # save space and time with between workflow caching (see docs)
@@ -21,6 +22,7 @@ rule get_annotation_gz:
         release="87",
         build="GRCh37",
         flavor="",  # optional, e.g. chr_patch_hapl_scaff, see Ensembl FTP.
+        # branch="plants",  # optional: specify branch
     log:
         "logs/get_annotation.log",
     cache: True  # save space and time with between workflow caching (see docs)

--- a/bio/reference/ensembl-annotation/wrapper.py
+++ b/bio/reference/ensembl-annotation/wrapper.py
@@ -24,6 +24,8 @@ branch = ""
 if release >= 81 and build == "GRCh37":
     # use the special grch37 branch for new releases
     branch = "grch37/"
+elif snakemake.params.get("branch"):
+    branch = snakemake.params.branch + "/"
 
 
 flavor = snakemake.params.get("flavor", "")

--- a/bio/reference/ensembl-sequence/test/Snakefile
+++ b/bio/reference/ensembl-sequence/test/Snakefile
@@ -1,28 +1,30 @@
 rule get_genome:
     output:
-        "refs/genome.fasta"
+        "refs/genome.fasta",
     params:
         species="saccharomyces_cerevisiae",
         datatype="dna",
         build="R64-1-1",
-        release="98"
+        release="98",
     log:
-        "logs/get_genome.log"
+        "logs/get_genome.log",
     cache: True  # save space and time with between workflow caching (see docs)
     wrapper:
         "master/bio/reference/ensembl-sequence"
 
+
 rule get_chromosome:
     output:
-        "refs/chr1.fasta"
+        "refs/chr1.fasta",
     params:
         species="saccharomyces_cerevisiae",
         datatype="dna",
         build="R64-1-1",
         release="101",
-        chromosome="I"
+        chromosome="I",  # optional: restrict to chromosome
+        # branch="plants",  # optional: specify branch
     log:
-        "logs/get_genome.log"
+        "logs/get_genome.log",
     cache: True  # save space and time with between workflow caching (see docs)
     wrapper:
         "master/bio/reference/ensembl-sequence"

--- a/bio/reference/ensembl-sequence/wrapper.py
+++ b/bio/reference/ensembl-sequence/wrapper.py
@@ -16,6 +16,8 @@ branch = ""
 if release >= 81 and build == "GRCh37":
     # use the special grch37 branch for new releases
     branch = "grch37/"
+elif snakemake.params.get("branch"):
+    branch = snakemake.params.branch + "/"
 
 log = snakemake.log_fmt_shell(stdout=False, stderr=True)
 

--- a/bio/reference/ensembl-variation/test/Snakefile
+++ b/bio/reference/ensembl-variation/test/Snakefile
@@ -11,6 +11,7 @@ rule get_variation:
         build="R64-1-1",
         type="all",  # one of "all", "somatic", "structural_variation"
         # chromosome="21", # optionally constrain to chromosome, only supported for homo_sapiens
+        # branch="plants",  # optional: specify branch
     log:
         "logs/get_variation.log",
     cache: True  # save space and time with between workflow caching (see docs)

--- a/bio/reference/ensembl-variation/wrapper.py
+++ b/bio/reference/ensembl-variation/wrapper.py
@@ -16,14 +16,17 @@ build = snakemake.params.build
 type = snakemake.params.type
 chromosome = snakemake.params.get("chromosome", "")
 
-if release < 98:
-    print("Ensembl releases <98 are unsupported.", file=open(snakemake.log[0], "w"))
-    exit(1)
 
 branch = ""
 if release >= 81 and build == "GRCh37":
     # use the special grch37 branch for new releases
     branch = "grch37/"
+elif snakemake.params.get("branch"):
+    branch = snakemake.params.branch + "/"
+
+if release < 98 and not branch:
+    print("Ensembl releases <98 are unsupported.", file=open(snakemake.log[0], "w"))
+    exit(1)
 
 log = snakemake.log_fmt_shell(stdout=False, stderr=True)
 


### PR DESCRIPTION
<!-- Ensure that the PR title follows conventional commit style (<type>: <description>)-->
<!-- Possible types are here: https://github.com/commitizen/conventional-commit-types/blob/master/index.json -->

### Description

<!-- Add a description of your PR here-->

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] I confirm that:

For all wrappers added by this PR, 

* there is a test case which covers any introduced changes,
* `input:` and `output:` file paths in the resulting rule can be changed arbitrarily,
* either the wrapper can only use a single core, or the example rule contains a `threads: x` statement with `x` being a reasonable default,
* rule names in the test case are in [snake_case](https://en.wikipedia.org/wiki/Snake_case) and somehow tell what the rule is about or match the tools purpose or name (e.g., `map_reads` for a step that maps reads),
* all `environment.yaml` specifications follow [the respective best practices](https://stackoverflow.com/a/64594513/2352071),
* wherever possible, command line arguments are inferred and set automatically (e.g. based on file extensions in `input:` or `output:`),
* all fields of the example rules in the `Snakefile`s and their entries are explained via comments (`input:`/`output:`/`params:` etc.),
* `stderr` and/or `stdout` are logged correctly (`log:`), depending on the wrapped tool,
* temporary files are either written to a unique hidden folder in the working directory, or (better) stored where the Python function `tempfile.gettempdir()` points to (see [here](https://docs.python.org/3/library/tempfile.html#tempfile.gettempdir); this also means that using any Python `tempfile` default behavior works),
* the `meta.yaml` contains a link to the documentation of the respective tool or command,
* `Snakefile`s pass the linting (`snakemake --lint`),
* `Snakefile`s are formatted with [snakefmt](https://github.com/snakemake/snakefmt),
* Python wrapper scripts are formatted with [black](https://black.readthedocs.io).
* Conda environments use a minimal amount of channels, in recommended ordering. E.g. for bioconda, use (conda-forge, bioconda, nodefaults, as conda-forge should have highest priority and defaults channels are usually not needed because most packages are in conda-forge nowadays).
