### PR TITLE
perf: bwa mem2 version update and use wrapper utils

### DIFF
--- a/bio/bwa-mem2/index/environment.yaml
+++ b/bio/bwa-mem2/index/environment.yaml
@@ -3,4 +3,4 @@ channels:
   - bioconda
   - nodefaults
 dependencies:
-  - bwa-mem2 ==2.2.1
+  - bwa-mem2 =2.2

--- a/bio/bwa-mem2/index/meta.yaml
+++ b/bio/bwa-mem2/index/meta.yaml
@@ -1,5 +1,10 @@
 name: "bwa-mem2 index"
 description: "Creates a bwa-mem2 index."
+url: https://github.com/bwa-mem2/bwa-mem2
 authors:
   - Christopher Schröder
   - Patrik Smeds
+input:
+  - Reference genome (FASTA )
+output:
+  - Indexed reference genome

--- a/bio/bwa-mem2/index/wrapper.py
+++ b/bio/bwa-mem2/index/wrapper.py
@@ -6,7 +6,7 @@ __license__ = "MIT"
 from os import path
 from snakemake.shell import shell
 
-log = snakemake.log_fmt_shell(stdout=False, stderr=True)
+log = snakemake.log_fmt_shell(stdout=True, stderr=True)
 
 # Check inputs/arguments.
 if len(snakemake.input) == 0:

--- a/bio/bwa-mem2/index/wrapper.py
+++ b/bio/bwa-mem2/index/wrapper.py
@@ -4,7 +4,6 @@ __email__ = "christopher.schroeder@tu-dortmund.de, patrik.smeds@gmail.com"
 __license__ = "MIT"
 
 from os import path
-
 from snakemake.shell import shell
 
 log = snakemake.log_fmt_shell(stdout=False, stderr=True)

--- a/bio/bwa-mem2/mem/environment.yaml
+++ b/bio/bwa-mem2/mem/environment.yaml
@@ -3,6 +3,7 @@ channels:
   - bioconda
   - nodefaults
 dependencies:
-  - bwa-mem2 ==2.2.1
-  - samtools ==1.12
+  - bwa-mem2 =2.2
+  - samtools =1.15
   - picard-slim =2.27
+  - snakemake-wrapper-utils =0.5

--- a/bio/bwa-mem2/mem/meta.yaml
+++ b/bio/bwa-mem2/mem/meta.yaml
@@ -1,6 +1,16 @@
 name: "bwa-mem2"
 description: Bwa-mem2 is the next version of the bwa-mem algorithm in bwa. It produces alignment identical to bwa and is ~1.3-3.1x faster depending on the use-case, dataset and the running machine. Optional sorting using samtools or picard.
+url: https://github.com/bwa-mem2/bwa-mem2
 authors:
   - Christopher Schröder
   - Johannes Köster
   - Julian de Ruiter
+input:
+  - FASTQ file(s)
+  - reference genome
+output:
+  - SAM/BAM/CRAM file
+notes: |
+  * The `extra` param allows for additional arguments for bwa-mem2.
+  * The `sorting` param allows to enable sorting, and can be either 'none', 'samtools' or 'picard'.
+  * The `sort_extra` allows for extra arguments for samtools/picard

--- a/bio/bwa-mem2/mem/wrapper.py
+++ b/bio/bwa-mem2/mem/wrapper.py
@@ -6,17 +6,22 @@ __email__ = "christopher.schroeder@tu-dortmund.de koester@jimmy.harvard.edu, jul
 __license__ = "MIT"
 
 
+import tempfile
 from os import path
-
 from snakemake.shell import shell
+from snakemake_wrapper_utils.java import get_java_opts
+from snakemake_wrapper_utils.samtools import get_samtools_opts
 
 
 # Extract arguments.
 extra = snakemake.params.get("extra", "")
-
+log = snakemake.log_fmt_shell(stdout=False, stderr=True)
 sort = snakemake.params.get("sort", "none")
 sort_order = snakemake.params.get("sort_order", "coordinate")
 sort_extra = snakemake.params.get("sort_extra", "")
+samtools_opts = get_samtools_opts(snakemake)
+java_opts = get_java_opts(snakemake)
+
 
 index = snakemake.input.get("index", "")
 if isinstance(index, str):
@@ -24,7 +29,6 @@ if isinstance(index, str):
 else:
     index = path.splitext(snakemake.input.idx[0])[0]
 
-log = snakemake.log_fmt_shell(stdout=False, stderr=True)
 
 # Check inputs/arguments.
 if not isinstance(snakemake.input.reads, str) and len(snakemake.input.reads) not in {
@@ -34,42 +38,35 @@ if not isinstance(snakemake.input.reads, str) and len(snakemake.input.reads) not
     raise ValueError("input must have 1 (single-end) or 2 (paired-end) elements")
 
 if sort_order not in {"coordinate", "queryname"}:
-    raise ValueError("Unexpected value for sort_order ({})".format(sort_order))
+    raise ValueError(f"Unexpected value for sort_order ({sort_order})")
 
 # Determine which pipe command to use for converting to bam or sorting.
 if sort == "none":
-
     # Simply convert to bam using samtools view.
-    pipe_cmd = "samtools view -Sbh -o {snakemake.output[0]} -"
+    pipe_cmd = "samtools view {samtools_opts}"
 
 elif sort == "samtools":
-
     # Sort alignments using samtools sort.
-    pipe_cmd = "samtools sort {sort_extra} -o {snakemake.output[0]} -"
+    pipe_cmd = "samtools sort {samtools_opts} {sort_extra} -T {tmpdir}"
 
     # Add name flag if needed.
     if sort_order == "queryname":
         sort_extra += " -n"
 
-    prefix = path.splitext(snakemake.output[0])[0]
-    sort_extra += " -T " + prefix + ".tmp"
-
 elif sort == "picard":
-
     # Sort alignments using picard SortSam.
-    pipe_cmd = (
-        "picard SortSam {sort_extra} INPUT=/dev/stdin"
-        " OUTPUT={snakemake.output[0]} SORT_ORDER={sort_order}"
-    )
+    pipe_cmd = "picard SortSam {java_opts} {sort_extra} --INPUT /dev/stdin --TMP_DIR {tmpdir} --SORT_ORDER {sort_order} --OUTPUT {snakemake.output[0]}"
 
 else:
-    raise ValueError("Unexpected value for params.sort ({})".format(sort))
+    raise ValueError(f"Unexpected value for params.sort ({sort})")
 
-shell(
-    "(bwa-mem2 mem"
-    " -t {snakemake.threads}"
-    " {extra}"
-    " {index}"
-    " {snakemake.input.reads}"
-    " | " + pipe_cmd + ") {log}"
-)
+
+with tempfile.TemporaryDirectory() as tmpdir:
+    shell(
+        "(bwa-mem2 mem"
+        " -t {snakemake.threads}"
+        " {extra}"
+        " {index}"
+        " {snakemake.input.reads}"
+        " | " + pipe_cmd + ") {log}"
+    )

--- a/bio/bwa/mem/environment.yaml
+++ b/bio/bwa/mem/environment.yaml
@@ -3,6 +3,7 @@ channels:
   - bioconda
   - nodefaults
 dependencies:
-  - bwa ==0.7.17
-  - samtools =1.12
+  - bwa =0.7
+  - samtools =1.15
   - picard-slim =2.27
+  - snakemake-wrapper-utils =0.5

--- a/bio/bwa/mem/meta.yaml
+++ b/bio/bwa/mem/meta.yaml
@@ -1,6 +1,7 @@
 name: "bwa mem"
 description: Map reads using bwa mem, with optional sorting using
   samtools or picard.
+url: http://bio-bwa.sourceforge.net/bwa.shtml
 authors:
   - Johannes Köster
   - Julian de Ruiter
@@ -14,5 +15,3 @@ notes: |
   * The `extra` param allows for additional arguments for bwa-mem.
   * The `sorting` param allows to enable sorting, and can be either 'none', 'samtools' or 'picard'.
   * The `sort_extra` allows for extra arguments for samtools/picard
-  * The `tmp_dir` param allows to define path to the temp dir.
-  * For more inforamtion see, http://bio-bwa.sourceforge.net/bwa.shtml

--- a/bio/bwa/mem/wrapper.py
+++ b/bio/bwa/mem/wrapper.py
@@ -4,18 +4,22 @@ __email__ = "koester@jimmy.harvard.edu, julianderuiter@gmail.com"
 __license__ = "MIT"
 
 
-from os import path
-import re
 import tempfile
+from os import path
 from snakemake.shell import shell
+from snakemake_wrapper_utils.java import get_java_opts
+from snakemake_wrapper_utils.samtools import get_samtools_opts
 
 
 # Extract arguments.
 extra = snakemake.params.get("extra", "")
-
+log = snakemake.log_fmt_shell(stdout=False, stderr=True)
 sort = snakemake.params.get("sorting", "none")
 sort_order = snakemake.params.get("sort_order", "coordinate")
 sort_extra = snakemake.params.get("sort_extra", "")
+samtools_opts = get_samtools_opts(snakemake)
+java_opts = get_java_opts(snakemake)
+
 
 index = snakemake.input.idx
 if isinstance(index, str):
@@ -24,51 +28,39 @@ else:
     index = path.splitext(snakemake.input.idx[0])[0]
 
 
-if re.search(r"-T\b", sort_extra) or re.search(r"--TMP_DIR\b", sort_extra):
-    sys.exit(
-        "You have specified temp dir (`-T` or `--TMP_DIR`) in params.sort_extra; this is automatically set from params.tmp_dir."
-    )
-
-log = snakemake.log_fmt_shell(stdout=False, stderr=True)
-
-
 # Check inputs/arguments.
 if not isinstance(snakemake.input.reads, str) and len(snakemake.input.reads) not in {
     1,
     2,
 }:
-    raise ValueError("input must have 1 (single-end) or " "2 (paired-end) elements")
+    raise ValueError("input must have 1 (single-end) or 2 (paired-end) elements")
+
 
 if sort_order not in {"coordinate", "queryname"}:
     raise ValueError("Unexpected value for sort_order ({})".format(sort_order))
 
+
 # Determine which pipe command to use for converting to bam or sorting.
 if sort == "none":
-
     # Simply convert to bam using samtools view.
-    pipe_cmd = "samtools view -Sbh -o {snakemake.output[0]} -"
+    pipe_cmd = "samtools view {samtools_opts}"
 
 elif sort == "samtools":
-
     # Add name flag if needed.
     if sort_order == "queryname":
         sort_extra += " -n"
 
     # Sort alignments using samtools sort.
-    pipe_cmd = "samtools sort -T {tmp} {sort_extra} -o {snakemake.output[0]} -"
+    pipe_cmd = "samtools sort {samtools_opts} {sort_extra} -T {tmpdir}"
 
 elif sort == "picard":
-
     # Sort alignments using picard SortSam.
-    pipe_cmd = (
-        "picard SortSam {sort_extra} --INPUT /dev/stdin"
-        " --OUTPUT {snakemake.output[0]} --SORT_ORDER {sort_order} --TMP_DIR {tmp}"
-    )
+    pipe_cmd = "picard SortSam {java_opts} {sort_extra} --INPUT /dev/stdin --TMP_DIR {tmpdir} --SORT_ORDER {sort_order} --OUTPUT {snakemake.output[0]}"
 
 else:
-    raise ValueError("Unexpected value for params.sort ({})".format(sort))
+    raise ValueError(f"Unexpected value for params.sort ({sort})")
 
-with tempfile.TemporaryDirectory() as tmp:
+with tempfile.TemporaryDirectory() as tmpdir:
     shell(
         "(bwa mem"
         " -t {snakemake.threads}"


### PR DESCRIPTION
<!-- Ensure that the PR title follows conventional commit style (<type>: <description>)-->
<!-- Possible types are here: https://github.com/commitizen/conventional-commit-types/blob/master/index.json -->

### Description

<!-- Add a description of your PR here-->
Updated versions, added use of tempfile, and use of wrapper utils.

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] I confirm that:

For all wrappers added by this PR, 

* there is a test case which covers any introduced changes,
* `input:` and `output:` file paths in the resulting rule can be changed arbitrarily,
* either the wrapper can only use a single core, or the example rule contains a `threads: x` statement with `x` being a reasonable default,
* rule names in the test case are in [snake_case](https://en.wikipedia.org/wiki/Snake_case) and somehow tell what the rule is about or match the tools purpose or name (e.g., `map_reads` for a step that maps reads),
* all `environment.yaml` specifications follow [the respective best practices](https://stackoverflow.com/a/64594513/2352071),
* wherever possible, command line arguments are inferred and set automatically (e.g. based on file extensions in `input:` or `output:`),
* all fields of the example rules in the `Snakefile`s and their entries are explained via comments (`input:`/`output:`/`params:` etc.),
* `stderr` and/or `stdout` are logged correctly (`log:`), depending on the wrapped tool,
* temporary files are either written to a unique hidden folder in the working directory, or (better) stored where the Python function `tempfile.gettempdir()` points to (see [here](https://docs.python.org/3/library/tempfile.html#tempfile.gettempdir); this also means that using any Python `tempfile` default behavior works),
* the `meta.yaml` contains a link to the documentation of the respective tool or command,
* `Snakefile`s pass the linting (`snakemake --lint`),
* `Snakefile`s are formatted with [snakefmt](https://github.com/snakemake/snakefmt),
* Python wrapper scripts are formatted with [black](https://black.readthedocs.io).
* Conda environments use a minimal amount of channels, in recommended ordering. E.g. for bioconda, use (conda-forge, bioconda, nodefaults, as conda-forge should have highest priority and defaults channels are usually not needed because most packages are in conda-forge nowadays).
