### PR TITLE
fix: snakemake and mamba deployment

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -59,9 +59,5 @@ jobs:
           DIFF_MASTER: ${{ github.event_name == 'pull_request' }}
           DIFF_LAST_COMMIT: ${{ github.ref == 'refs/heads/master' }}
         run: |
-          # activate conda env
-          export PATH="/usr/share/miniconda/bin:$PATH"
-          source activate snakemake
-
           # run tests
           pytest test.py -v

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,14 +34,19 @@ jobs:
           submodules: recursive
           fetch-depth: 0
 
+      - name: Setup mamba
+        uses: conda-incubator/setup-miniconda@v2
+        with:
+          activate-environment: snakemake
+          channels: "conda-forge, bioconda"
+          miniforge-variant: Mambaforge
+          miniforge-version: latest
+
       - name: Setup Snakemake environment
+        shell: bash -el {0}
         run: |
-          # ensure that mamba is happy to write into the cache
-          sudo chown -R runner:docker /usr/share/miniconda/pkgs/cache
-          conda install -c conda-forge mamba --quiet
-          export PATH="/usr/share/miniconda/bin:$PATH"
-          mamba create -c bioconda -c conda-forge --quiet -y --name snakemake snakemake-minimal pytest
           conda config --set channel_priority strict
+          mamba install -n snakemake -y snakemake-minimal pytest
 
       - name: Fetch master
         if: github.ref != 'refs/heads/master'
@@ -49,6 +54,7 @@ jobs:
           git fetch origin master
 
       - name: Run tests
+        shell: bash -el {0}
         env:
           DIFF_MASTER: ${{ github.event_name == 'pull_request' }}
           DIFF_LAST_COMMIT: ${{ github.ref == 'refs/heads/master' }}

--- a/.github/workflows/qc.yml
+++ b/.github/workflows/qc.yml
@@ -8,42 +8,59 @@ jobs:
   formatting:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
+
+      - name: Setup mamba
+        uses: conda-incubator/setup-miniconda@v2
+        with:
+          activate-environment: fmt
+          channels: "conda-forge, bioconda"
+          miniforge-variant: Mambaforge
+          miniforge-version: latest
 
       - name: Setup environment
-        run: conda create --quiet -c bioconda -c conda-forge --name fmt black snakefmt
+        shell: bash -el {0}
+        run: |
+          conda config --set channel_priority strict
+          mamba install -n fmt -y black snakefmt
 
       - name: Check Python formatting
+        shell: bash -el {0}
         run: |
-          export PATH="/usr/share/miniconda/bin:$PATH"
-          source activate fmt
           black --check */*/*/wrapper.py */*/wrapper.py
-      
+
       # TODO reactivate once comment errors are fixed
       # - name: Check Snakemake formatting
       #   run: |
       #     export PATH="/usr/share/miniconda/bin:$PATH"
       #     source activate fmt
       #     snakefmt --check $(git diff origin/master --name-only | grep Snakefile)
-  
+
   linting:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
 
+      - name: Setup mamba
+        uses: conda-incubator/setup-miniconda@v2
+        with:
+          activate-environment: snakemake
+          channels: "conda-forge, bioconda"
+          miniforge-variant: Mambaforge
+          miniforge-version: latest
+
       - name: Setup Snakemake environment
+        shell: bash -el {0}
         run: |
-          # ensure that mamba is happy to write into the cache
-          sudo chown -R runner:docker /usr/share/miniconda/pkgs/cache
-          conda install -c conda-forge mamba --quiet
-          export PATH="/usr/share/miniconda/bin:$PATH"
-          mamba create -c bioconda -c conda-forge --quiet -y --name snakemake snakemake-minimal
-      
+          conda config --set channel_priority strict
+          mamba install -n snakemake -y snakemake-minimal snakemake
+
       - name: Fetch master
         run: |
           git fetch origin master
 
       - name: Linting
+        shell: bash -el {0}
         run: |
           export PATH="/usr/share/miniconda/bin:$PATH"
           source activate snakemake

--- a/.github/workflows/qc.yml
+++ b/.github/workflows/qc.yml
@@ -62,8 +62,6 @@ jobs:
       - name: Linting
         shell: bash -el {0}
         run: |
-          export PATH="/usr/share/miniconda/bin:$PATH"
-          source activate snakemake
           declare -i ERRORS=0
           # get all modified and added files, not those that are deleted
           for f in $(git diff origin/master --name-only --diff-filter=d | grep Snakefile)

--- a/test.py
+++ b/test.py
@@ -3173,7 +3173,7 @@ def test_star_align():
             shell=True,
         )
         subprocess.check_call(
-            "bash -l -c 'source ~/.bashrc; mamba activate star-env; STAR --genomeDir "
+            "bash -l -c 'source $(dirname $(which mamba))/activate star-env; STAR --genomeDir "
             "bio/star/align/test/index "
             "--genomeFastaFiles bio/star/align/test/genome.fasta "
             "--runMode genomeGenerate "

--- a/test.py
+++ b/test.py
@@ -3173,7 +3173,7 @@ def test_star_align():
             shell=True,
         )
         subprocess.check_call(
-            "bash -l -c 'source $(dirname $(which mamba))/activate star-env; STAR --genomeDir "
+            "bash -l -c 'source $(dirname $(dirname $(which mamba)))/bin/activate star-env; STAR --genomeDir "
             "bio/star/align/test/index "
             "--genomeFastaFiles bio/star/align/test/genome.fasta "
             "--runMode genomeGenerate "

--- a/test.py
+++ b/test.py
@@ -3173,7 +3173,7 @@ def test_star_align():
             shell=True,
         )
         subprocess.check_call(
-            "bash -l -c 'mamba activate star-env; STAR --genomeDir "
+            "bash -l -c 'source activate star-env; STAR --genomeDir "
             "bio/star/align/test/index "
             "--genomeFastaFiles bio/star/align/test/genome.fasta "
             "--runMode genomeGenerate "

--- a/test.py
+++ b/test.py
@@ -3169,18 +3169,16 @@ def test_star_align():
     os.makedirs("bio/star/align/test/index", exist_ok=True)
     try:
         subprocess.check_call(
-            "conda env create " "--file bio/star/align/environment.yaml " "-n star-env",
+            "mamba env create --file bio/star/align/environment.yaml -n star-env",
             shell=True,
-            executable="/bin/bash",
         )
         subprocess.check_call(
-            "source activate star-env; STAR --genomeDir "
+            "mamba activate star-env; STAR --genomeDir "
             "bio/star/align/test/index "
             "--genomeFastaFiles bio/star/align/test/genome.fasta "
             "--runMode genomeGenerate "
             "--genomeSAindexNbases 8",
             shell=True,
-            executable="/bin/bash",
         )
     finally:
         shutil.rmtree("star-env", ignore_errors=True)

--- a/test.py
+++ b/test.py
@@ -3173,11 +3173,11 @@ def test_star_align():
             shell=True,
         )
         subprocess.check_call(
-            "mamba activate star-env; STAR --genomeDir "
+            "bash -l -c 'mamba activate star-env; STAR --genomeDir "
             "bio/star/align/test/index "
             "--genomeFastaFiles bio/star/align/test/genome.fasta "
             "--runMode genomeGenerate "
-            "--genomeSAindexNbases 8",
+            "--genomeSAindexNbases 8'",
             shell=True,
         )
     finally:

--- a/test.py
+++ b/test.py
@@ -3173,7 +3173,7 @@ def test_star_align():
             shell=True,
         )
         subprocess.check_call(
-            "bash -l -c 'source ~/.profile; mamba activate star-env; STAR --genomeDir "
+            "bash -l -c 'source ~/.bashrc; mamba activate star-env; STAR --genomeDir "
             "bio/star/align/test/index "
             "--genomeFastaFiles bio/star/align/test/genome.fasta "
             "--runMode genomeGenerate "

--- a/test.py
+++ b/test.py
@@ -3173,7 +3173,7 @@ def test_star_align():
             shell=True,
         )
         subprocess.check_call(
-            "bash -l -c 'source activate star-env; STAR --genomeDir "
+            "bash -l -c 'source ~/.profile; mamba activate star-env; STAR --genomeDir "
             "bio/star/align/test/index "
             "--genomeFastaFiles bio/star/align/test/genome.fasta "
             "--runMode genomeGenerate "


### PR DESCRIPTION
<!-- Ensure that the PR title follows conventional commit style (<type>: <description>)-->
<!-- Possible types are here: https://github.com/commitizen/conventional-commit-types/blob/master/index.json -->

### Description

<!-- Add a description of your PR here-->

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] I confirm that:

For all wrappers added by this PR, 

* there is a test case which covers any introduced changes,
* `input:` and `output:` file paths in the resulting rule can be changed arbitrarily,
* either the wrapper can only use a single core, or the example rule contains a `threads: x` statement with `x` being a reasonable default,
* rule names in the test case are in [snake_case](https://en.wikipedia.org/wiki/Snake_case) and somehow tell what the rule is about or match the tools purpose or name (e.g., `map_reads` for a step that maps reads),
* all `environment.yaml` specifications follow [the respective best practices](https://stackoverflow.com/a/64594513/2352071),
* wherever possible, command line arguments are inferred and set automatically (e.g. based on file extensions in `input:` or `output:`),
* all fields of the example rules in the `Snakefile`s and their entries are explained via comments (`input:`/`output:`/`params:` etc.),
* `stderr` and/or `stdout` are logged correctly (`log:`), depending on the wrapped tool,
* temporary files are either written to a unique hidden folder in the working directory, or (better) stored where the Python function `tempfile.gettempdir()` points to (see [here](https://docs.python.org/3/library/tempfile.html#tempfile.gettempdir); this also means that using any Python `tempfile` default behavior works),
* the `meta.yaml` contains a link to the documentation of the respective tool or command,
* `Snakefile`s pass the linting (`snakemake --lint`),
* `Snakefile`s are formatted with [snakefmt](https://github.com/snakemake/snakefmt),
* Python wrapper scripts are formatted with [black](https://black.readthedocs.io).
* Conda environments use a minimal amount of channels, in recommended ordering. E.g. for bioconda, use (conda-forge, bioconda, nodefaults, as conda-forge should have highest priority and defaults channels are usually not needed because most packages are in conda-forge nowadays).
