### PR TITLE
fix: ensembl annotation GRCh37 gft release

### DIFF
--- a/bio/reference/ensembl-annotation/test/Snakefile
+++ b/bio/reference/ensembl-annotation/test/Snakefile
@@ -3,7 +3,7 @@ rule get_annotation:
         "refs/annotation.gtf",
     params:
         species="homo_sapiens",
-        release="87",
+        release="105",
         build="GRCh37",
         flavor="",  # optional, e.g. chr_patch_hapl_scaff, see Ensembl FTP.
         # branch="plants",  # optional: specify branch
@@ -19,7 +19,7 @@ rule get_annotation_gz:
         "refs/annotation.gtf.gz",
     params:
         species="homo_sapiens",
-        release="87",
+        release="105",
         build="GRCh37",
         flavor="",  # optional, e.g. chr_patch_hapl_scaff, see Ensembl FTP.
         # branch="plants",  # optional: specify branch

--- a/bio/reference/ensembl-annotation/wrapper.py
+++ b/bio/reference/ensembl-annotation/wrapper.py
@@ -15,7 +15,7 @@ log = snakemake.log_fmt_shell(stdout=False, stderr=True)
 species = snakemake.params.species.lower()
 build = snakemake.params.build
 release = int(snakemake.params.release)
-gft_release = release
+gtf_release = release
 out_fmt = Path(snakemake.output[0]).suffixes
 out_gz = (out_fmt.pop() and True) if out_fmt[-1] == ".gz" else False
 out_fmt = out_fmt.pop().lstrip(".")
@@ -27,7 +27,7 @@ if build == "GRCh37":
         # use the special grch37 branch for new releases
         branch = "grch37/"
     if release > 87:
-        gft_release = 87
+        gtf_release = 87
 elif snakemake.params.get("branch"):
     branch = snakemake.params.branch + "/"
 
@@ -48,9 +48,9 @@ else:
     )
 
 
-url = "ftp://ftp.ensembl.org/pub/{branch}release-{release}/{out_fmt}/{species}/{species_cap}.{build}.{gft_release}.{flavor}{suffix}".format(
+url = "ftp://ftp.ensembl.org/pub/{branch}release-{release}/{out_fmt}/{species}/{species_cap}.{build}.{gtf_release}.{flavor}{suffix}".format(
     release=release,
-    gft_release=gft_release,
+    gtf_release=gtf_release,
     build=build,
     species=species,
     out_fmt=out_fmt,

--- a/bio/reference/ensembl-annotation/wrapper.py
+++ b/bio/reference/ensembl-annotation/wrapper.py
@@ -15,15 +15,19 @@ log = snakemake.log_fmt_shell(stdout=False, stderr=True)
 species = snakemake.params.species.lower()
 build = snakemake.params.build
 release = int(snakemake.params.release)
+gft_release = release
 out_fmt = Path(snakemake.output[0]).suffixes
 out_gz = (out_fmt.pop() and True) if out_fmt[-1] == ".gz" else False
 out_fmt = out_fmt.pop().lstrip(".")
 
 
 branch = ""
-if release >= 81 and build == "GRCh37":
-    # use the special grch37 branch for new releases
-    branch = "grch37/"
+if build == "GRCh37":
+    if release >= 81:
+        # use the special grch37 branch for new releases
+        branch = "grch37/"
+    if release > 87:
+        gft_release = 87
 elif snakemake.params.get("branch"):
     branch = snakemake.params.branch + "/"
 
@@ -44,8 +48,9 @@ else:
     )
 
 
-url = "ftp://ftp.ensembl.org/pub/{branch}release-{release}/{out_fmt}/{species}/{species_cap}.{build}.{release}.{flavor}{suffix}".format(
+url = "ftp://ftp.ensembl.org/pub/{branch}release-{release}/{out_fmt}/{species}/{species_cap}.{build}.{gft_release}.{flavor}{suffix}".format(
     release=release,
+    gft_release=gft_release,
     build=build,
     species=species,
     out_fmt=out_fmt,


### PR DESCRIPTION
<!-- Ensure that the PR title follows conventional commit style (<type>: <description>)-->
<!-- Possible types are here: https://github.com/commitizen/conventional-commit-types/blob/master/index.json -->

### Description

When downloading the annotation fails for GRCh37 releases greater than 87 as the release version in the gft-file remains 87.
This is fixed by adding an extra variable for the release version in the gft filename.

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] I confirm that:

For all wrappers added by this PR, 

* there is a test case which covers any introduced changes,
* `input:` and `output:` file paths in the resulting rule can be changed arbitrarily,
* either the wrapper can only use a single core, or the example rule contains a `threads: x` statement with `x` being a reasonable default,
* rule names in the test case are in [snake_case](https://en.wikipedia.org/wiki/Snake_case) and somehow tell what the rule is about or match the tools purpose or name (e.g., `map_reads` for a step that maps reads),
* all `environment.yaml` specifications follow [the respective best practices](https://stackoverflow.com/a/64594513/2352071),
* wherever possible, command line arguments are inferred and set automatically (e.g. based on file extensions in `input:` or `output:`),
* all fields of the example rules in the `Snakefile`s and their entries are explained via comments (`input:`/`output:`/`params:` etc.),
* `stderr` and/or `stdout` are logged correctly (`log:`), depending on the wrapped tool,
* temporary files are either written to a unique hidden folder in the working directory, or (better) stored where the Python function `tempfile.gettempdir()` points to (see [here](https://docs.python.org/3/library/tempfile.html#tempfile.gettempdir); this also means that using any Python `tempfile` default behavior works),
* the `meta.yaml` contains a link to the documentation of the respective tool or command,
* `Snakefile`s pass the linting (`snakemake --lint`),
* `Snakefile`s are formatted with [snakefmt](https://github.com/snakemake/snakefmt),
* Python wrapper scripts are formatted with [black](https://black.readthedocs.io).
* Conda environments use a minimal amount of channels, in recommended ordering. E.g. for bioconda, use (conda-forge, bioconda, nodefaults, as conda-forge should have highest priority and defaults channels are usually not needed because most packages are in conda-forge nowadays).
