### PR TITLE
perf: bump Salmon to v1.10.1

### DIFF
--- a/bio/salmon/quant/environment.yaml
+++ b/bio/salmon/quant/environment.yaml
@@ -1,8 +1,9 @@
 channels:
-  - conda-forge
   - bioconda
+  - conda-forge
   - nodefaults
 dependencies:
   - salmon =1.10.1
   - gzip =1.12
   - bzip2 =1.0.8
+  

--- a/bio/salmon/quant/environment.yaml
+++ b/bio/salmon/quant/environment.yaml
@@ -3,6 +3,6 @@ channels:
   - bioconda
   - nodefaults
 dependencies:
-  - salmon =1.9.0
+  - salmon =1.10.1
   - gzip =1.12
   - bzip2 =1.0.8


### PR DESCRIPTION
### Description

Simple modification of salmon quant environment to install the latest version (v1.10.1)


### QC
<!-- Make sure that you can tick the boxes below. -->

* [X] I confirm that:

For all wrappers added by this PR, 

* there is a test case which covers any introduced changes,
* `input:` and `output:` file paths in the resulting rule can be changed arbitrarily,
* either the wrapper can only use a single core, or the example rule contains a `threads: x` statement with `x` being a reasonable default,
* rule names in the test case are in [snake_case](https://en.wikipedia.org/wiki/Snake_case) and somehow tell what the rule is about or match the tools purpose or name (e.g., `map_reads` for a step that maps reads),
* all `environment.yaml` specifications follow [the respective best practices](https://stackoverflow.com/a/64594513/2352071),
* wherever possible, command line arguments are inferred and set automatically (e.g. based on file extensions in `input:` or `output:`),
* all fields of the example rules in the `Snakefile`s and their entries are explained via comments (`input:`/`output:`/`params:` etc.),
* `stderr` and/or `stdout` are logged correctly (`log:`), depending on the wrapped tool,
* temporary files are either written to a unique hidden folder in the working directory, or (better) stored where the Python function `tempfile.gettempdir()` points to (see [here](https://docs.python.org/3/library/tempfile.html#tempfile.gettempdir); this also means that using any Python `tempfile` default behavior works),
* the `meta.yaml` contains a link to the documentation of the respective tool or command,
* `Snakefile`s pass the linting (`snakemake --lint`),
* `Snakefile`s are formatted with [snakefmt](https://github.com/snakemake/snakefmt),
* Python wrapper scripts are formatted with [black](https://black.readthedocs.io).
* Conda environments use a minimal amount of channels, in recommended ordering. E.g. for bioconda, use (conda-forge, bioconda, nodefaults, as conda-forge should have highest priority and defaults channels are usually not needed because most packages are in conda-forge nowadays).

```
pytest test.py -v -k test_salmon_quant
========================================================== test session starts ===========================================================
platform linux -- Python 3.10.8, pytest-7.2.1, pluggy-1.0.0 -- /home/austin/mambaforge/bin/python3.10
cachedir: .pytest_cache
rootdir: /home/austin/snakemake-wrappers
plugins: xdist-3.1.0
collected 441 items / 440 deselected / 1 selected                                                                                        

test.py::test_salmon_quant XPASS                                                                                                   [100%]

============================================= 440 deselected, 1 xpassed in 71.30s (0:01:11) ==============================================
```