### PR TITLE
feat: samtools view allow region specification

### DIFF
--- a/bio/samtools/view/meta.yaml
+++ b/bio/samtools/view/meta.yaml
@@ -1,5 +1,6 @@
 name: samtools view
 description: Convert or filter SAM/BAM.
+url: http://www.htslib.org/doc/samtools-view.html
 authors:
   - Johannes Köster
   - Filipe G. Vieira

--- a/bio/samtools/view/meta.yaml
+++ b/bio/samtools/view/meta.yaml
@@ -12,4 +12,3 @@ output:
 notes: |
   * The `extra` param allows for additional program arguments (not `-@/--threads`, `--write-index`, `-o` or `-O/--output-fmt`).
   * The `region` param allows one to specify region to extract as `RNAME[:STARTPOS[-ENDPOS]]` (e.g. `chr1`, `chr2:10000000`, `chr3:1000-2000`, `'*'`).
-  * For more information see, http://www.htslib.org/doc/samtools-view.html

--- a/bio/samtools/view/meta.yaml
+++ b/bio/samtools/view/meta.yaml
@@ -3,6 +3,7 @@ description: Convert or filter SAM/BAM.
 authors:
   - Johannes Köster
   - Filipe G. Vieira
+  - Lance Parsons
 input:
   - SAM/BAM/CRAM file
 output:
@@ -10,4 +11,5 @@ output:
   - SAM/BAM/CRAM index file (optional)
 notes: |
   * The `extra` param allows for additional program arguments (not `-@/--threads`, `--write-index`, `-o` or `-O/--output-fmt`).
+  * The `region` param allows one to specify region to extract as `RNAME[:STARTPOS[-ENDPOS]]` (e.g. `chr1`, `chr2:10000000`, `chr3:1000-2000`, `'*'`).
   * For more information see, http://www.htslib.org/doc/samtools-view.html

--- a/bio/samtools/view/test/Snakefile
+++ b/bio/samtools/view/test/Snakefile
@@ -8,6 +8,7 @@ rule samtools_view:
         "{sample}.log",
     params:
         extra="",  # optional params string
+        region="",  # optional region string
     threads: 2
     wrapper:
         "master/bio/samtools/view"

--- a/bio/samtools/view/wrapper.py
+++ b/bio/samtools/view/wrapper.py
@@ -9,7 +9,8 @@ from snakemake_wrapper_utils.samtools import get_samtools_opts
 
 samtools_opts = get_samtools_opts(snakemake)
 extra = snakemake.params.get("extra", "")
+region = snakemake.params.get("region", "")
 log = snakemake.log_fmt_shell(stdout=True, stderr=True, append=True)
 
 
-shell("samtools view {samtools_opts} {extra} {snakemake.input[0]} {log}")
+shell("samtools view {samtools_opts} {extra} {snakemake.input[0]} {region} {log}")


### PR DESCRIPTION
The region to extract with `samtools view` must be specified after the input file (separate from other options), thus a dedicated parameter is required.

<!-- Ensure that the PR title follows conventional commit style (<type>: <description>)-->
<!-- Possible types are here: https://github.com/commitizen/conventional-commit-types/blob/master/index.json -->

### Description

<!-- Add a description of your PR here-->

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] I confirm that:

For all wrappers added by this PR, 

* there is a test case which covers any introduced changes,
* `input:` and `output:` file paths in the resulting rule can be changed arbitrarily,
* either the wrapper can only use a single core, or the example rule contains a `threads: x` statement with `x` being a reasonable default,
* rule names in the test case are in [snake_case](https://en.wikipedia.org/wiki/Snake_case) and somehow tell what the rule is about or match the tools purpose or name (e.g., `map_reads` for a step that maps reads),
* all `environment.yaml` specifications follow [the respective best practices](https://stackoverflow.com/a/64594513/2352071),
* wherever possible, command line arguments are inferred and set automatically (e.g. based on file extensions in `input:` or `output:`),
* all fields of the example rules in the `Snakefile`s and their entries are explained via comments (`input:`/`output:`/`params:` etc.),
* `stderr` and/or `stdout` are logged correctly (`log:`), depending on the wrapped tool,
* temporary files are either written to a unique hidden folder in the working directory, or (better) stored where the Python function `tempfile.gettempdir()` points to (see [here](https://docs.python.org/3/library/tempfile.html#tempfile.gettempdir); this also means that using any Python `tempfile` default behavior works),
* the `meta.yaml` contains a link to the documentation of the respective tool or command,
* `Snakefile`s pass the linting (`snakemake --lint`),
* `Snakefile`s are formatted with [snakefmt](https://github.com/snakemake/snakefmt),
* Python wrapper scripts are formatted with [black](https://black.readthedocs.io).
* Conda environments use a minimal amount of channels, in recommended ordering. E.g. for bioconda, use (conda-forge, bioconda, nodefaults, as conda-forge should have highest priority and defaults channels are usually not needed because most packages are in conda-forge nowadays).
