### PR TITLE
feat: allowed strelka germline using multiple bam

### DIFF
--- a/bio/strelka/germline/wrapper.py
+++ b/bio/strelka/germline/wrapper.py
@@ -1,10 +1,9 @@
-__author__ = "Jan Forster"
+__author__ = "Jan Forster, Christopher Schröder"
 __copyright__ = "Copyright 2019, Jan Forster"
 __email__ = "jan.forster@uk-essen.de"
 __license__ = "MIT"
 
 
-import os
 from pathlib import Path
 from snakemake.shell import shell
 
@@ -14,15 +13,19 @@ log = snakemake.log_fmt_shell(stdout=True, stderr=True)
 
 bam = snakemake.input.get("bam")  # input bam file, required
 assert bam is not None, "input-> bam is a required input parameter"
+if isinstance(bam, str):
+    bam = [bam]
 
 if snakemake.output[0].endswith(".vcf.gz"):
     run_dir = Path(snakemake.output[0]).parents[2]
 else:
     run_dir = snakemake.output
 
+bam_input = " ".join(f"--bam {b}" for b in bam)
+
 shell(
     "(configureStrelkaGermlineWorkflow.py "  # configure the strelka run
-    "--bam {bam} "  # input bam
+    "{bam_input} "  # input bam
     "--referenceFasta {snakemake.input.fasta} "  # reference genome
     "--runDir {run_dir} "  # output directory
     "{config_extra} "  # additional parameters for the configuration


### PR DESCRIPTION
<!-- Ensure that the PR title follows conventional commit style (<type>: <description>)-->
<!-- Possible types are here: https://github.com/commitizen/conventional-commit-types/blob/master/index.json -->

### Description

<!-- Add a description of your PR here-->

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] I confirm that:

For all wrappers added by this PR, 

* there is a test case which covers any introduced changes,
* `input:` and `output:` file paths in the resulting rule can be changed arbitrarily,
* either the wrapper can only use a single core, or the example rule contains a `threads: x` statement with `x` being a reasonable default,
* rule names in the test case are in [snake_case](https://en.wikipedia.org/wiki/Snake_case) and somehow tell what the rule is about or match the tools purpose or name (e.g., `map_reads` for a step that maps reads),
* all `environment.yaml` specifications follow [the respective best practices](https://stackoverflow.com/a/64594513/2352071),
* wherever possible, command line arguments are inferred and set automatically (e.g. based on file extensions in `input:` or `output:`),
* all fields of the example rules in the `Snakefile`s and their entries are explained via comments (`input:`/`output:`/`params:` etc.),
* `stderr` and/or `stdout` are logged correctly (`log:`), depending on the wrapped tool,
* temporary files are either written to a unique hidden folder in the working directory, or (better) stored where the Python function `tempfile.gettempdir()` points to (see [here](https://docs.python.org/3/library/tempfile.html#tempfile.gettempdir); this also means that using any Python `tempfile` default behavior works),
* the `meta.yaml` contains a link to the documentation of the respective tool or command,
* `Snakefile`s pass the linting (`snakemake --lint`),
* `Snakefile`s are formatted with [snakefmt](https://github.com/snakemake/snakefmt),
* Python wrapper scripts are formatted with [black](https://black.readthedocs.io).
* Conda environments use a minimal amount of channels, in recommended ordering. E.g. for bioconda, use (conda-forge, bioconda, nodefaults, as conda-forge should have highest priority and defaults channels are usually not needed because most packages are in conda-forge nowadays).
