### PR TITLE
feat: automate inference of index name

### DIFF
--- a/bio/picard/markduplicates/meta.yaml
+++ b/bio/picard/markduplicates/meta.yaml
@@ -1,15 +1,19 @@
 name: picard MarkDuplicates
 description: |
-  Mark PCR and optical duplicates with picard tools. For more information about MarkDuplicates see `picard documentation <https://broadinstitute.github.io/picard/command-line-overview.html#MarkDuplicates>`_.
+  Mark PCR and optical duplicates with picard tools.
+url: https://broadinstitute.github.io/picard/command-line-overview.html#MarkDuplicates
 authors:
   - Johannes Köster
   - Christopher Schröder
+  - Filipe G. Vieira
 input:
   - bam/cram file(s)
 output:
   - bam/cram file with marked or removed duplicates
+params:
+  - `java_opts` allows for additional arguments to be passed to the java compiler, e.g. "-XX:ParallelGCThreads=10" (not for `-XmX` or `-Djava.io.tmpdir`, since they are handled automatically).
+  - `extra` allows for additional program arguments.
+  - `embed_ref` allows to embed the fasta reference into the cram
+  - `withmatecigar` allows to run `MarkDuplicatesWithMateCigar <https://broadinstitute.github.io/picard/command-line-overview.html#MarkDuplicatesWithMateCigar>`_ instead.
 notes: |
-  * The `java_opts` param allows for additional arguments to be passed to the java compiler, e.g. "-XX:ParallelGCThreads=10" (not for `-XmX` or `-Djava.io.tmpdir`, since they are handled automatically).
-  * The `extra` param allows for additional program arguments.
   * `--TMP_DIR` is automatically set by `resources.tmpdir`
-  * For more information see, https://broadinstitute.github.io/picard/command-line-overview.html#MarkDuplicates

--- a/bio/picard/markduplicates/test/Snakefile
+++ b/bio/picard/markduplicates/test/Snakefile
@@ -6,9 +6,10 @@ rule mark_duplicates:
     # and then merging
     output:
         bam="dedup/{sample}.bam",
+        idx="dedup/{sample}.bai",
         metrics="dedup/{sample}.metrics.txt",
     log:
-        "logs/picard/dedup/{sample}.log",
+        "logs/dedup/{sample}.log",
     params:
         extra="--REMOVE_DUPLICATES true",
     # optional specification of memory usage of the JVM that snakemake will respect with global
@@ -21,6 +22,18 @@ rule mark_duplicates:
         "master/bio/picard/markduplicates"
 
 
+use rule mark_duplicates as mark_duplicates_withmatecigar with:
+    output:
+        bam="dedup/{sample}.matecigar.bam",
+        idx="dedup/{sample}.matecigar.bai",
+        metrics="dedup/{sample}.matecigar.metrics.txt",
+    log:
+        "logs/dedup/{sample}.matecigar.log",
+    params:
+        withmatecigar=True,
+        extra="--REMOVE_DUPLICATES true",
+
+
 rule mark_duplicates_cram:
     input:
         bams="mapped/{sample}.bam",
@@ -30,12 +43,14 @@ rule mark_duplicates_cram:
     # and then merging
     output:
         bam="dedup/{sample}.cram",
-        metrics="dedup/{sample}.metrics.txt",
+        idx="dedup/{sample}.crai",
+        metrics="dedup/{sample}.cram.metrics.txt",
     log:
-        "logs/picard/dedup/{sample}.log",
+        "logs/dedup/{sample}.cram.log",
     params:
         extra="--REMOVE_DUPLICATES true",
         embed_ref=True,  # set true if the fasta reference should be embedded into the cram
+        withmatecigar=False,
     # optional specification of memory usage of the JVM that snakemake will respect with global
     # resource restrictions (https://snakemake.readthedocs.io/en/latest/snakefiles/rules.html#resources)
     # and which can be used to request RAM during cluster job submission as `{resources.mem_mb}`:

--- a/test.py
+++ b/test.py
@@ -2835,12 +2835,18 @@ def test_picard_markduplicates_cram():
 
 
 @skip_if_not_modified
+def test_picard_markduplicates_matecigar():
+    run(
+        "bio/picard/markduplicates",
+        ["snakemake", "--cores", "1", "dedup/a.matecigar.bam", "--use-conda", "-F"],
+    )
+
+@skip_if_not_modified
 def test_picard_markduplicateswithmatecigar():
     run(
         "bio/picard/markduplicateswithmatecigar",
         ["snakemake", "--cores", "1", "dedup/a.bam", "--use-conda", "-F"],
     )
-
 
 @skip_if_not_modified
 def test_picard_collectalignmentsummarymetrics():


### PR DESCRIPTION
<!-- Ensure that the PR title follows conventional commit style (<type>: <description>)-->
<!-- Possible types are here: https://github.com/commitizen/conventional-commit-types/blob/master/index.json -->

### Description

<!-- Add a description of your PR here-->
Added automated inference of index name and to call `MarkDuplicatesWithMateCigar` instead of the default, since both tools are quite similar.
These changes render the wrapper `bio/picard/markduplicateswithmatecigar` redundant,

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] I confirm that:

For all wrappers added by this PR, 

* there is a test case which covers any introduced changes,
* `input:` and `output:` file paths in the resulting rule can be changed arbitrarily,
* either the wrapper can only use a single core, or the example rule contains a `threads: x` statement with `x` being a reasonable default,
* rule names in the test case are in [snake_case](https://en.wikipedia.org/wiki/Snake_case) and somehow tell what the rule is about or match the tools purpose or name (e.g., `map_reads` for a step that maps reads),
* all `environment.yaml` specifications follow [the respective best practices](https://stackoverflow.com/a/64594513/2352071),
* wherever possible, command line arguments are inferred and set automatically (e.g. based on file extensions in `input:` or `output:`),
* all fields of the example rules in the `Snakefile`s and their entries are explained via comments (`input:`/`output:`/`params:` etc.),
* `stderr` and/or `stdout` are logged correctly (`log:`), depending on the wrapped tool,
* temporary files are either written to a unique hidden folder in the working directory, or (better) stored where the Python function `tempfile.gettempdir()` points to (see [here](https://docs.python.org/3/library/tempfile.html#tempfile.gettempdir); this also means that using any Python `tempfile` default behavior works),
* the `meta.yaml` contains a link to the documentation of the respective tool or command,
* `Snakefile`s pass the linting (`snakemake --lint`),
* `Snakefile`s are formatted with [snakefmt](https://github.com/snakemake/snakefmt),
* Python wrapper scripts are formatted with [black](https://black.readthedocs.io).
* Conda environments use a minimal amount of channels, in recommended ordering. E.g. for bioconda, use (conda-forge, bioconda, nodefaults, as conda-forge should have highest priority and defaults channels are usually not needed because most packages are in conda-forge nowadays).
