### PR TITLE
perf: Update params so wrapper correctly assigns params.extra

### DIFF
--- a/bio/bismark/bismark_genome_preparation/test/Snakefile
+++ b/bio/bismark/bismark_genome_preparation/test/Snakefile
@@ -20,6 +20,6 @@ rule bismark_genome_preparation_fa_gz:
     log:
         "logs/indexes/{genome}/Bisulfite_Genome.log"
     params:
-        ""  # optional params string
+        extra=""  # optional params string
     wrapper:
         "master/bio/bismark/bismark_genome_preparation"


### PR DESCRIPTION
Since the `../wrapper.py` picks up the named params `params_extra = snakemake.params.get("extra", "")`, here is the fix to ensure optional parameters are picked up during execution