### PR TITLE
fix: pin numpy dependency in cooltools wrappers to avoid https://github.com/numba/numba/issues/8615

### DIFF
--- a/bio/cooltools/dots/environment.yaml
+++ b/bio/cooltools/dots/environment.yaml
@@ -4,3 +4,4 @@ channels:
   - nodefaults
 dependencies:
   - cooltools =0.5
+  - numpy <1.24

--- a/bio/cooltools/eigs_cis/environment.yaml
+++ b/bio/cooltools/eigs_cis/environment.yaml
@@ -5,3 +5,4 @@ channels:
 dependencies:
   - ucsc-bedgraphtobigwig
   - cooltools =0.5.2
+  - numpy <1.24

--- a/bio/cooltools/eigs_trans/environment.yaml
+++ b/bio/cooltools/eigs_trans/environment.yaml
@@ -5,3 +5,4 @@ channels:
 dependencies:
   - ucsc-bedgraphtobigwig
   - cooltools =0.5.2
+  - numpy <1.24

--- a/bio/cooltools/expected_cis/environment.yaml
+++ b/bio/cooltools/expected_cis/environment.yaml
@@ -3,4 +3,5 @@ channels:
   - defaults
   - bioconda
 dependencies:
-  - cooltools =0.5.1
+  - cooltools =0.5.2
+  - numpy <1.24

--- a/bio/cooltools/expected_trans/environment.yaml
+++ b/bio/cooltools/expected_trans/environment.yaml
@@ -4,3 +4,4 @@ channels:
   - bioconda
 dependencies:
   - cooltools =0.5.1
+  - numpy <1.24

--- a/bio/cooltools/genome/binnify/environment.yaml
+++ b/bio/cooltools/genome/binnify/environment.yaml
@@ -4,3 +4,4 @@ channels:
   - bioconda
 dependencies:
   - cooltools =0.5
+  - numpy <1.24

--- a/bio/cooltools/genome/gc/environment.yaml
+++ b/bio/cooltools/genome/gc/environment.yaml
@@ -4,3 +4,4 @@ channels:
   - bioconda
 dependencies:
   - cooltools =0.5
+  - numpy <1.24

--- a/bio/cooltools/insulation/environment.yaml
+++ b/bio/cooltools/insulation/environment.yaml
@@ -3,4 +3,5 @@ channels:
   - defaults
   - bioconda
 dependencies:
-  - cooltools =0.5
+  - cooltools =0.5.2
+  - numpy <1.24

--- a/bio/cooltools/pileup/environment.yaml
+++ b/bio/cooltools/pileup/environment.yaml
@@ -4,3 +4,4 @@ channels:
   - bioconda
 dependencies:
   - cooltools =0.5.2
+  - numpy <1.24

--- a/bio/cooltools/saddle/environment.yaml
+++ b/bio/cooltools/saddle/environment.yaml
@@ -3,4 +3,5 @@ channels:
   - defaults
   - bioconda
 dependencies:
-  - cooltools =0.5.1
+  - cooltools =0.5.2
+  - numpy <1.24


### PR DESCRIPTION
<!-- Ensure that the PR title follows conventional commit style (<type>: <description>)-->
<!-- Possible types are here: https://github.com/commitizen/conventional-commit-types/blob/master/index.json -->

### Description

<!-- Add a description of your PR here-->

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] I confirm that:

For all wrappers added by this PR, 

* there is a test case which covers any introduced changes,
* `input:` and `output:` file paths in the resulting rule can be changed arbitrarily,
* either the wrapper can only use a single core, or the example rule contains a `threads: x` statement with `x` being a reasonable default,
* rule names in the test case are in [snake_case](https://en.wikipedia.org/wiki/Snake_case) and somehow tell what the rule is about or match the tools purpose or name (e.g., `map_reads` for a step that maps reads),
* all `environment.yaml` specifications follow [the respective best practices](https://stackoverflow.com/a/64594513/2352071),
* wherever possible, command line arguments are inferred and set automatically (e.g. based on file extensions in `input:` or `output:`),
* all fields of the example rules in the `Snakefile`s and their entries are explained via comments (`input:`/`output:`/`params:` etc.),
* `stderr` and/or `stdout` are logged correctly (`log:`), depending on the wrapped tool,
* temporary files are either written to a unique hidden folder in the working directory, or (better) stored where the Python function `tempfile.gettempdir()` points to (see [here](https://docs.python.org/3/library/tempfile.html#tempfile.gettempdir); this also means that using any Python `tempfile` default behavior works),
* the `meta.yaml` contains a link to the documentation of the respective tool or command,
* `Snakefile`s pass the linting (`snakemake --lint`),
* `Snakefile`s are formatted with [snakefmt](https://github.com/snakemake/snakefmt),
* Python wrapper scripts are formatted with [black](https://black.readthedocs.io).
* Conda environments use a minimal amount of channels, in recommended ordering. E.g. for bioconda, use (conda-forge, bioconda, nodefaults, as conda-forge should have highest priority and defaults channels are usually not needed because most packages are in conda-forge nowadays).
