### PR TITLE
fix: upgrade vep wrappers to latest version, fixing issues with strict channel priorities.

### DIFF
--- a/bio/vep/annotate/environment.yaml
+++ b/bio/vep/annotate/environment.yaml
@@ -5,4 +5,4 @@ channels:
 dependencies:
   - ensembl-vep =107
   - bcftools =1.15
-  - perl-encode-locale
+  - perl-lwp-simple

--- a/bio/vep/annotate/environment.yaml
+++ b/bio/vep/annotate/environment.yaml
@@ -5,4 +5,7 @@ channels:
 dependencies:
   - ensembl-vep =107
   - bcftools =1.15
-  - perl-lwp-simple
+  # TODO remove once bioconda CDN has been updated to exclude
+  # broken unpinned perl-encode-locale packages
+  - perl-encode-locale=1.05=pl5321hdfd78af_7
+  - perl =5.32.1

--- a/bio/vep/annotate/environment.yaml
+++ b/bio/vep/annotate/environment.yaml
@@ -3,5 +3,5 @@ channels:
   - bioconda
   - nodefaults
 dependencies:
-  - ensembl-vep =105
-  - bcftools =1.12
+  - ensembl-vep =107
+  - bcftools =1.15

--- a/bio/vep/annotate/environment.yaml
+++ b/bio/vep/annotate/environment.yaml
@@ -5,4 +5,4 @@ channels:
 dependencies:
   - ensembl-vep =107
   - bcftools =1.15
-  - perl-encode
+  - perl-encode-locale

--- a/bio/vep/annotate/environment.yaml
+++ b/bio/vep/annotate/environment.yaml
@@ -5,3 +5,4 @@ channels:
 dependencies:
   - ensembl-vep =107
   - bcftools =1.15
+  - perl-encode

--- a/bio/vep/annotate/wrapper.py
+++ b/bio/vep/annotate/wrapper.py
@@ -61,7 +61,7 @@ if cache:
         "--offline --cache --dir_cache {cache} --cache_version {release} --species {species} --assembly {build}"
     ).format(cache=cache, release=release, build=build, species=species)
 
-shell("ls $CONDA_PREFIX/lib/perl5/site_perl/Encode/Locale.pm")
+shell("ls $CONDA_PREFIX/lib/perl5/site_perl")
 shell(
     "(bcftools view '{snakemake.input.calls}' | "
     "vep {extra} {fork} "

--- a/bio/vep/annotate/wrapper.py
+++ b/bio/vep/annotate/wrapper.py
@@ -60,7 +60,7 @@ if cache:
     cache = (
         "--offline --cache --dir_cache {cache} --cache_version {release} --species {species} --assembly {build}"
     ).format(cache=cache, release=release, build=build, species=species)
-
+shell("which perl")
 shell(
     "(bcftools view '{snakemake.input.calls}' | "
     "vep {extra} {fork} "

--- a/bio/vep/annotate/wrapper.py
+++ b/bio/vep/annotate/wrapper.py
@@ -60,7 +60,7 @@ if cache:
     cache = (
         "--offline --cache --dir_cache {cache} --cache_version {release} --species {species} --assembly {build}"
     ).format(cache=cache, release=release, build=build, species=species)
-shell("which perl")
+shell("which perl; conda list")
 shell(
     "(bcftools view '{snakemake.input.calls}' | "
     "vep {extra} {fork} "

--- a/bio/vep/annotate/wrapper.py
+++ b/bio/vep/annotate/wrapper.py
@@ -61,7 +61,6 @@ if cache:
         "--offline --cache --dir_cache {cache} --cache_version {release} --species {species} --assembly {build}"
     ).format(cache=cache, release=release, build=build, species=species)
 
-shell("ls $CONDA_PREFIX/lib/perl5/site_perl")
 shell(
     "(bcftools view '{snakemake.input.calls}' | "
     "vep {extra} {fork} "

--- a/bio/vep/annotate/wrapper.py
+++ b/bio/vep/annotate/wrapper.py
@@ -60,7 +60,7 @@ if cache:
     cache = (
         "--offline --cache --dir_cache {cache} --cache_version {release} --species {species} --assembly {build}"
     ).format(cache=cache, release=release, build=build, species=species)
-shell("which perl; conda list")
+shell("which perl; conda list; echo $PERL5LIB")
 shell(
     "(bcftools view '{snakemake.input.calls}' | "
     "vep {extra} {fork} "

--- a/bio/vep/annotate/wrapper.py
+++ b/bio/vep/annotate/wrapper.py
@@ -61,6 +61,7 @@ if cache:
         "--offline --cache --dir_cache {cache} --cache_version {release} --species {species} --assembly {build}"
     ).format(cache=cache, release=release, build=build, species=species)
 
+shell("ls $CONDA_PREFIX/lib/perl5/site_perl/Encode/Locale.pm")
 shell(
     "(bcftools view '{snakemake.input.calls}' | "
     "vep {extra} {fork} "

--- a/bio/vep/annotate/wrapper.py
+++ b/bio/vep/annotate/wrapper.py
@@ -60,7 +60,7 @@ if cache:
     cache = (
         "--offline --cache --dir_cache {cache} --cache_version {release} --species {species} --assembly {build}"
     ).format(cache=cache, release=release, build=build, species=species)
-shell("which perl; conda list; echo $PERL5LIB")
+shell("conda list")
 shell(
     "(bcftools view '{snakemake.input.calls}' | "
     "vep {extra} {fork} "

--- a/bio/vep/cache/environment.yaml
+++ b/bio/vep/cache/environment.yaml
@@ -3,6 +3,4 @@ channels:
   - bioconda
   - nodefaults
 dependencies:
-  # This version should not be changed unless the vep_install command needs an
-  # update or suddenly stops working.
-  - ensembl-vep =105
+  - ensembl-vep =107

--- a/test.py
+++ b/test.py
@@ -4506,7 +4506,7 @@ def test_vep_plugins():
 def test_vep_annotate():
     run(
         "bio/vep/annotate",
-        ["snakemake", "--cores", "1", "variants.annotated.bcf", "--use-conda", "-F"],
+        ["snakemake", "--cores", "1", "variants.annotated.bcf", "--use-conda", "-F", "--verbose"],
     )
 
 


### PR DESCRIPTION
<!-- Ensure that the PR title follows conventional commit style (<type>: <description>)-->
<!-- Possible types are here: https://github.com/commitizen/conventional-commit-types/blob/master/index.json -->

### Description

<!-- Add a description of your PR here-->

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] I confirm that:

For all wrappers added by this PR, 

* there is a test case which covers any introduced changes,
* `input:` and `output:` file paths in the resulting rule can be changed arbitrarily,
* either the wrapper can only use a single core, or the example rule contains a `threads: x` statement with `x` being a reasonable default,
* rule names in the test case are in [snake_case](https://en.wikipedia.org/wiki/Snake_case) and somehow tell what the rule is about or match the tools purpose or name (e.g., `map_reads` for a step that maps reads),
* all `environment.yaml` specifications follow [the respective best practices](https://stackoverflow.com/a/64594513/2352071),
* wherever possible, command line arguments are inferred and set automatically (e.g. based on file extensions in `input:` or `output:`),
* all fields of the example rules in the `Snakefile`s and their entries are explained via comments (`input:`/`output:`/`params:` etc.),
* `stderr` and/or `stdout` are logged correctly (`log:`), depending on the wrapped tool,
* temporary files are either written to a unique hidden folder in the working directory, or (better) stored where the Python function `tempfile.gettempdir()` points to (see [here](https://docs.python.org/3/library/tempfile.html#tempfile.gettempdir); this also means that using any Python `tempfile` default behavior works),
* the `meta.yaml` contains a link to the documentation of the respective tool or command,
* `Snakefile`s pass the linting (`snakemake --lint`),
* `Snakefile`s are formatted with [snakefmt](https://github.com/snakemake/snakefmt),
* Python wrapper scripts are formatted with [black](https://black.readthedocs.io).
* Conda environments use a minimal amount of channels, in recommended ordering. E.g. for bioconda, use (conda-forge, bioconda, nodefaults, as conda-forge should have highest priority and defaults channels are usually not needed because most packages are in conda-forge nowadays).
