### PR TITLE
fix: Correct referencing of Snakemake input variables (release: 1.19.2)

### DIFF
--- a/bio/rsem/calculate-expression/meta.yaml
+++ b/bio/rsem/calculate-expression/meta.yaml
@@ -1,11 +1,15 @@
 name: rsem calculate expression
+url: http://deweylab.github.io/RSEM/rsem-calculate-expression.html
 description: |
         Run rsem-calculate-expression to estimate gene and isoform expression from RNA-Seq data.
 authors:
   - Brett Copeland
 input:
-  - BAM aligned to transcriptome
+  - bam: BAM file with reads aligned to transcriptome
+  - fq_one: FASTQ file of reads (read_1 for paired-end sequencing)
+  - fq_two: Optional second FASTQ file of reads (read_2 for paired-end sequencing)
 output:
-  - Per-gene and per-isoform read quantification.
+  - genes_results: This file contains per-gene quantification data for the sample
+  - isoforms_results: This file contains per-transcript quantification data for the sample
 notes: |
   * For more information, see https://github.com/deweylab/RSEM.

--- a/bio/rsem/calculate-expression/test/Snakefile
+++ b/bio/rsem/calculate-expression/test/Snakefile
@@ -19,5 +19,6 @@ rule calculate_expression:
         extra="--seed 42",
     log:
         "logs/rsem/calculate_expression/a.log",
+    threads: 2
     wrapper:
         "master/bio/rsem/calculate-expression"

--- a/bio/rsem/calculate-expression/wrapper.py
+++ b/bio/rsem/calculate-expression/wrapper.py
@@ -19,14 +19,14 @@ if bam:
     paired_end = snakemake.params.get("paired-end", False)
 else:
     input_bam = ""
-    if fq:
+    if fq_one:
         input_bam = False
-        if isinstance(fq, list):
-            num_fq_one = len(fq)
-            input_string = ",".join(fq)
+        if isinstance(fq_one, list):
+            num_fq_one = len(fq_one)
+            input_string = ",".join(fq_one)
         else:
             num_fq_one = 1
-            input_string = fq
+            input_string = fq_one
         if fq_two:
             paired_end = True
             if isinstance(fq_two, list):


### PR DESCRIPTION
<!-- Ensure that the PR title follows conventional commit style (<type>: <description>)-->
<!-- Possible types are here: https://github.com/commitizen/conventional-commit-types/blob/master/index.json -->

### Description

<!-- Add a description of your PR here-->
The wrapper for **RSEM Calculate Expression** referenced the wrong Snakemake input variables. This was fixed with an additional adding of threads. Also an update of the meta.yaml was performed.

### QC
<!-- Make sure that you can tick the boxes below. -->

* [ ] I confirm that:

For all wrappers added by this PR, 

* there is a test case which covers any introduced changes,
* `input:` and `output:` file paths in the resulting rule can be changed arbitrarily,
* either the wrapper can only use a single core, or the example rule contains a `threads: x` statement with `x` being a reasonable default,
* rule names in the test case are in [snake_case](https://en.wikipedia.org/wiki/Snake_case) and somehow tell what the rule is about or match the tools purpose or name (e.g., `map_reads` for a step that maps reads),
* all `environment.yaml` specifications follow [the respective best practices](https://stackoverflow.com/a/64594513/2352071),
* wherever possible, command line arguments are inferred and set automatically (e.g. based on file extensions in `input:` or `output:`),
* all fields of the example rules in the `Snakefile`s and their entries are explained via comments (`input:`/`output:`/`params:` etc.),
* `stderr` and/or `stdout` are logged correctly (`log:`), depending on the wrapped tool,
* temporary files are either written to a unique hidden folder in the working directory, or (better) stored where the Python function `tempfile.gettempdir()` points to (see [here](https://docs.python.org/3/library/tempfile.html#tempfile.gettempdir); this also means that using any Python `tempfile` default behavior works),
* the `meta.yaml` contains a link to the documentation of the respective tool or command,
* `Snakefile`s pass the linting (`snakemake --lint`),
* `Snakefile`s are formatted with [snakefmt](https://github.com/snakemake/snakefmt),
* Python wrapper scripts are formatted with [black](https://black.readthedocs.io).
* Conda environments use a minimal amount of channels, in recommended ordering. E.g. for bioconda, use (conda-forge, bioconda, nodefaults, as conda-forge should have highest priority and defaults channels are usually not needed because most packages are in conda-forge nowadays).
