### PR TITLE
fix: removed unnecessary dependencies

### DIFF
--- a/bio/bbtools/bbduk/environment.yaml
+++ b/bio/bbtools/bbduk/environment.yaml
@@ -5,4 +5,3 @@ channels:
 dependencies:
   - bbmap =39.01
   - snakemake-wrapper-utils =0.5.3
-  - python =3.11.3

--- a/bio/bbtools/loglog/environment.yaml
+++ b/bio/bbtools/loglog/environment.yaml
@@ -4,5 +4,4 @@ channels:
   - nodefaults
 dependencies:
   - bbmap =39.01
-  - python =3.11.3
   - snakemake-wrapper-utils =0.5.3

--- a/bio/bbtools/tadpole/environment.yaml
+++ b/bio/bbtools/tadpole/environment.yaml
@@ -4,5 +4,4 @@ channels:
   - nodefaults
 dependencies:
   - bbmap =39.01
-  - python =3.11.0
   - snakemake-wrapper-utils =0.5.2

--- a/bio/bbtools/tadpole/environment.yaml
+++ b/bio/bbtools/tadpole/environment.yaml
@@ -4,4 +4,4 @@ channels:
   - nodefaults
 dependencies:
   - bbmap =39.01
-  - snakemake-wrapper-utils =0.5.2
+  - snakemake-wrapper-utils =0.5.3


### PR DESCRIPTION
<!-- Ensure that the PR title follows conventional commit style (<type>: <description>)-->
<!-- Possible types are here: https://github.com/commitizen/conventional-commit-types/blob/master/index.json -->

### Description

<!-- Add a description of your PR here-->
Removed unnecessary `python` dependency that, sometimes (at least with the current version), could give errors:

```
Encountered problems while solving:
  - package python-3.11.3-h2755cc3_0_cpython requires libzlib >=1.2.13,<1.3.0a0, but none of the providers can be installed
```
### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] I confirm that:

For all wrappers added by this PR, 

* there is a test case which covers any introduced changes,
* `input:` and `output:` file paths in the resulting rule can be changed arbitrarily,
* either the wrapper can only use a single core, or the example rule contains a `threads: x` statement with `x` being a reasonable default,
* rule names in the test case are in [snake_case](https://en.wikipedia.org/wiki/Snake_case) and somehow tell what the rule is about or match the tools purpose or name (e.g., `map_reads` for a step that maps reads),
* all `environment.yaml` specifications follow [the respective best practices](https://stackoverflow.com/a/64594513/2352071),
* wherever possible, command line arguments are inferred and set automatically (e.g. based on file extensions in `input:` or `output:`),
* all fields of the example rules in the `Snakefile`s and their entries are explained via comments (`input:`/`output:`/`params:` etc.),
* `stderr` and/or `stdout` are logged correctly (`log:`), depending on the wrapped tool,
* temporary files are either written to a unique hidden folder in the working directory, or (better) stored where the Python function `tempfile.gettempdir()` points to (see [here](https://docs.python.org/3/library/tempfile.html#tempfile.gettempdir); this also means that using any Python `tempfile` default behavior works),
* the `meta.yaml` contains a link to the documentation of the respective tool or command,
* `Snakefile`s pass the linting (`snakemake --lint`),
* `Snakefile`s are formatted with [snakefmt](https://github.com/snakemake/snakefmt),
* Python wrapper scripts are formatted with [black](https://black.readthedocs.io).
* Conda environments use a minimal amount of channels, in recommended ordering. E.g. for bioconda, use (conda-forge, bioconda, nodefaults, as conda-forge should have highest priority and defaults channels are usually not needed because most packages are in conda-forge nowadays).
