### PR TITLE
dbg: autobump

### DIFF
--- a/.github/workflows/autobump.yml
+++ b/.github/workflows/autobump.yml
@@ -27,6 +27,7 @@ jobs:
         uses: snakemake/snakedeploy-github-action@dbg
         env:
           GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
+          TMPDIR: ${{ env.RUNNER_TEMP }}
         with:
           subcommand: update-conda-envs
           args: "*/*/environment.yaml */*/*/environment.yaml --create-prs --warn-on-error --entity-regex '(?P<entity>.+)/environment.yaml' --pr-add-label"

--- a/.github/workflows/autobump.yml
+++ b/.github/workflows/autobump.yml
@@ -1,9 +1,15 @@
-name: Tests
+name: autobump
 
-# TODO replace by nightly cron job
 on:
   schedule:
     - cron: "0 0 * * 5"
+  # TODO remove before merging
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - "*"
 
 jobs:
   autobump:
@@ -18,7 +24,7 @@ jobs:
           private_key: ${{ secrets.SNAKEDEPLOY_BOT_PRIVATE_KEY }}
 
       - name: Update conda envs
-        uses: snakemake/snakedeploy-github-action@v1
+        uses: snakemake/snakedeploy-github-action@dbg
         env:
           GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
         with:

--- a/.github/workflows/autobump.yml
+++ b/.github/workflows/autobump.yml
@@ -3,13 +3,6 @@ name: autobump
 on:
   schedule:
     - cron: "0 0 * * 5"
-  # TODO remove before merging
-  push:
-    branches:
-      - master
-  pull_request:
-    branches:
-      - "*"
 
 jobs:
   autobump:
@@ -24,10 +17,9 @@ jobs:
           private_key: ${{ secrets.SNAKEDEPLOY_BOT_PRIVATE_KEY }}
 
       - name: Update conda envs
-        uses: snakemake/snakedeploy-github-action@dbg
+        uses: snakemake/snakedeploy-github-action@v1
         env:
           GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
-          TMPDIR: ${{ env.RUNNER_TEMP }}
         with:
           subcommand: update-conda-envs
           args: "*/*/environment.yaml */*/*/environment.yaml --create-prs --warn-on-error --entity-regex '(?P<entity>.+)/environment.yaml' --pr-add-label"

--- a/.github/workflows/autobump.yml
+++ b/.github/workflows/autobump.yml
@@ -29,4 +29,4 @@ jobs:
           GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
         with:
           subcommand: update-conda-envs
-          args: "*/*/environment.yaml */*/*/environment.yaml --create-prs --entity-regex '(?P<entity>.+)/environment.yaml' --pr-add-label"
+          args: "*/*/environment.yaml */*/*/environment.yaml --create-prs --warn-on-error --entity-regex '(?P<entity>.+)/environment.yaml' --pr-add-label"

--- a/docs/_templates/wrapper.rst
+++ b/docs/_templates/wrapper.rst
@@ -7,6 +7,12 @@
 .. image:: https://img.shields.io/badge/blacklisted-{{ blacklisted|urlencode }}-red
 {% endif %}
 
+.. image:: https://img.shields.io/github/issues-pr/snakemake/snakemake-wrappers/{{ wrapper_path }}?label=version%20update%20pull%20requests
+
+.. image:: https://img.shields.io/github/issues-pr/snakemake/snakemake-wrappers/bio/bwa/samse?label=version%20update%20pull%20requests
+   :alt: GitHub pull requests by-label
+   :target: https://github.com/snakemake/snakemake-wrappers/pulls?q=is%3Apr+is%3Aopen+label%3A{{ wrapper_path }}
+
 {{ description }}
 
 {% if url %}

--- a/docs/_templates/wrapper.rst
+++ b/docs/_templates/wrapper.rst
@@ -8,9 +8,6 @@
 {% endif %}
 
 .. image:: https://img.shields.io/github/issues-pr/snakemake/snakemake-wrappers/{{ wrapper_path }}?label=version%20update%20pull%20requests
-
-.. image:: https://img.shields.io/github/issues-pr/snakemake/snakemake-wrappers/bio/bwa/samse?label=version%20update%20pull%20requests
-   :alt: GitHub pull requests by-label
    :target: https://github.com/snakemake/snakemake-wrappers/pulls?q=is%3Apr+is%3Aopen+label%3A{{ wrapper_path }}
 
 {{ description }}

--- a/docs/generate_docs.py
+++ b/docs/generate_docs.py
@@ -105,6 +105,7 @@ def render_wrapper(path, target, wrapper_id):
             wrapper_lang=wrapper_lang,
             pkgs=pkgs,
             id=wrapper_id,
+            wrapper_path=path,
             **meta,
         )
         readme.write(rst)


### PR DESCRIPTION
<!-- Ensure that the PR title follows conventional commit style (<type>: <description>)-->
<!-- Possible types are here: https://github.com/commitizen/conventional-commit-types/blob/master/index.json -->

### Description

<!-- Add a description of your PR here-->

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] I confirm that:

For all wrappers added by this PR, 

* there is a test case which covers any introduced changes,
* `input:` and `output:` file paths in the resulting rule can be changed arbitrarily,
* either the wrapper can only use a single core, or the example rule contains a `threads: x` statement with `x` being a reasonable default,
* rule names in the test case are in [snake_case](https://en.wikipedia.org/wiki/Snake_case) and somehow tell what the rule is about or match the tools purpose or name (e.g., `map_reads` for a step that maps reads),
* all `environment.yaml` specifications follow [the respective best practices](https://stackoverflow.com/a/64594513/2352071),
* wherever possible, command line arguments are inferred and set automatically (e.g. based on file extensions in `input:` or `output:`),
* all fields of the example rules in the `Snakefile`s and their entries are explained via comments (`input:`/`output:`/`params:` etc.),
* `stderr` and/or `stdout` are logged correctly (`log:`), depending on the wrapped tool,
* temporary files are either written to a unique hidden folder in the working directory, or (better) stored where the Python function `tempfile.gettempdir()` points to (see [here](https://docs.python.org/3/library/tempfile.html#tempfile.gettempdir); this also means that using any Python `tempfile` default behavior works),
* the `meta.yaml` contains a link to the documentation of the respective tool or command,
* `Snakefile`s pass the linting (`snakemake --lint`),
* `Snakefile`s are formatted with [snakefmt](https://github.com/snakemake/snakefmt),
* Python wrapper scripts are formatted with [black](https://black.readthedocs.io).
* Conda environments use a minimal amount of channels, in recommended ordering. E.g. for bioconda, use (conda-forge, bioconda, nodefaults, as conda-forge should have highest priority and defaults channels are usually not needed because most packages are in conda-forge nowadays).
