### PR TITLE
fix: allow for optional pindel bed files

### DIFF
--- a/bio/pindel/call/wrapper.py
+++ b/bio/pindel/call/wrapper.py
@@ -8,19 +8,17 @@ from snakemake.shell import shell
 extra = snakemake.params.get("extra", "")
 log = snakemake.log_fmt_shell(stdout=True, stderr=True)
 
-include_bed = snakemake.input.get("include_bed", None)
-exclude_bed = snakemake.input.get("exclude_bed", None)
+include_bed = snakemake.input.get("include_bed", "")
+exclude_bed = snakemake.input.get("exclude_bed", "")
 
 if include_bed and exclude_bed:
     raise Exception("supply either include_bed or exclude_bed, not both")
 
-include_arg = ""
 if include_bed:
-    include_arg = f"-j {include_bed}"
+    include_bed = f"-j {include_bed}"
 
-exclude_arg = ""
 if exclude_bed:
-    exclude_arg = f"-J {exclude_bed}"
+    exclude_bed = f"-J {exclude_bed}"
 
 output_prefix = snakemake.output[0].rsplit("_", 1)[0]
 
@@ -28,8 +26,8 @@ shell(
     "pindel "
     "-T {snakemake.threads} "
     "{extra} "
-    "{include_arg} "
-    "{exclude_arg} "
+    "{include_bed} "
+    "{exclude_bed} "
     "-i {snakemake.input.config} "
     "-f {snakemake.input.ref} "
     "-o {output_prefix} {log}"

--- a/bio/pindel/call/wrapper.py
+++ b/bio/pindel/call/wrapper.py
@@ -11,15 +11,15 @@ log = snakemake.log_fmt_shell(stdout=True, stderr=True)
 include_bed = snakemake.input.get("include_bed", None)
 exclude_bed = snakemake.input.get("exclude_bed", None)
 
-if include_bed is not None and exclude_bed is not None:
+if include_bed and exclude_bed:
     raise Exception("supply either include_bed or exclude_bed, not both")
 
 include_arg = ""
-if include_bed is not None:
+if include_bed:
     include_arg = f"-j {include_bed}"
 
 exclude_arg = ""
-if exclude_bed is not None:
+if exclude_bed:
     exclude_arg = f"-J {exclude_bed}"
 
 output_prefix = snakemake.output[0].rsplit("_", 1)[0]


### PR DESCRIPTION
### Description

With the previous implementation the only way of omitting the bed file arguments was if they were completely missing from the rule definition. This change allows for optional bed file arguments, e.g.

```python
rule pindel_call:
    input:
        include_bed=config.get("include_bed", [])
        # rest of the rule definition omitted
```

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] I confirm that:

For all wrappers added by this PR, 

* there is a test case which covers any introduced changes,
* `input:` and `output:` file paths in the resulting rule can be changed arbitrarily,
* either the wrapper can only use a single core, or the example rule contains a `threads: x` statement with `x` being a reasonable default,
* rule names in the test case are in [snake_case](https://en.wikipedia.org/wiki/Snake_case) and somehow tell what the rule is about or match the tools purpose or name (e.g., `map_reads` for a step that maps reads),
* all `environment.yaml` specifications follow [the respective best practices](https://stackoverflow.com/a/64594513/2352071),
* wherever possible, command line arguments are inferred and set automatically (e.g. based on file extensions in `input:` or `output:`),
* all fields of the example rules in the `Snakefile`s and their entries are explained via comments (`input:`/`output:`/`params:` etc.),
* `stderr` and/or `stdout` are logged correctly (`log:`), depending on the wrapped tool,
* temporary files are either written to a unique hidden folder in the working directory, or (better) stored where the Python function `tempfile.gettempdir()` points to (see [here](https://docs.python.org/3/library/tempfile.html#tempfile.gettempdir); this also means that using any Python `tempfile` default behavior works),
* the `meta.yaml` contains a link to the documentation of the respective tool or command,
* `Snakefile`s pass the linting (`snakemake --lint`),
* `Snakefile`s are formatted with [snakefmt](https://github.com/snakemake/snakefmt),
* Python wrapper scripts are formatted with [black](https://black.readthedocs.io).
* Conda environments use a minimal amount of channels, in recommended ordering. E.g. for bioconda, use (conda-forge, bioconda, nodefaults, as conda-forge should have highest priority and defaults channels are usually not needed because most packages are in conda-forge nowadays).
