### PR TITLE
fix: fixed bug when formatting string

### DIFF
--- a/bio/gatk/denoisereadcounts/wrapper.py
+++ b/bio/gatk/denoisereadcounts/wrapper.py
@@ -9,14 +9,15 @@ from snakemake.shell import shell
 from snakemake_wrapper_utils.java import get_java_opts
 
 
-panel_of_normal = ""
-if snakemake.input.get("pon", None):
-    panel_of_normal = "--count-panel-of-normals {snakemake.input.pon}"
+pon = snakemake.input.get("pon", "")
+if pon:
+    pon = f"--count-panel-of-normals {snakemake.input.pon}"
 
 
-gc_intervals = ""
-if snakemake.input.get("gc_interval", None):
-    gc_intervals = "--annotated-intervals {snakemake.input.gc_interval}"
+gc_interval = snakemake.input.get("gc_interval", "")
+if gc_interval:
+    gc_interval = f"--annotated-intervals {snakemake.input.gc_interval}"
+
 
 extra = snakemake.params.get("extra", "")
 java_opts = get_java_opts(snakemake)
@@ -26,12 +27,12 @@ log = snakemake.log_fmt_shell(stdout=True, stderr=True)
 with tempfile.TemporaryDirectory() as tmpdir:
     shell(
         "gatk --java-options '{java_opts}' DenoiseReadCounts"
-        " -I {snakemake.input.hdf5} "
-        " {panel_of_normal}"
-        " {gc_intervals}"
+        " --input {snakemake.input.hdf5}"
+        " {pon}"
+        " {gc_interval}"
+        " {extra}"
         " --standardized-copy-ratios {snakemake.output.std_copy_ratio}"
         " --denoised-copy-ratios {snakemake.output.denoised_copy_ratio}"
         " --tmp-dir {tmpdir}"
-        " {extra}"
         " {log}"
     )


### PR DESCRIPTION
<!-- Ensure that the PR title follows conventional commit style (<type>: <description>)-->
<!-- Possible types are here: https://github.com/commitizen/conventional-commit-types/blob/master/index.json -->

### Description

<!-- Add a description of your PR here-->
Fixed bug when formatting string

### QC
<!-- Make sure that you can tick the boxes below. -->

* [ ] I confirm that:

For all wrappers added by this PR, 

* there is a test case which covers any introduced changes,
* `input:` and `output:` file paths in the resulting rule can be changed arbitrarily,
* either the wrapper can only use a single core, or the example rule contains a `threads: x` statement with `x` being a reasonable default,
* rule names in the test case are in [snake_case](https://en.wikipedia.org/wiki/Snake_case) and somehow tell what the rule is about or match the tools purpose or name (e.g., `map_reads` for a step that maps reads),
* all `environment.yaml` specifications follow [the respective best practices](https://stackoverflow.com/a/64594513/2352071),
* wherever possible, command line arguments are inferred and set automatically (e.g. based on file extensions in `input:` or `output:`),
* all fields of the example rules in the `Snakefile`s and their entries are explained via comments (`input:`/`output:`/`params:` etc.),
* `stderr` and/or `stdout` are logged correctly (`log:`), depending on the wrapped tool,
* temporary files are either written to a unique hidden folder in the working directory, or (better) stored where the Python function `tempfile.gettempdir()` points to (see [here](https://docs.python.org/3/library/tempfile.html#tempfile.gettempdir); this also means that using any Python `tempfile` default behavior works),
* the `meta.yaml` contains a link to the documentation of the respective tool or command,
* `Snakefile`s pass the linting (`snakemake --lint`),
* `Snakefile`s are formatted with [snakefmt](https://github.com/snakemake/snakefmt),
* Python wrapper scripts are formatted with [black](https://black.readthedocs.io).
* Conda environments use a minimal amount of channels, in recommended ordering. E.g. for bioconda, use (conda-forge, bioconda, nodefaults, as conda-forge should have highest priority and defaults channels are usually not needed because most packages are in conda-forge nowadays).
