### PR TITLE
chore: autobump conda envs

### DIFF
--- a/.github/workflows/autobump.yml
+++ b/.github/workflows/autobump.yml
@@ -1,0 +1,28 @@
+name: Tests
+
+# TODO replace by nightly cron job
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - "*"
+
+jobs:
+  autobump:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: tibdex/github-app-token@v1
+        id: generate-token
+        with:
+          app_id: ${{ secrets.SNAKEDEPLOY_BOT_APP_ID }}
+          private_key: ${{ secrets.SNAKEDEPLOY_BOT_PRIVATE_KEY }}
+
+      - name: Update conda envs
+        uses: snakemake/snakedeploy-github-action@v1
+        env:
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
+        with:
+          subcommand: update-conda-envs
+          args: workflow/envs/*.yaml --create-prs

--- a/.github/workflows/autobump.yml
+++ b/.github/workflows/autobump.yml
@@ -25,4 +25,4 @@ jobs:
           GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
         with:
           subcommand: update-conda-envs
-          args: workflow/envs/*.yaml --create-prs
+          args: "*/*/environment.yaml */*/*/environment.yaml --create-prs"

--- a/.github/workflows/autobump.yml
+++ b/.github/workflows/autobump.yml
@@ -20,7 +20,7 @@ jobs:
           private_key: ${{ secrets.SNAKEDEPLOY_BOT_PRIVATE_KEY }}
 
       - name: Update conda envs
-        uses: snakemake/snakedeploy-github-action@v1.0.3
+        uses: snakemake/snakedeploy-github-action@dbg
         env:
           GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
         with:

--- a/.github/workflows/autobump.yml
+++ b/.github/workflows/autobump.yml
@@ -13,6 +13,8 @@ jobs:
   autobump:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v3
+
       - uses: tibdex/github-app-token@v1
         id: generate-token
         with:
@@ -20,7 +22,7 @@ jobs:
           private_key: ${{ secrets.SNAKEDEPLOY_BOT_PRIVATE_KEY }}
 
       - name: Update conda envs
-        uses: snakemake/snakedeploy-github-action@dbg
+        uses: snakemake/snakedeploy-github-action@v1
         env:
           GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
         with:

--- a/.github/workflows/autobump.yml
+++ b/.github/workflows/autobump.yml
@@ -2,12 +2,8 @@ name: Tests
 
 # TODO replace by nightly cron job
 on:
-  push:
-    branches:
-      - master
-  pull_request:
-    branches:
-      - "*"
+  schedule:
+    - cron: "0 0 * * 5"
 
 jobs:
   autobump:

--- a/.github/workflows/autobump.yml
+++ b/.github/workflows/autobump.yml
@@ -20,7 +20,7 @@ jobs:
           private_key: ${{ secrets.SNAKEDEPLOY_BOT_PRIVATE_KEY }}
 
       - name: Update conda envs
-        uses: snakemake/snakedeploy-github-action@v1
+        uses: snakemake/snakedeploy-github-action@v1.0.3
         env:
           GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
         with:

--- a/.github/workflows/autobump.yml
+++ b/.github/workflows/autobump.yml
@@ -22,9 +22,9 @@ jobs:
           private_key: ${{ secrets.SNAKEDEPLOY_BOT_PRIVATE_KEY }}
 
       - name: Update conda envs
-        uses: snakemake/snakedeploy-github-action@dbg
+        uses: snakemake/snakedeploy-github-action@v1
         env:
           GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
         with:
           subcommand: update-conda-envs
-          args: "*/*/environment.yaml */*/*/environment.yaml --create-prs"
+          args: "*/*/environment.yaml */*/*/environment.yaml --create-prs --entity-regex '(?P<entity>.+)/environment.yaml' --pr-add-label"

--- a/.github/workflows/autobump.yml
+++ b/.github/workflows/autobump.yml
@@ -18,7 +18,7 @@ jobs:
           private_key: ${{ secrets.SNAKEDEPLOY_BOT_PRIVATE_KEY }}
 
       - name: Update conda envs
-        uses: snakemake/snakedeploy-github-action@dbg
+        uses: snakemake/snakedeploy-github-action@v1
         env:
           GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
         with:

--- a/.github/workflows/autobump.yml
+++ b/.github/workflows/autobump.yml
@@ -22,7 +22,7 @@ jobs:
           private_key: ${{ secrets.SNAKEDEPLOY_BOT_PRIVATE_KEY }}
 
       - name: Update conda envs
-        uses: snakemake/snakedeploy-github-action@v1
+        uses: snakemake/snakedeploy-github-action@dbg
         env:
           GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,9 +5,8 @@ on:
     branches:
       - master
   pull_request:
-    branches_ignore: []
-  schedule:
-    - cron: '0 0 * * 0'
+    branches:
+      - "*"
 
 jobs:
   docs:
@@ -37,12 +36,12 @@ jobs:
 
       - name: Setup Snakemake environment
         run: |
-           # ensure that mamba is happy to write into the cache
-           sudo chown -R runner:docker /usr/share/miniconda/pkgs/cache
-           conda install -c conda-forge mamba --quiet
-           export PATH="/usr/share/miniconda/bin:$PATH"
-           mamba create -c bioconda -c conda-forge --quiet -y --name snakemake snakemake-minimal pytest
-           conda config --set channel_priority strict
+          # ensure that mamba is happy to write into the cache
+          sudo chown -R runner:docker /usr/share/miniconda/pkgs/cache
+          conda install -c conda-forge mamba --quiet
+          export PATH="/usr/share/miniconda/bin:$PATH"
+          mamba create -c bioconda -c conda-forge --quiet -y --name snakemake snakemake-minimal pytest
+          conda config --set channel_priority strict
 
       - name: Fetch master
         if: github.ref != 'refs/heads/master'


### PR DESCRIPTION
<!-- Ensure that the PR title follows conventional commit style (<type>: <description>)-->
<!-- Possible types are here: https://github.com/commitizen/conventional-commit-types/blob/master/index.json -->

### Description

<!-- Add a description of your PR here-->

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] I confirm that:

For all wrappers added by this PR, 

* there is a test case which covers any introduced changes,
* `input:` and `output:` file paths in the resulting rule can be changed arbitrarily,
* either the wrapper can only use a single core, or the example rule contains a `threads: x` statement with `x` being a reasonable default,
* rule names in the test case are in [snake_case](https://en.wikipedia.org/wiki/Snake_case) and somehow tell what the rule is about or match the tools purpose or name (e.g., `map_reads` for a step that maps reads),
* all `environment.yaml` specifications follow [the respective best practices](https://stackoverflow.com/a/64594513/2352071),
* wherever possible, command line arguments are inferred and set automatically (e.g. based on file extensions in `input:` or `output:`),
* all fields of the example rules in the `Snakefile`s and their entries are explained via comments (`input:`/`output:`/`params:` etc.),
* `stderr` and/or `stdout` are logged correctly (`log:`), depending on the wrapped tool,
* temporary files are either written to a unique hidden folder in the working directory, or (better) stored where the Python function `tempfile.gettempdir()` points to (see [here](https://docs.python.org/3/library/tempfile.html#tempfile.gettempdir); this also means that using any Python `tempfile` default behavior works),
* the `meta.yaml` contains a link to the documentation of the respective tool or command,
* `Snakefile`s pass the linting (`snakemake --lint`),
* `Snakefile`s are formatted with [snakefmt](https://github.com/snakemake/snakefmt),
* Python wrapper scripts are formatted with [black](https://black.readthedocs.io).
* Conda environments use a minimal amount of channels, in recommended ordering. E.g. for bioconda, use (conda-forge, bioconda, nodefaults, as conda-forge should have highest priority and defaults channels are usually not needed because most packages are in conda-forge nowadays).
