### PR TITLE
docs: suggest "omit-software" cache behavior for download only wrappers

### DIFF
--- a/bio/benchmark/chm-eval-kit/test/Snakefile
+++ b/bio/benchmark/chm-eval-kit/test/Snakefile
@@ -1,12 +1,12 @@
 rule chm_eval_kit:
     output:
-        directory("resources/chm-eval-kit")
+        directory("resources/chm-eval-kit"),
     params:
         # Tag and version must match, see https://github.com/lh3/CHM-eval/releases.
         tag="v0.5",
-        version="20180222"
+        version="20180222",
     log:
-        "logs/chm-eval-kit.log"
-    cache: True
+        "logs/chm-eval-kit.log",
+    cache: "omit-software"
     wrapper:
         "master/bio/benchmark/chm-eval-kit"

--- a/bio/benchmark/chm-eval/test/Snakefile
+++ b/bio/benchmark/chm-eval/test/Snakefile
@@ -1,28 +1,28 @@
-rule chm_eval_kit:                           # [hide]
-    output:                                  # [hide]
-        directory("resources/chm-eval-kit")  # [hide]
-    params:                                  # [hide]
-        tag="v0.5",                          # [hide]
-        version="20180222"                   # [hide]
-    log:                                     # [hide]
-        "logs/chm-eval-kit.log"              # [hide]
-    cache: True                              # [hide]
-    wrapper:                                 # [hide]
+rule chm_eval_kit:  # [hide]
+    output:  # [hide]
+        directory("resources/chm-eval-kit"),  # [hide]
+    params:  # [hide]
+        tag="v0.5",  # [hide]
+        version="20180222",  # [hide]
+    log:  # [hide]
+        "logs/chm-eval-kit.log",  # [hide]
+    cache: "omit-software"  # [hide]
+    wrapper:  # [hide]
         "master/bio/benchmark/chm-eval-kit"  # [hide]
-                                             # [hide]
+        # [hide]
 
 
 rule chm_eval:
     input:
         kit="resources/chm-eval-kit",
-        vcf="{sample}.vcf"
+        vcf="{sample}.vcf",
     output:
-        summary="chm-eval/{sample}.summary", # summary statistics
-        bed="chm-eval/{sample}.err.bed.gz" # bed file with errors
+        summary="chm-eval/{sample}.summary",  # summary statistics
+        bed="chm-eval/{sample}.err.bed.gz",  # bed file with errors
     params:
         extra="",
-        build="38"
+        build="38",
     log:
-        "logs/chm-eval/{sample}.log"
+        "logs/chm-eval/{sample}.log",
     wrapper:
         "master/bio/benchmark/chm-eval"

--- a/bio/genomepy/test/Snakefile
+++ b/bio/genomepy/test/Snakefile
@@ -1,11 +1,18 @@
 rule genomepy:
     output:
-        multiext("{assembly}/{assembly}", ".fa", ".fa.fai", ".fa.sizes", ".gaps.bed", 
-                 ".annotation.gtf.gz", ".blacklist.bed")
+        multiext(
+            "{assembly}/{assembly}",
+            ".fa",
+            ".fa.fai",
+            ".fa.sizes",
+            ".gaps.bed",
+            ".annotation.gtf.gz",
+            ".blacklist.bed",
+        ),
     log:
-        "logs/genomepy_{assembly}.log"
+        "logs/genomepy_{assembly}.log",
     params:
-        provider="UCSC"  # optional, defaults to ucsc. Choose from ucsc, ensembl, and ncbi
-    cache: True  # mark as eligible for between workflow caching
+        provider="UCSC",  # optional, defaults to ucsc. Choose from ucsc, ensembl, and ncbi
+    cache: "omit-software"  # mark as eligible for between workflow caching
     wrapper:
         "master/bio/genomepy"

--- a/bio/reference/ensembl-annotation/test/Snakefile
+++ b/bio/reference/ensembl-annotation/test/Snakefile
@@ -9,7 +9,7 @@ rule get_annotation:
         # branch="plants",  # optional: specify branch
     log:
         "logs/get_annotation.log",
-    cache: True  # save space and time with between workflow caching (see docs)
+    cache: "omit-software"  # save space and time with between workflow caching (see docs)
     wrapper:
         "master/bio/reference/ensembl-annotation"
 
@@ -25,6 +25,6 @@ rule get_annotation_gz:
         # branch="plants",  # optional: specify branch
     log:
         "logs/get_annotation.log",
-    cache: True  # save space and time with between workflow caching (see docs)
+    cache: "omit-software"  # save space and time with between workflow caching (see docs)
     wrapper:
         "master/bio/reference/ensembl-annotation"

--- a/bio/reference/ensembl-sequence/test/Snakefile
+++ b/bio/reference/ensembl-sequence/test/Snakefile
@@ -8,7 +8,7 @@ rule get_genome:
         release="98",
     log:
         "logs/get_genome.log",
-    cache: True  # save space and time with between workflow caching (see docs)
+    cache: "omit-software"  # save space and time with between workflow caching (see docs)
     wrapper:
         "master/bio/reference/ensembl-sequence"
 
@@ -25,6 +25,6 @@ rule get_chromosome:
         # branch="plants",  # optional: specify branch
     log:
         "logs/get_genome.log",
-    cache: True  # save space and time with between workflow caching (see docs)
+    cache: "omit-software"  # save space and time with between workflow caching (see docs)
     wrapper:
         "master/bio/reference/ensembl-sequence"

--- a/bio/reference/ensembl-sequence/test/old_release.smk
+++ b/bio/reference/ensembl-sequence/test/old_release.smk
@@ -1,28 +1,29 @@
 rule get_genome:
     output:
-        "refs/genome.fasta"
-    params:
-        species="saccharomyces_cerevisiae",
-        datatype="dna",
-        build="R64-1-1",
-        release="75"
-    log:
-        "logs/get_genome.log"
-    cache: True  # save space and time with between workflow caching (see docs)
-    wrapper:
-        "master/bio/reference/ensembl-sequence"
-
-rule get_chromosome:
-    output:
-        "refs/old_release.chr1.fasta"
+        "refs/genome.fasta",
     params:
         species="saccharomyces_cerevisiae",
         datatype="dna",
         build="R64-1-1",
         release="75",
-        chromosome="I"
     log:
-        "logs/get_genome.log"
-    cache: True  # save space and time with between workflow caching (see docs)
+        "logs/get_genome.log",
+    cache: "omit-software"  # save space and time with between workflow caching (see docs)
+    wrapper:
+        "master/bio/reference/ensembl-sequence"
+
+
+rule get_chromosome:
+    output:
+        "refs/old_release.chr1.fasta",
+    params:
+        species="saccharomyces_cerevisiae",
+        datatype="dna",
+        build="R64-1-1",
+        release="75",
+        chromosome="I",
+    log:
+        "logs/get_genome.log",
+    cache: "omit-software"  # save space and time with between workflow caching (see docs)
     wrapper:
         "master/bio/reference/ensembl-sequence"

--- a/bio/reference/ensembl-variation/test/Snakefile
+++ b/bio/reference/ensembl-variation/test/Snakefile
@@ -14,6 +14,6 @@ rule get_variation:
         # branch="plants",  # optional: specify branch
     log:
         "logs/get_variation.log",
-    cache: True  # save space and time with between workflow caching (see docs)
+    cache: "omit-software"  # save space and time with between workflow caching (see docs)
     wrapper:
         "master/bio/reference/ensembl-variation"

--- a/bio/vep/cache/test/Snakefile
+++ b/bio/vep/cache/test/Snakefile
@@ -1,12 +1,12 @@
 rule get_vep_cache:
     output:
-        directory("resources/vep/cache")
+        directory("resources/vep/cache"),
     params:
         species="saccharomyces_cerevisiae",
         build="R64-1-1",
-        release="98"
+        release="98",
     log:
-        "logs/vep/cache.log"
-    cache: True  # save space and time with between workflow caching (see docs)
+        "logs/vep/cache.log",
+    cache: "omit-software"  # save space and time with between workflow caching (see docs)
     wrapper:
         "master/bio/vep/cache"

--- a/meta/bio/star_arriba/test/Snakefile
+++ b/meta/bio/star_arriba/test/Snakefile
@@ -9,7 +9,7 @@ rule star_index:
         extra="--sjdbGTFfile resources/genome.gtf --sjdbOverhang 100",
     log:
         "logs/star_index_genome.log",
-    cache: True
+    cache: True  # mark as eligible for between workflow caching
     wrapper:
         "master/bio/star/index"
 


### PR DESCRIPTION
<!-- Ensure that the PR title follows conventional commit style (<type>: <description>)-->
<!-- Possible types are here: https://github.com/commitizen/conventional-commit-types/blob/master/index.json -->

### Description

<!-- Add a description of your PR here-->

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] I confirm that:

For all wrappers added by this PR, 

* there is a test case which covers any introduced changes,
* `input:` and `output:` file paths in the resulting rule can be changed arbitrarily,
* either the wrapper can only use a single core, or the example rule contains a `threads: x` statement with `x` being a reasonable default,
* rule names in the test case are in [snake_case](https://en.wikipedia.org/wiki/Snake_case) and somehow tell what the rule is about or match the tools purpose or name (e.g., `map_reads` for a step that maps reads),
* all `environment.yaml` specifications follow [the respective best practices](https://stackoverflow.com/a/64594513/2352071),
* wherever possible, command line arguments are inferred and set automatically (e.g. based on file extensions in `input:` or `output:`),
* all fields of the example rules in the `Snakefile`s and their entries are explained via comments (`input:`/`output:`/`params:` etc.),
* `stderr` and/or `stdout` are logged correctly (`log:`), depending on the wrapped tool,
* temporary files are either written to a unique hidden folder in the working directory, or (better) stored where the Python function `tempfile.gettempdir()` points to (see [here](https://docs.python.org/3/library/tempfile.html#tempfile.gettempdir); this also means that using any Python `tempfile` default behavior works),
* the `meta.yaml` contains a link to the documentation of the respective tool or command,
* `Snakefile`s pass the linting (`snakemake --lint`),
* `Snakefile`s are formatted with [snakefmt](https://github.com/snakemake/snakefmt),
* Python wrapper scripts are formatted with [black](https://black.readthedocs.io).
* Conda environments use a minimal amount of channels, in recommended ordering. E.g. for bioconda, use (conda-forge, bioconda, nodefaults, as conda-forge should have highest priority and defaults channels are usually not needed because most packages are in conda-forge nowadays).
