### PR TITLE
feat: gatk modelsegments wrapper

### DIFF
--- a/bio/gatk/modelsegments/environment.yaml
+++ b/bio/gatk/modelsegments/environment.yaml
@@ -1,0 +1,7 @@
+channels:
+  - conda-forge
+  - bioconda
+  - nodefaults
+dependencies:
+  - gatk4 =4.4.0.0
+  - snakemake-wrapper-utils =0.5.3

--- a/bio/gatk/modelsegments/meta.yaml
+++ b/bio/gatk/modelsegments/meta.yaml
@@ -10,7 +10,6 @@ input:
   - matched_normal allelic-counts, Optional
   - segments picard interval-list file containing a multisample segmentation output by a previous run, optional
 params:
-  - prefix for output filenames, if not specified the wrapper will try to extract it from the output files
   - The `java_opts` param allows for additional arguments to be passed to the java compiler, e.g. "-XX:ParallelGCThreads=10" (not for `-XmX` or `-Djava.io.tmpdir`, since they are handled automatically).
   - The `extra` param allows for additional program arguments.
 output:

--- a/bio/gatk/modelsegments/meta.yaml
+++ b/bio/gatk/modelsegments/meta.yaml
@@ -5,15 +5,15 @@ description: |
 authors:
   - Patrik Smeds
 input:
-  - denoised_copy_ratios file, optional 
-  - allelic_counts file, Optional
-  - matched_normal allelic-counts, Optional
-  - segments picard interval-list file containing a multisample segmentation output by a previous run, optional
-params:
-  - The `java_opts` param allows for additional arguments to be passed to the java compiler, e.g. "-XX:ParallelGCThreads=10" (not for `-XmX` or `-Djava.io.tmpdir`, since they are handled automatically).
-  - The `extra` param allows for additional program arguments.
+  - denoised_copy_ratios: denoised_copy_ratios file (optional)
+  - allelic_counts: allelic_counts file (optional)
+  - normal_allelic_counts: matched_normal allelic-counts (optional)
+  - segments: segments Picard interval-list file containing a multisample segmentation output by a previous run (optional)
 output:
-  - list of files, one ore more files ending with '.modelFinal.seq', '.cr.seg', '.af.igv.seg', '.cr.igv.seg', '.hets.tsv', '.modelBegin.cr.param', '.modelBegin.af.param', '.modelBegin.seg', '.modelFinal.af.param' and '.modelFinal.cr.param'
+  - list of files ending with either '.modelFinal.seq', '.cr.seg', '.af.igv.seg', '.cr.igv.seg', '.hets.tsv', '.modelBegin.cr.param', '.modelBegin.af.param', '.modelBegin.seg', '.modelFinal.af.param' or '.modelFinal.cr.param'
+params:
+  - java_opts: additional arguments to be passed to the java compiler, e.g. "-XX:ParallelGCThreads=10" (not for `-XmX` or `-Djava.io.tmpdir`, since they are handled automatically).
+  - extra: additional program arguments.
 note: |
   * Expected input is either denoised_copy_ratios or allelic_counts
   * matched_normal must provided together with allelic_counts

--- a/bio/gatk/modelsegments/meta.yaml
+++ b/bio/gatk/modelsegments/meta.yaml
@@ -1,0 +1,20 @@
+name: gatk ModelSegments
+url: https://gatk.broadinstitute.org/hc/en-us/articles/13832747657883-ModelSegments
+description: |
+  Models segmented copy ratios from denoised copy ratios and segmented minor-allele fractions from allelic counts
+authors:
+  - Patrik Smeds
+input:
+  - denoised_copy_ratios file, optional 
+  - allelic_counts file, Optional
+  - matched_normal allelic-counts, Optional
+  - segments picard interval-list file containing a multisample segmentation output by a previous run, optional
+params:
+  - prefix for output filenames, if not specified the wrapper will try to extract it from the output files
+  - The `java_opts` param allows for additional arguments to be passed to the java compiler, e.g. "-XX:ParallelGCThreads=10" (not for `-XmX` or `-Djava.io.tmpdir`, since they are handled automatically).
+  - The `extra` param allows for additional program arguments.
+output:
+  - list of files, one ore more files ending with '.modelFinal.seq', '.cr.seg', '.af.igv.seg', '.cr.igv.seg', '.hets.tsv', '.modelBegin.cr.param', '.modelBegin.af.param', '.modelBegin.seg', '.modelFinal.af.param' and '.modelFinal.cr.param'
+note: |
+  * Expected input is either denoised_copy_ratios or allelic_counts
+  * matched_normal must provided together with allelic_counts

--- a/bio/gatk/modelsegments/meta.yaml
+++ b/bio/gatk/modelsegments/meta.yaml
@@ -15,5 +15,5 @@ params:
   - java_opts: additional arguments to be passed to the java compiler, e.g. "-XX:ParallelGCThreads=10" (not for `-XmX` or `-Djava.io.tmpdir`, since they are handled automatically).
   - extra: additional program arguments.
 note: |
-  * Expected input is either denoised_copy_ratios or allelic_counts
-  * matched_normal must provided together with allelic_counts
+  * Expected input is either `denoised_copy_ratios` or `allelic_counts`
+  * `normal_allelic_counts` must be provided together with `allelic_counts`

--- a/bio/gatk/modelsegments/test/Snakefile
+++ b/bio/gatk/modelsegments/test/Snakefile
@@ -3,7 +3,7 @@ rule modelsegments_denoise_input:
         denoised_copy_ratios="a.denoisedCR.tsv",
     output:
         "a.den.modelFinal.seg",
-        "a.den.cr.seg",
+        "a.n.cr.seg",
     log:
         "logs/gatk/modelsegments_denoise.log",
     params:

--- a/bio/gatk/modelsegments/test/Snakefile
+++ b/bio/gatk/modelsegments/test/Snakefile
@@ -1,0 +1,17 @@
+rule modelsegments_denoise_input:
+    input:
+        denoised_copy_ratios="a.denoisedCR.tsv",
+    output:
+        "a.den.modelFinal.seg",
+        "a.den.cr.seg",
+    log:
+        "logs/gatk/modelsegments_denoise.log",
+    params:
+        #prefix="a.den.test",
+        extra="",  # optional
+        java_opts="",  # optional
+    resources:
+        mem_mb=1024,
+    wrapper:
+        "master/bio/gatk/modelsegments"
+

--- a/bio/gatk/modelsegments/test/a.denoisedCR.tsv
+++ b/bio/gatk/modelsegments/test/a.denoisedCR.tsv
@@ -1,0 +1,6 @@
+@HD	VN:1.6
+@SQ	SN:ref	LN:45
+@SQ	SN:ref2	LN:40
+@RG	ID:GATKCopyNumber	SM:mysample
+CONTIG	START	END	LOG2_COPY_RATIO
+ref2	1	30	0.000000

--- a/bio/gatk/modelsegments/wrapper.py
+++ b/bio/gatk/modelsegments/wrapper.py
@@ -1,0 +1,105 @@
+__author__ = "Patrik Smeds"
+__copyright__ = "Copyright 2023, Patrik Smed"
+__email__ = "patrik.smeds@gmail.com"
+__license__ = "MIT"
+
+import os
+import tempfile
+from snakemake.shell import shell
+from snakemake_wrapper_utils.java import get_java_opts
+
+
+denoised_copy_ratios = ""
+if snakemake.input.get("denoised_copy_ratios", None):
+    denoised_copy_ratios = (
+        f"--denoised-copy-ratios {snakemake.input.denoised_copy_ratios}"
+    )
+
+allelic_counts = ""
+if snakemake.input.get("allelic_counts", None):
+    allelic_counts = f"--allelic-counts {snakemake.input.allelic_counts}"
+
+normal_allelic_counts = ""
+if snakemake.input.get("normal_allelic_counts", None):
+    matched_normal_allelic_counts = (
+        f"--normal-allelic-counts {snakemake.inut.normal_allelic_counts}"
+    )
+
+segments = ""
+if snakemake.input.get("segments", None):
+    interval_list = f"--segments {snakemake.input.segments}"
+
+if not allelic_counts and not denoised_copy_ratios:
+    raise Exception(
+        "wrapper input requires either 'allelic_counts' or 'denoise_copy_ratios' to be set"
+    )
+
+if normal_allelic_counts and not allelic_counts:
+    raise Exception(
+        "'allelica_counts' is required when 'normal-allelic-counts' is an input to the rule!"
+    )
+
+
+output_prefix = None
+if snakemake.params.get("output_prefix"):
+    # Make sure specified prefix matches listed output files
+    output_prefix = snakemake.params.output_prefix
+    for output in snakemake.output:
+        output_file = os.path.basename(output)
+        if not output_file.startswith(prefix):
+            raise Exception(
+                f"output file {output_file} doesn't start with the provided prefix {prefix}"
+            )
+else:
+    expected_output_file_endings = [
+        ".modelFinal.seq",
+        ".cr.seg",
+        ".af.igv.seg",
+        ".cr.igv.seg",
+        ".hets.tsv",
+        ".modelBegin.cr.param",
+        ".modelBegin.af.param",
+        ".modelBegin.seg",
+        ".modelFinal.af.param",
+        ".modelFinal.cr.param",
+    ]
+    # Create prefix from listed output files
+    for output in snakemake.output:
+        output_file = os.path.basename(output)
+        for output_extensions in expected_output_file_endings:
+            if output_file.endswith(output_extensions):
+                output_prefix = output_file.replace(output_extensions, "")
+                break
+        if output_prefix:
+            break
+    if not output_prefix:
+        raise Exception(
+            "Unable to extract prefix from listed files, expecting file(s) ending "
+            f"with at least one of {expected_output_file_endings}"
+        )
+
+extra = snakemake.params.get("extra", "")
+java_opts = get_java_opts(snakemake)
+
+log = snakemake.log_fmt_shell(stdout=True, stderr=True)
+
+
+with tempfile.TemporaryDirectory() as tmpdir:
+    output_folder = os.path.join(tmpdir, "output_folder")
+    shell(
+        "gatk --java-options '{java_opts}' ModelSegments"
+        " {segments}"
+        " {denoised_copy_ratios}"
+        " {allelic_counts}"
+        " {normal_allelic_counts}"
+        " --output-prefix {output_prefix}"
+        " -O {output_folder}"
+        " --tmp-dir {tmpdir}"
+        " {extra}"
+        " {log}"
+    )
+
+    for output in snakemake.output:
+        filename = os.path.basename(output)
+        outfile = os.path.join(output_folder, filename)
+        shell("cp {outfile} {output}")

--- a/test.py
+++ b/test.py
@@ -3963,6 +3963,14 @@ def test_gatk_haplotypecaller_gvcf():
 
 
 @skip_if_not_modified
+def test_gatk_modelsegments():
+    run(
+        "bio/gatk/modelsegments",
+        ["snakemake", "--cores", "1", "a.den.modelFinal.seg", "--use-conda", "-F"],
+    )
+
+
+@skip_if_not_modified
 def test_gatk_variantrecalibrator():
     def check_log(log):
         assert "USAGE" not in log


### PR DESCRIPTION

### Description

gatk ModelSegments wrapper

### QC
<!-- Make sure that you can tick the boxes below. -->

* [ ] I confirm that:

For all wrappers added by this PR, 

* there is a test case which covers any introduced changes,
* `input:` and `output:` file paths in the resulting rule can be changed arbitrarily,
* either the wrapper can only use a single core, or the example rule contains a `threads: x` statement with `x` being a reasonable default,
* rule names in the test case are in [snake_case](https://en.wikipedia.org/wiki/Snake_case) and somehow tell what the rule is about or match the tools purpose or name (e.g., `map_reads` for a step that maps reads),
* all `environment.yaml` specifications follow [the respective best practices](https://stackoverflow.com/a/64594513/2352071),
* wherever possible, command line arguments are inferred and set automatically (e.g. based on file extensions in `input:` or `output:`),
* all fields of the example rules in the `Snakefile`s and their entries are explained via comments (`input:`/`output:`/`params:` etc.),
* `stderr` and/or `stdout` are logged correctly (`log:`), depending on the wrapped tool,
* temporary files are either written to a unique hidden folder in the working directory, or (better) stored where the Python function `tempfile.gettempdir()` points to (see [here](https://docs.python.org/3/library/tempfile.html#tempfile.gettempdir); this also means that using any Python `tempfile` default behavior works),
* the `meta.yaml` contains a link to the documentation of the respective tool or command,
* `Snakefile`s pass the linting (`snakemake --lint`),
* `Snakefile`s are formatted with [snakefmt](https://github.com/snakemake/snakefmt),
* Python wrapper scripts are formatted with [black](https://black.readthedocs.io).
* Conda environments use a minimal amount of channels, in recommended ordering. E.g. for bioconda, use (conda-forge, bioconda, nodefaults, as conda-forge should have highest priority and defaults channels are usually not needed because most packages are in conda-forge nowadays).
