### PR TITLE
fix: consensus meta wrapper

### DIFF
--- a/bio/rbt/collapse_reads_to_fragments-bam/environment.yaml
+++ b/bio/rbt/collapse_reads_to_fragments-bam/environment.yaml
@@ -3,4 +3,4 @@ channels:
   - conda-forge
   - nodefaults
 dependencies:
-  - rust-bio-tools =0.41.0
+  - rust-bio-tools =0.42.0

--- a/bio/rbt/collapse_reads_to_fragments-bam/test/Snakefile
+++ b/bio/rbt/collapse_reads_to_fragments-bam/test/Snakefile
@@ -12,7 +12,7 @@ rule calc_consensus_reads:
         consensus_se="results/consensus/{sample}.se.fq",
         skipped="results/consensus/{sample}.skipped.bam",
     params:
-        extra="--verbose-read-names",
+        extra="--annotate-read-ids",
     log:
         "logs/consensus/{sample}.log",
     wrapper:

--- a/bio/rbt/collapse_reads_to_fragments-bam/test/Snakefile
+++ b/bio/rbt/collapse_reads_to_fragments-bam/test/Snakefile
@@ -12,7 +12,7 @@ rule calc_consensus_reads:
         consensus_se="results/consensus/{sample}.se.fq",
         skipped="results/consensus/{sample}.skipped.bam",
     params:
-        extra="--annotate-read-ids",
+        extra="--annotate-record-ids",
     log:
         "logs/consensus/{sample}.log",
     wrapper:

--- a/bio/varscan/somatic/environment.yaml
+++ b/bio/varscan/somatic/environment.yaml
@@ -1,8 +1,8 @@
-name: varscan
 channels:
   - conda-forge
   - bioconda
   - nodefaults
 dependencies:
-  - varscan ==2.4.3
-  - snakemake-wrapper-utils ==0.1.3
+  - varscan =2.4.4
+  - snakemake-wrapper-utils =0.5.0
+name: varscan

--- a/meta/bio/calc_consensus_reads/test/Snakefile
+++ b/meta/bio/calc_consensus_reads/test/Snakefile
@@ -29,7 +29,7 @@ rule map_consensus_reads:
     output:
         temp("results/consensus_mapped/{sample}.{read_type}.bam"),
     params:
-        extra=r"-R '@RG\tID:{sample}\tSM:{sample}'",
+        extra=r"-C -R '@RG\tID:{sample}\tSM:{sample}'",
         index=lambda w, input: os.path.splitext(input.idx[0])[0],
         sort="samtools",
         sort_order="coordinate",


### PR DESCRIPTION

### Description

Currently the snakemake meta wrapper does not transfer information defined in the fastq description field to the bam records during remapping the consensus reads.
Thereby strand information are lost in the resulting bam-file.
As a result variants called by varlociraptor do not benefit from these information.

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] I confirm that:

For all wrappers added by this PR, 

* there is a test case which covers any introduced changes,
* `input:` and `output:` file paths in the resulting rule can be changed arbitrarily,
* either the wrapper can only use a single core, or the example rule contains a `threads: x` statement with `x` being a reasonable default,
* rule names in the test case are in [snake_case](https://en.wikipedia.org/wiki/Snake_case) and somehow tell what the rule is about or match the tools purpose or name (e.g., `map_reads` for a step that maps reads),
* all `environment.yaml` specifications follow [the respective best practices](https://stackoverflow.com/a/64594513/2352071),
* wherever possible, command line arguments are inferred and set automatically (e.g. based on file extensions in `input:` or `output:`),
* all fields of the example rules in the `Snakefile`s and their entries are explained via comments (`input:`/`output:`/`params:` etc.),
* `stderr` and/or `stdout` are logged correctly (`log:`), depending on the wrapped tool,
* temporary files are either written to a unique hidden folder in the working directory, or (better) stored where the Python function `tempfile.gettempdir()` points to (see [here](https://docs.python.org/3/library/tempfile.html#tempfile.gettempdir); this also means that using any Python `tempfile` default behavior works),
* the `meta.yaml` contains a link to the documentation of the respective tool or command,
* `Snakefile`s pass the linting (`snakemake --lint`),
* `Snakefile`s are formatted with [snakefmt](https://github.com/snakemake/snakefmt),
* Python wrapper scripts are formatted with [black](https://black.readthedocs.io).
* Conda environments use a minimal amount of channels, in recommended ordering. E.g. for bioconda, use (conda-forge, bioconda, nodefaults, as conda-forge should have highest priority and defaults channels are usually not needed because most packages are in conda-forge nowadays).
