### PR TITLE
fix: properly handle proxy setting in vep cache wrapper

### DIFF
--- a/bio/vep/cache/wrapper.py
+++ b/bio/vep/cache/wrapper.py
@@ -18,7 +18,7 @@ with tempfile.TemporaryDirectory() as tmpdir:
     shell(
         "curl -L ftp://ftp.ensembl.org/pub/release-{snakemake.params.release}/"
         "variation/VEP/{cache_tarball} "
-        "-o {tmpdir.name}/{cache_tarball} {log}"
+        "-o {tmpdir}/{cache_tarball} {log}"
     )
 
     log = snakemake.log_fmt_shell(stdout=True, stderr=True, append=True)
@@ -27,7 +27,7 @@ with tempfile.TemporaryDirectory() as tmpdir:
         "--SPECIES {snakemake.params.species} "
         "--ASSEMBLY {snakemake.params.build} "
         "--VERSION {snakemake.params.release} "
-        "--CACHEURL {tmpdir.name} "
+        "--CACHEURL {tmpdir} "
         "--CACHEDIR {snakemake.output} "
         "--CONVERT "
         "--NO_UPDATE "

--- a/bio/vep/cache/wrapper.py
+++ b/bio/vep/cache/wrapper.py
@@ -1,21 +1,35 @@
 __author__ = "Johannes Köster"
-__copyright__ = "Copyright 2020, Johannes Köster"
+__copyright__ = "Copyright 2023, Johannes Köster"
 __email__ = "johannes.koester@uni-due.de"
 __license__ = "MIT"
 
+import tempfile
 from pathlib import Path
 from snakemake.shell import shell
 
-extra = snakemake.params.get("extra", "")
-log = snakemake.log_fmt_shell(stdout=True, stderr=True)
 
-shell(
-    "vep_install --AUTO cf "
-    "--SPECIES {snakemake.params.species} "
-    "--ASSEMBLY {snakemake.params.build} "
-    "--VERSION {snakemake.params.release} "
-    "--CACHEDIR {snakemake.output} "
-    "--CONVERT "
-    "--NO_UPDATE "
-    "{extra} {log}"
-)
+extra = snakemake.params.get("extra", "")
+
+with tempfile.TemporaryDirectory() as tmpdir:
+    # We download the cache tarball manually because vep_install does not consider proxy settings (in contrast to curl).
+    # See https://github.com/bcbio/bcbio-nextgen/issues/1080
+    cache_tarball = f"{snakemake.params.species}_vep_{snakemake.params.release}_{snakemake.params.build}.tar.gz"
+    log = snakemake.log_fmt_shell(stdout=True, stderr=True)
+    shell(
+        "curl -L ftp://ftp.ensembl.org/pub/release-{snakemake.params.release}/"
+        "variation/VEP/{cache_tarball} "
+        "-o {tmpdir.name}/{cache_tarball} {log}"
+    )
+
+    log = snakemake.log_fmt_shell(stdout=True, stderr=True, append=True)
+    shell(
+        "vep_install --AUTO cf "
+        "--SPECIES {snakemake.params.species} "
+        "--ASSEMBLY {snakemake.params.build} "
+        "--VERSION {snakemake.params.release} "
+        "--CACHEURL {tmpdir.name} "
+        "--CACHEDIR {snakemake.output} "
+        "--CONVERT "
+        "--NO_UPDATE "
+        "{extra} {log}"
+    )

--- a/bio/vep/cache/wrapper.py
+++ b/bio/vep/cache/wrapper.py
@@ -13,11 +13,12 @@ extra = snakemake.params.get("extra", "")
 with tempfile.TemporaryDirectory() as tmpdir:
     # We download the cache tarball manually because vep_install does not consider proxy settings (in contrast to curl).
     # See https://github.com/bcbio/bcbio-nextgen/issues/1080
+    vep_dir = "vep" if snakemake.params.release >= 97 else "VEP"
     cache_tarball = f"{snakemake.params.species}_vep_{snakemake.params.release}_{snakemake.params.build}.tar.gz"
     log = snakemake.log_fmt_shell(stdout=True, stderr=True)
     shell(
         "curl -L ftp://ftp.ensembl.org/pub/release-{snakemake.params.release}/"
-        "variation/VEP/{cache_tarball} "
+        "variation/{vep_dir}/{cache_tarball} "
         "-o {tmpdir}/{cache_tarball} {log}"
     )
 

--- a/bio/vep/cache/wrapper.py
+++ b/bio/vep/cache/wrapper.py
@@ -10,11 +10,16 @@ from snakemake.shell import shell
 
 extra = snakemake.params.get("extra", "")
 
+try:
+    release = int(snakemake.params.release)
+except ValueError:
+    raise ValueError("The parameter release is supposed to be an integer.")
+
 with tempfile.TemporaryDirectory() as tmpdir:
     # We download the cache tarball manually because vep_install does not consider proxy settings (in contrast to curl).
     # See https://github.com/bcbio/bcbio-nextgen/issues/1080
-    vep_dir = "vep" if snakemake.params.release >= 97 else "VEP"
-    cache_tarball = f"{snakemake.params.species}_vep_{snakemake.params.release}_{snakemake.params.build}.tar.gz"
+    vep_dir = "vep" if release >= 97 else "VEP"
+    cache_tarball = f"{snakemake.params.species}_vep_{release}_{snakemake.params.build}.tar.gz"
     log = snakemake.log_fmt_shell(stdout=True, stderr=True)
     shell(
         "curl -L ftp://ftp.ensembl.org/pub/release-{snakemake.params.release}/"
@@ -27,7 +32,7 @@ with tempfile.TemporaryDirectory() as tmpdir:
         "vep_install --AUTO cf "
         "--SPECIES {snakemake.params.species} "
         "--ASSEMBLY {snakemake.params.build} "
-        "--VERSION {snakemake.params.release} "
+        "--VERSION {release} "
         "--CACHEURL {tmpdir} "
         "--CACHEDIR {snakemake.output} "
         "--CONVERT "

--- a/bio/vep/cache/wrapper.py
+++ b/bio/vep/cache/wrapper.py
@@ -19,7 +19,9 @@ with tempfile.TemporaryDirectory() as tmpdir:
     # We download the cache tarball manually because vep_install does not consider proxy settings (in contrast to curl).
     # See https://github.com/bcbio/bcbio-nextgen/issues/1080
     vep_dir = "vep" if release >= 97 else "VEP"
-    cache_tarball = f"{snakemake.params.species}_vep_{release}_{snakemake.params.build}.tar.gz"
+    cache_tarball = (
+        f"{snakemake.params.species}_vep_{release}_{snakemake.params.build}.tar.gz"
+    )
     log = snakemake.log_fmt_shell(stdout=True, stderr=True)
     shell(
         "curl -L ftp://ftp.ensembl.org/pub/release-{snakemake.params.release}/"


### PR DESCRIPTION
<!-- Ensure that the PR title follows conventional commit style (<type>: <description>)-->
<!-- Possible types are here: https://github.com/commitizen/conventional-commit-types/blob/master/index.json -->

### Description

<!-- Add a description of your PR here-->

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] I confirm that:

For all wrappers added by this PR, 

* there is a test case which covers any introduced changes,
* `input:` and `output:` file paths in the resulting rule can be changed arbitrarily,
* either the wrapper can only use a single core, or the example rule contains a `threads: x` statement with `x` being a reasonable default,
* rule names in the test case are in [snake_case](https://en.wikipedia.org/wiki/Snake_case) and somehow tell what the rule is about or match the tools purpose or name (e.g., `map_reads` for a step that maps reads),
* all `environment.yaml` specifications follow [the respective best practices](https://stackoverflow.com/a/64594513/2352071),
* wherever possible, command line arguments are inferred and set automatically (e.g. based on file extensions in `input:` or `output:`),
* all fields of the example rules in the `Snakefile`s and their entries are explained via comments (`input:`/`output:`/`params:` etc.),
* `stderr` and/or `stdout` are logged correctly (`log:`), depending on the wrapped tool,
* temporary files are either written to a unique hidden folder in the working directory, or (better) stored where the Python function `tempfile.gettempdir()` points to (see [here](https://docs.python.org/3/library/tempfile.html#tempfile.gettempdir); this also means that using any Python `tempfile` default behavior works),
* the `meta.yaml` contains a link to the documentation of the respective tool or command,
* `Snakefile`s pass the linting (`snakemake --lint`),
* `Snakefile`s are formatted with [snakefmt](https://github.com/snakemake/snakefmt),
* Python wrapper scripts are formatted with [black](https://black.readthedocs.io).
* Conda environments use a minimal amount of channels, in recommended ordering. E.g. for bioconda, use (conda-forge, bioconda, nodefaults, as conda-forge should have highest priority and defaults channels are usually not needed because most packages are in conda-forge nowadays).
