### PR TITLE
feat: improve star_arriba metawrapper

### DIFF
--- a/meta/bio/star_arriba/test/Snakefile
+++ b/meta/bio/star_arriba/test/Snakefile
@@ -6,7 +6,7 @@ rule star_index:
         directory("resources/star_genome"),
     threads: 4
     params:
-        extra=lambda wc, input: "--sjdbGTFfile {input.annotation} --sjdbOverhang 100",
+        extra=lambda wc, input: f"--sjdbGTFfile {input.annotation} --sjdbOverhang 100",
     log:
         "logs/star_index_genome.log",
     cache: True  # mark as eligible for between workflow caching

--- a/meta/bio/star_arriba/test/Snakefile
+++ b/meta/bio/star_arriba/test/Snakefile
@@ -6,7 +6,7 @@ rule star_index:
         directory("resources/star_genome"),
     threads: 4
     params:
-        extra="--sjdbGTFfile resources/genome.gtf --sjdbOverhang 100",
+        extra=lambda wc, input: "--sjdbGTFfile {input.annotation} --sjdbOverhang 100",
     log:
         "logs/star_index_genome.log",
     cache: True  # mark as eligible for between workflow caching


### PR DESCRIPTION
<!-- Ensure that the PR title follows conventional commit style (<type>: <description>)-->
<!-- Possible types are here: https://github.com/commitizen/conventional-commit-types/blob/master/index.json -->

### Description

When creating the star index the path of the annotation file is currently hardcoded. As it is defined in the input I would suggest to make it a variable.

In addition I would like to discuss if the Test-Snakefile should be more generic.
The `arriba`-rule currently definies a blacklist-file as parameter while it is not part of the input.
In addition the contigs are also limited to chromosome 1 and 2.
As I would expect that a meta wrapper should work out of the box with default parameters when imported as a module it appears reasonable to me to remove this parameters (if this does not make the CI run forever). 

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] I confirm that:

For all wrappers added by this PR, 

* there is a test case which covers any introduced changes,
* `input:` and `output:` file paths in the resulting rule can be changed arbitrarily,
* either the wrapper can only use a single core, or the example rule contains a `threads: x` statement with `x` being a reasonable default,
* rule names in the test case are in [snake_case](https://en.wikipedia.org/wiki/Snake_case) and somehow tell what the rule is about or match the tools purpose or name (e.g., `map_reads` for a step that maps reads),
* all `environment.yaml` specifications follow [the respective best practices](https://stackoverflow.com/a/64594513/2352071),
* wherever possible, command line arguments are inferred and set automatically (e.g. based on file extensions in `input:` or `output:`),
* all fields of the example rules in the `Snakefile`s and their entries are explained via comments (`input:`/`output:`/`params:` etc.),
* `stderr` and/or `stdout` are logged correctly (`log:`), depending on the wrapped tool,
* temporary files are either written to a unique hidden folder in the working directory, or (better) stored where the Python function `tempfile.gettempdir()` points to (see [here](https://docs.python.org/3/library/tempfile.html#tempfile.gettempdir); this also means that using any Python `tempfile` default behavior works),
* the `meta.yaml` contains a link to the documentation of the respective tool or command,
* `Snakefile`s pass the linting (`snakemake --lint`),
* `Snakefile`s are formatted with [snakefmt](https://github.com/snakemake/snakefmt),
* Python wrapper scripts are formatted with [black](https://black.readthedocs.io).
* Conda environments use a minimal amount of channels, in recommended ordering. E.g. for bioconda, use (conda-forge, bioconda, nodefaults, as conda-forge should have highest priority and defaults channels are usually not needed because most packages are in conda-forge nowadays).
