### PR TITLE
feat: add cram support to applybsqr

### DIFF
--- a/bio/gatk/applybqsr/environment.yaml
+++ b/bio/gatk/applybqsr/environment.yaml
@@ -6,3 +6,4 @@ dependencies:
   - gatk4 =4.2
   - openjdk =8
   - snakemake-wrapper-utils =0.3
+  - samtools =1.16

--- a/bio/gatk/applybqsr/test/Snakefile
+++ b/bio/gatk/applybqsr/test/Snakefile
@@ -11,6 +11,7 @@ rule gatk_applybqsr:
     params:
         extra="",  # optional
         java_opts="",  # optional
+        embed_ref=True,  # embed the reference in cram output
     resources:
         mem_mb=1024,
     wrapper:

--- a/bio/gatk/applybqsr/test/Snakefile_cram
+++ b/bio/gatk/applybqsr/test/Snakefile_cram
@@ -11,7 +11,7 @@ rule gatk_applybqsr:
     params:
         extra="",  # optional
         java_opts="",  # optional
-        embed_ref=True,  # embed the reference in output cram
+        embed_ref=True,  # embed the reference in cram output
     resources:
         mem_mb=1024,
     wrapper:

--- a/bio/gatk/applybqsr/test/Snakefile_cram
+++ b/bio/gatk/applybqsr/test/Snakefile_cram
@@ -1,0 +1,18 @@
+rule gatk_applybqsr:
+    input:
+        bam="mapped/{sample}.cram",
+        ref="genome.fasta",
+        dict="genome.dict",
+        recal_table="recal/{sample}.grp",
+    output:
+        bam="recal/{sample}.bam",
+    log:
+        "logs/gatk/gatk_applybqsr/{sample}.log",
+    params:
+        extra="",  # optional
+        java_opts="",  # optional
+        embed_ref=True,  # embed the reference in output cram
+    resources:
+        mem_mb=1024,
+    wrapper:
+        "master/bio/gatk/applybqsr"

--- a/bio/gatk/applybqsr/test/Snakefile_cram
+++ b/bio/gatk/applybqsr/test/Snakefile_cram
@@ -1,11 +1,11 @@
 rule gatk_applybqsr:
     input:
-        bam="mapped/{sample}.cram",
+        bam="mapped/{sample}.bam",
         ref="genome.fasta",
         dict="genome.dict",
         recal_table="recal/{sample}.grp",
     output:
-        bam="recal/{sample}.bam",
+        bam="recal/{sample}.cram",
     log:
         "logs/gatk/gatk_applybqsr/{sample}.log",
     params:

--- a/bio/gatk/applybqsr/wrapper.py
+++ b/bio/gatk/applybqsr/wrapper.py
@@ -18,9 +18,7 @@ log = snakemake.log_fmt_shell(stdout=True, stderr=True, append=True)
 
 if snakemake.output.bam.endswith(".cram") and embed_ref:
     output = "/dev/stdout"
-    pipe_cmd = (
-        " | samtools view -h -O cram,embed_ref -T {reference} -o {snakemake.output.bam}"
-    )
+    pipe_cmd = " | samtools view -h -O cram,embed_ref -T {reference} -o {snakemake.output.bam} -"
 else:
     output = snakemake.output.bam
     pipe_cmd = ""
@@ -33,7 +31,5 @@ with tempfile.TemporaryDirectory() as tmpdir:
         " --reference {reference}"
         " {extra}"
         " --tmp-dir {tmpdir}"
-        " --output {output}"
-        " {pipe_cmd})"
-        " {log}"
+        " --output {output}" + pipe_cmd + ") {log}"
     )

--- a/bio/gatk/applybqsr/wrapper.py
+++ b/bio/gatk/applybqsr/wrapper.py
@@ -10,7 +10,7 @@ from snakemake_wrapper_utils.java import get_java_opts
 
 # Extract arguments
 extra = snakemake.params.get("extra", "")
-reference = snakemake.input.get("reference")
+reference = snakemake.input.get("ref")
 embed_ref = snakemake.params.get("embed_ref", False)
 java_opts = get_java_opts(snakemake)
 

--- a/bio/gatk/applybqsr/wrapper.py
+++ b/bio/gatk/applybqsr/wrapper.py
@@ -8,19 +8,32 @@ import tempfile
 from snakemake.shell import shell
 from snakemake_wrapper_utils.java import get_java_opts
 
+# Extract arguments
 extra = snakemake.params.get("extra", "")
+reference = snakemake.input.get("reference")
+embed_ref = snakemake.params.get("embed_ref", False)
 java_opts = get_java_opts(snakemake)
 
 log = snakemake.log_fmt_shell(stdout=True, stderr=True, append=True)
 
+if snakemake.output.bam.endswith(".cram") and embed_ref:
+    output = "/dev/stdout"
+    pipe_cmd = (
+        " | samtools view -h -O cram,embed_ref -T {reference} -o {snakemake.output.bam}"
+    )
+else:
+    output = snakemake.output.bam
+    pipe_cmd = ""
+
 with tempfile.TemporaryDirectory() as tmpdir:
     shell(
-        "gatk --java-options '{java_opts}' ApplyBQSR"
+        "(gatk --java-options '{java_opts}' ApplyBQSR"
         " --input {snakemake.input.bam}"
         " --bqsr-recal-file {snakemake.input.recal_table}"
-        " --reference {snakemake.input.ref}"
+        " --reference {reference}"
         " {extra}"
         " --tmp-dir {tmpdir}"
-        " --output {snakemake.output.bam}"
+        " --output {output}"
+        " {pipe_cmd})"
         " {log}"
     )

--- a/bio/gatk/applybqsrspark/environment.yaml
+++ b/bio/gatk/applybqsrspark/environment.yaml
@@ -6,3 +6,4 @@ dependencies:
   - gatk4 =4.2
   - openjdk =8
   - snakemake-wrapper-utils =0.3
+  - samtools =1.16

--- a/bio/gatk/applybqsrspark/test/Snakefile
+++ b/bio/gatk/applybqsrspark/test/Snakefile
@@ -14,6 +14,8 @@ rule gatk_applybqsr_spark:
         #spark_runner="",  # optional, local by default
         #spark_master="",  # optional
         #spark_extra="", # optional
+        embed_ref=True,  # embed reference in cram output
+        exceed_thread_limit=True,  # samtools is also parallized and thread limit is not guaranteed anymore
     resources:
         mem_mb=1024,
     wrapper:

--- a/bio/gatk/applybqsrspark/test/Snakefile_cram
+++ b/bio/gatk/applybqsrspark/test/Snakefile_cram
@@ -19,5 +19,4 @@ rule gatk_applybqsr_spark:
     resources:
         mem_mb=1024,
     wrapper:
-        #"master/bio/gatk/applybqsrspark"
-        "file://.."
+        "master/bio/gatk/applybqsrspark"

--- a/bio/gatk/applybqsrspark/test/Snakefile_cram
+++ b/bio/gatk/applybqsrspark/test/Snakefile_cram
@@ -19,4 +19,5 @@ rule gatk_applybqsr_spark:
     resources:
         mem_mb=1024,
     wrapper:
-        "master/bio/gatk/applybqsrspark"
+        #"master/bio/gatk/applybqsrspark"
+        "file://.."

--- a/bio/gatk/applybqsrspark/test/Snakefile_cram
+++ b/bio/gatk/applybqsrspark/test/Snakefile_cram
@@ -1,0 +1,22 @@
+rule gatk_applybqsr_spark:
+    input:
+        bam="mapped/{sample}.cram",
+        ref="genome.fasta",
+        dict="genome.dict",
+        recal_table="recal/{sample}.grp",
+    output:
+        bam="recal/{sample}.bam",
+    log:
+        "logs/gatk/gatk_applybqsr_spark/{sample}.log",
+    params:
+        extra="",  # optional
+        java_opts="",  # optional
+        #spark_runner="",  # optional, local by default
+        #spark_master="",  # optional
+        #spark_extra="", # optional
+        embed_ref=True,  # embed reference in cram output
+        exceed_thread_limit=True,  # samtools is also parallized
+    resources:
+        mem_mb=1024,
+    wrapper:
+        "master/bio/gatk/applybqsrspark"

--- a/bio/gatk/applybqsrspark/test/Snakefile_cram
+++ b/bio/gatk/applybqsrspark/test/Snakefile_cram
@@ -1,11 +1,11 @@
 rule gatk_applybqsr_spark:
     input:
-        bam="mapped/{sample}.cram",
+        bam="mapped/{sample}.bam",
         ref="genome.fasta",
         dict="genome.dict",
         recal_table="recal/{sample}.grp",
     output:
-        bam="recal/{sample}.bam",
+        bam="recal/{sample}.cram",
     log:
         "logs/gatk/gatk_applybqsr_spark/{sample}.log",
     params:

--- a/bio/gatk/applybqsrspark/wrapper.py
+++ b/bio/gatk/applybqsrspark/wrapper.py
@@ -28,8 +28,8 @@ else:
     samtools_threads = 1
 
 if snakemake.output.bam.endswith(".cram") and embed_ref:
-    output = "/dev/stdout"
-    pipe_cmd = " | samtools view -h -O cram,embed_ref -T {reference} -o {snakemake.output.bam} -@ {samtools_threads}"
+    output = "/dev/stdout --create-output-bam-splitting-index false"
+    pipe_cmd = " | samtools view -h -O cram,embed_ref -T {reference} -o {snakemake.output.bam} -@ {samtools_threads} -"
 else:
     output = snakemake.output.bam
     pipe_cmd = ""
@@ -49,6 +49,6 @@ with tempfile.TemporaryDirectory() as tmpdir:
         " --output-shard-tmp-dir {tmpdir_shards}"
         " --output {output}"
         " -- --spark-runner {spark_runner} --spark-master {spark_master} {spark_extra}"
-        " {pipe_cmd})"
-        " {log}"
+        + pipe_cmd
+        + ") {log}"
     )

--- a/test.py
+++ b/test.py
@@ -3620,6 +3620,13 @@ def test_gatk_applybqsr():
         ["snakemake", "--cores", "1", "recal/a.bam", "--use-conda", "-F"],
     )
 
+@skip_if_not_modified
+def test_gatk_applybqsr_spark():
+    run(
+        "bio/gatk/applybqsr",
+        ["snakemake", "--cores", "1", "recal/a.cram", "--use-conda", "-F"],
+    )
+
 
 @skip_if_not_modified
 def test_gatk_applybqsrspark():

--- a/test.py
+++ b/test.py
@@ -3621,10 +3621,10 @@ def test_gatk_applybqsr():
     )
 
 @skip_if_not_modified
-def test_gatk_applybqsr_spark():
+def test_gatk_applybqsr_cram():
     run(
         "bio/gatk/applybqsr",
-        ["snakemake", "--cores", "1", "recal/a.cram", "--use-conda", "-F"],
+        ["snakemake", "-s", "Snakefile_cram", "--cores", "1", "recal/a.cram", "--use-conda", "-F"],
     )
 
 
@@ -3635,6 +3635,12 @@ def test_gatk_applybqsrspark():
         ["snakemake", "--cores", "1", "recal/a.bam", "--use-conda", "-F"],
     )
 
+@skip_if_not_modified
+def test_gatk_applybqsrspark_cram():
+    run(
+        "bio/gatk/applybqsrspark",
+        ["snakemake", "-s", "Snakefile_cram", "--cores", "1", "recal/a.cram", "--use-conda", "-F"],
+    )
 
 @skip_if_not_modified
 def test_gatk_haplotypecaller_vcf():


### PR DESCRIPTION
<!-- Ensure that the PR title follows conventional commit style (<type>: <description>)-->
<!-- Possible types are here: https://github.com/commitizen/conventional-commit-types/blob/master/index.json -->

### Description

<!-- Add a description of your PR here-->

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] I confirm that:

For all wrappers added by this PR, 

* there is a test case which covers any introduced changes,
* `input:` and `output:` file paths in the resulting rule can be changed arbitrarily,
* either the wrapper can only use a single core, or the example rule contains a `threads: x` statement with `x` being a reasonable default,
* rule names in the test case are in [snake_case](https://en.wikipedia.org/wiki/Snake_case) and somehow tell what the rule is about or match the tools purpose or name (e.g., `map_reads` for a step that maps reads),
* all `environment.yaml` specifications follow [the respective best practices](https://stackoverflow.com/a/64594513/2352071),
* wherever possible, command line arguments are inferred and set automatically (e.g. based on file extensions in `input:` or `output:`),
* all fields of the example rules in the `Snakefile`s and their entries are explained via comments (`input:`/`output:`/`params:` etc.),
* `stderr` and/or `stdout` are logged correctly (`log:`), depending on the wrapped tool,
* temporary files are either written to a unique hidden folder in the working directory, or (better) stored where the Python function `tempfile.gettempdir()` points to (see [here](https://docs.python.org/3/library/tempfile.html#tempfile.gettempdir); this also means that using any Python `tempfile` default behavior works),
* the `meta.yaml` contains a link to the documentation of the respective tool or command,
* `Snakefile`s pass the linting (`snakemake --lint`),
* `Snakefile`s are formatted with [snakefmt](https://github.com/snakemake/snakefmt),
* Python wrapper scripts are formatted with [black](https://black.readthedocs.io).
* Conda environments use a minimal amount of channels, in recommended ordering. E.g. for bioconda, use (conda-forge, bioconda, nodefaults, as conda-forge should have highest priority and defaults channels are usually not needed because most packages are in conda-forge nowadays).
