### PR TITLE
fix: bwa-meme and bwa-memx documentation

### DIFF
--- a/bio/bwa-meme/mem/test/Snakefile
+++ b/bio/bwa-meme/mem/test/Snakefile
@@ -1,20 +1,4 @@
-rule all:  # [hide]
-    input:  # [hide]
-        "mapped/a.cram",  # [hide]
-        "mapped/a.picard.cram",  # [hide]
-
-
-rule L2_PARAMETERS_extract:  #[hide]
-    input:  #[hide]
-        "genome.fasta.suffixarray_uint64_L2_PARAMETERS.gz",  #[hide]
-    output:  #[hide]
-        temp("genome.fasta.suffixarray_uint64_L2_PARAMETERS"),  #[hide]
-    conda:  # [hide]
-        "gzip.yaml"  # [hide]
-    log:  # [hide]
-        "log/extract.l2.log",  # [hide]
-    shell:  #[hide]
-        "zcat {input} > {output} 2> {log}"  # [hide]
+include: "hide.smk"  #[hide]
 
 
 rule bwa_meme_mem:
@@ -47,40 +31,6 @@ rule bwa_meme_mem:
         dedup_extra="-M",  # Extra args for samblaster.
         exceed_thread_limit=True,  # Set threads als for samtools sort / view (total used CPU may exceed threads!)
         embed_ref=True,  # Embed reference when writing cram.
-    threads: 8
-    wrapper:
-        "master/bio/bwa-meme/mem"
-
-
-rule bwa_meme_mem_picard:
-    input:
-        reads=["reads/{sample}.1.fastq", "reads/{sample}.2.fastq"],
-        reference="genome.fasta",
-        idx=multiext(
-            "genome.fasta",
-            ".0123",
-            ".amb",
-            ".ann",
-            ".pac",
-            ".pos_packed",
-            ".suffixarray_uint64",
-            ".suffixarray_uint64_L0_PARAMETERS",
-            ".suffixarray_uint64_L1_PARAMETERS",
-            ".suffixarray_uint64_L2_PARAMETERS",
-        ),
-    output:
-        "mapped/{sample}.picard.cram",
-    log:
-        "logs/bwa_meme/{sample}.log",
-    params:
-        extra=r"-R '@RG\tID:{sample}\tSM:{sample}' -M",
-        sort="picard",
-        sort_order="coordinate",
-        sort_extra="",
-        dedup="mark",
-        dedup_extra="-M",
-        exceed_thread_limit=True,
-        embed_ref=True,
     threads: 8
     wrapper:
         "master/bio/bwa-meme/mem"

--- a/bio/bwa-meme/mem/test/hide.smk
+++ b/bio/bwa-meme/mem/test/hide.smk
@@ -1,0 +1,51 @@
+rule all:
+    input:
+        "mapped/a.cram",
+        "mapped/a.picard.cram",
+
+
+rule L2_PARAMETERS_extract:
+    input:
+        "genome.fasta.suffixarray_uint64_L2_PARAMETERS.gz",
+    output:
+        temp("genome.fasta.suffixarray_uint64_L2_PARAMETERS"),
+    conda:
+        "gzip.yaml"
+    log:
+        "log/extract.l2.log",
+    shell:
+        "zcat {input} > {output} 2> {log}"
+
+
+rule bwa_meme_mem_picard:
+    input:
+        reads=["reads/{sample}.1.fastq", "reads/{sample}.2.fastq"],
+        reference="genome.fasta",
+        idx=multiext(
+            "genome.fasta",
+            ".0123",
+            ".amb",
+            ".ann",
+            ".pac",
+            ".pos_packed",
+            ".suffixarray_uint64",
+            ".suffixarray_uint64_L0_PARAMETERS",
+            ".suffixarray_uint64_L1_PARAMETERS",
+            ".suffixarray_uint64_L2_PARAMETERS",
+        ),
+    output:
+        "mapped/{sample}.picard.cram",
+    log:
+        "logs/bwa_meme/{sample}.log",
+    params:
+        extra=r"-R '@RG\tID:{sample}\tSM:{sample}' -M",
+        sort="picard",
+        sort_order="coordinate",
+        sort_extra="",
+        dedup="mark",
+        dedup_extra="-M",
+        exceed_thread_limit=True,
+        embed_ref=True,
+    threads: 8
+    wrapper:
+        "master/bio/bwa-meme/mem"

--- a/bio/bwa-meme/mem/test/hide.smk
+++ b/bio/bwa-meme/mem/test/hide.smk
@@ -1,4 +1,4 @@
-rule all:
+rule bwa_meme_test:
     input:
         "mapped/a.cram",
         "mapped/a.picard.cram",

--- a/bio/bwa-memx/mem/test/Snakefile
+++ b/bio/bwa-memx/mem/test/Snakefile
@@ -1,21 +1,4 @@
-rule bwa_memx_test:  # [hide]
-    input:  # [hide]
-        "mapped/mem/a.cram",  # [hide]
-        "mapped/mem2/a.cram",  # [hide]
-        "mapped/meme/a.cram",  # [hide]
-
-
-rule L2_PARAMETERS_extract:  #[hide]
-    input:  #[hide]
-        "genome.fasta.suffixarray_uint64_L2_PARAMETERS.gz",  #[hide]
-    output:  #[hide]
-        temp("genome.fasta.suffixarray_uint64_L2_PARAMETERS"),  #[hide]
-    conda:  #[hide]
-        "gzip.yaml"  #[hide]
-    log:  #[hide]
-        "log/extract.l2.log",  #[hide]
-    shell:  #[hide]
-        "zcat {input} > {output} 2> {log}"  #[hide]
+include: "hide.smk"  #[hide]
 
 
 rule bwa_memx_mem:

--- a/bio/bwa-memx/mem/test/hide.smk
+++ b/bio/bwa-memx/mem/test/hide.smk
@@ -1,0 +1,18 @@
+rule bwa_memx_test:
+    input:
+        "mapped/mem/a.cram",
+        "mapped/mem2/a.cram",
+        "mapped/meme/a.cram",
+
+
+rule L2_PARAMETERS_extract:
+    input:
+        "genome.fasta.suffixarray_uint64_L2_PARAMETERS.gz",
+    output:
+        temp("genome.fasta.suffixarray_uint64_L2_PARAMETERS"),
+    conda:
+        "gzip.yaml"
+    log:
+        "log/extract.l2.log",
+    shell:
+        "zcat {input} > {output} 2> {log}"

--- a/test.py
+++ b/test.py
@@ -1700,6 +1700,7 @@ def test_bwa_meme():
             "1",
             "--use-conda",
             "-F",
+            "bwa_meme_test",
         ],
     )
 


### PR DESCRIPTION
<!-- Ensure that the PR title follows conventional commit style (<type>: <description>)-->
<!-- Possible types are here: https://github.com/commitizen/conventional-commit-types/blob/master/index.json -->

### Description

<!-- Add a description of your PR here-->

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] I confirm that:

For all wrappers added by this PR, 

* there is a test case which covers any introduced changes,
* `input:` and `output:` file paths in the resulting rule can be changed arbitrarily,
* either the wrapper can only use a single core, or the example rule contains a `threads: x` statement with `x` being a reasonable default,
* rule names in the test case are in [snake_case](https://en.wikipedia.org/wiki/Snake_case) and somehow tell what the rule is about or match the tools purpose or name (e.g., `map_reads` for a step that maps reads),
* all `environment.yaml` specifications follow [the respective best practices](https://stackoverflow.com/a/64594513/2352071),
* wherever possible, command line arguments are inferred and set automatically (e.g. based on file extensions in `input:` or `output:`),
* all fields of the example rules in the `Snakefile`s and their entries are explained via comments (`input:`/`output:`/`params:` etc.),
* `stderr` and/or `stdout` are logged correctly (`log:`), depending on the wrapped tool,
* temporary files are either written to a unique hidden folder in the working directory, or (better) stored where the Python function `tempfile.gettempdir()` points to (see [here](https://docs.python.org/3/library/tempfile.html#tempfile.gettempdir); this also means that using any Python `tempfile` default behavior works),
* the `meta.yaml` contains a link to the documentation of the respective tool or command,
* `Snakefile`s pass the linting (`snakemake --lint`),
* `Snakefile`s are formatted with [snakefmt](https://github.com/snakemake/snakefmt),
* Python wrapper scripts are formatted with [black](https://black.readthedocs.io).
* Conda environments use a minimal amount of channels, in recommended ordering. E.g. for bioconda, use (conda-forge, bioconda, nodefaults, as conda-forge should have highest priority and defaults channels are usually not needed because most packages are in conda-forge nowadays).
