### PR TITLE
feat: enable output of unmapped reads

### DIFF
--- a/bio/star/align/meta.yaml
+++ b/bio/star/align/meta.yaml
@@ -5,6 +5,7 @@ authors:
   - Johannes Köster
   - Tomás Di Domenico
   - Filipe G. Vieira
+  - Kashyap Chhatbar
 notes: |
   * The `extra` param allows for additional program arguments.
   * It is advisable to consider updating the limits setting before running STAR,

--- a/bio/star/align/test/Snakefile
+++ b/bio/star/align/test/Snakefile
@@ -12,8 +12,7 @@ rule star_pe_multi:
         aln="star/pe/{sample}/pe_aligned.sam",
         log="logs/pe/{sample}/Log.out",
         sj="star/pe/{sample}/SJ.out.tab",
-        unmapped1="star/pe/{sample}/unmapped.1.fastq.gz",
-        unmapped2="star/pe/{sample}/unmapped.2.fastq.gz",
+        unmapped=["star/pe/{sample}/unmapped.1.fastq.gz","star/pe/{sample}/unmapped.2.fastq.gz"],
     log:
         "logs/pe/{sample}.log",
     params:

--- a/bio/star/align/test/Snakefile
+++ b/bio/star/align/test/Snakefile
@@ -12,6 +12,8 @@ rule star_pe_multi:
         aln="star/pe/{sample}/pe_aligned.sam",
         log="logs/pe/{sample}/Log.out",
         sj="star/pe/{sample}/SJ.out.tab",
+        unmapped1="star/pe/{sample}/unmapped.1.fastq.gz",
+        unmapped2="star/pe/{sample}/unmapped.2.fastq.gz",
     log:
         "logs/pe/{sample}.log",
     params:
@@ -32,6 +34,7 @@ rule star_se:
         aln="star/se/{sample}/se_aligned.bam",
         log="logs/se/{sample}/Log.out",
         log_final="logs/se/{sample}/Log.final.out",
+        unmapped="star/se/{sample}/unmapped.fastq",
     log:
         "logs/se/{sample}.log",
     params:

--- a/bio/star/align/wrapper.py
+++ b/bio/star/align/wrapper.py
@@ -42,6 +42,12 @@ elif fq1[0].endswith(".bz2"):
 else:
     readcmd = ""
 
+if snakemake.output.get("unmapped1") and snakemake.output.get("unmapped2"):    
+    unmappedcmd = "--outReadsUnmapped Fastx"
+elif snakemake.output.get("unmapped"):
+    unmappedcmd = "--outReadsUnmapped Fastx"
+else:
+    unmappedcmd = ""
 
 index = snakemake.input.get("idx")
 if not index:
@@ -64,6 +70,7 @@ with tempfile.TemporaryDirectory() as tmpdir:
         " --readFilesIn {input_str}"
         " {readcmd}"
         " {extra}"
+        " {unmappedcmd}"
         " --outTmpDir {tmpdir}/STARtmp"
         " --outFileNamePrefix {tmpdir}/"
         " --outStd {stdout}"
@@ -83,3 +90,24 @@ with tempfile.TemporaryDirectory() as tmpdir:
         shell("cat {tmpdir}/Log.progress.out > {snakemake.output.log_progress:q}")
     if snakemake.output.get("log_final"):
         shell("cat {tmpdir}/Log.final.out > {snakemake.output.log_final:q}")
+    if snakemake.output.get("unmapped1"):
+        if snakemake.output.get("unmapped1").endswith("gz"):
+            shell(
+                "gzip -c {tmpdir}/Unmapped.out.mate1 > {snakemake.output.unmapped1:q}"
+            )
+        else:
+            shell("cat {tmpdir}/Unmapped.out.mate1 > {snakemake.output.unmapped1:q}")
+    if snakemake.output.get("unmapped2"):
+        if snakemake.output.get("unmapped2").endswith("gz"):
+            shell(
+                "gzip -c {tmpdir}/Unmapped.out.mate2 > {snakemake.output.unmapped2:q}"
+            )
+        else:
+            shell("cat {tmpdir}/Unmapped.out.mate2 > {snakemake.output.unmapped2:q}")
+    if snakemake.output.get("unmapped"):
+        if snakemake.output.get("unmapped").endswith("gz"):
+            shell(
+                "gzip -c {tmpdir}/Unmapped.out.mate1 > {snakemake.output.unmapped:q}"
+            )
+        else:
+            shell("cat {tmpdir}/Unmapped.out.mate1 > {snakemake.output.unmapped:q}")

--- a/bio/star/align/wrapper.py
+++ b/bio/star/align/wrapper.py
@@ -42,7 +42,7 @@ elif fq1[0].endswith(".bz2"):
 else:
     readcmd = ""
 
-out_unmapped = snakemake.output.get("unmapped", "")
+out_unmapped = snakemake.output.get("unmapped", None)
 if out_unmapped:
     out_unmapped = "--outReadsUnmapped Fastx"
 
@@ -95,6 +95,4 @@ with tempfile.TemporaryDirectory() as tmpdir:
 
         for i, out_unmapped in enumerate(unmapped, 1):
             cmd = "gzip -c" if out_unmapped.endswith("gz") else "cat"
-            shell(
-                "{cmd} {tmpdir}/Unmapped.out.mate{i} > {out_unmapped}"
-            )
+            shell("{cmd} {tmpdir}/Unmapped.out.mate{i} > {out_unmapped}")

--- a/bio/star/align/wrapper.py
+++ b/bio/star/align/wrapper.py
@@ -42,7 +42,7 @@ elif fq1[0].endswith(".bz2"):
 else:
     readcmd = ""
 
-if snakemake.output.get("unmapped1") and snakemake.output.get("unmapped2"):    
+if snakemake.output.get("unmapped1") and snakemake.output.get("unmapped2"):
     unmappedcmd = "--outReadsUnmapped Fastx"
 elif snakemake.output.get("unmapped"):
     unmappedcmd = "--outReadsUnmapped Fastx"
@@ -106,8 +106,6 @@ with tempfile.TemporaryDirectory() as tmpdir:
             shell("cat {tmpdir}/Unmapped.out.mate2 > {snakemake.output.unmapped2:q}")
     if snakemake.output.get("unmapped"):
         if snakemake.output.get("unmapped").endswith("gz"):
-            shell(
-                "gzip -c {tmpdir}/Unmapped.out.mate1 > {snakemake.output.unmapped:q}"
-            )
+            shell("gzip -c {tmpdir}/Unmapped.out.mate1 > {snakemake.output.unmapped:q}")
         else:
             shell("cat {tmpdir}/Unmapped.out.mate1 > {snakemake.output.unmapped:q}")

--- a/bio/star/align/wrapper.py
+++ b/bio/star/align/wrapper.py
@@ -93,7 +93,7 @@ with tempfile.TemporaryDirectory() as tmpdir:
         if not fq2:
             unmapped = [unmapped]
 
-    for i, out_unmapped in unmapped.items():
+    for i, out_unmapped in enumerate(unmapped):
         if out_unmapped.endswith("gz"):
             shell(
                 "gzip -c {tmpdir}/Unmapped.out.mate{i+1} > {snakemake.output.unmapped[i]:q}"

--- a/bio/star/align/wrapper.py
+++ b/bio/star/align/wrapper.py
@@ -93,12 +93,8 @@ with tempfile.TemporaryDirectory() as tmpdir:
         if not fq2:
             unmapped = [unmapped]
 
-    for i, out_unmapped in enumerate(unmapped):
-        if out_unmapped.endswith("gz"):
-            shell(
-                "gzip -c {tmpdir}/Unmapped.out.mate{i+1} > {snakemake.output.unmapped[i]:q}"
-            )
-        else:
-            shell(
-                "cat {tmpdir}/Unmapped.out.mate{i+1} > {snakemake.output.unmapped[i]:q}"
-            )
+    for i, out_unmapped in enumerate(unmapped, 1):
+        cmd = "gzip -c" if out_unmapped.endswith("gz") else "cat":
+        shell(
+            "{cmd} {tmpdir}/Unmapped.out.mate{i} > {snakemake.output.unmapped[i-1]:q}"
+        )

--- a/bio/star/align/wrapper.py
+++ b/bio/star/align/wrapper.py
@@ -96,5 +96,5 @@ with tempfile.TemporaryDirectory() as tmpdir:
         for i, out_unmapped in enumerate(unmapped, 1):
             cmd = "gzip -c" if out_unmapped.endswith("gz") else "cat"
             shell(
-                "{cmd} {tmpdir}/Unmapped.out.mate{i} > {snakemake.output.unmapped[i-1]:q}"
+                "{cmd} {tmpdir}/Unmapped.out.mate{i} > {out_unmapped}"
             )

--- a/bio/star/align/wrapper.py
+++ b/bio/star/align/wrapper.py
@@ -99,4 +99,6 @@ with tempfile.TemporaryDirectory() as tmpdir:
                 "gzip -c {tmpdir}/Unmapped.out.mate{i+1} > {snakemake.output.unmapped[i]:q}"
             )
         else:
-            shell("cat {tmpdir}/Unmapped.out.mate{i+1} > {snakemake.output.unmapped[i]:q}")
+            shell(
+                "cat {tmpdir}/Unmapped.out.mate{i+1} > {snakemake.output.unmapped[i]:q}"
+            )

--- a/bio/star/align/wrapper.py
+++ b/bio/star/align/wrapper.py
@@ -93,8 +93,8 @@ with tempfile.TemporaryDirectory() as tmpdir:
         if not fq2:
             unmapped = [unmapped]
 
-    for i, out_unmapped in enumerate(unmapped, 1):
-        cmd = "gzip -c" if out_unmapped.endswith("gz") else "cat"
-        shell(
-            "{cmd} {tmpdir}/Unmapped.out.mate{i} > {snakemake.output.unmapped[i-1]:q}"
-        )
+        for i, out_unmapped in enumerate(unmapped, 1):
+            cmd = "gzip -c" if out_unmapped.endswith("gz") else "cat"
+            shell(
+                "{cmd} {tmpdir}/Unmapped.out.mate{i} > {snakemake.output.unmapped[i-1]:q}"
+            )

--- a/bio/star/align/wrapper.py
+++ b/bio/star/align/wrapper.py
@@ -94,7 +94,7 @@ with tempfile.TemporaryDirectory() as tmpdir:
             unmapped = [unmapped]
 
     for i, out_unmapped in enumerate(unmapped, 1):
-        cmd = "gzip -c" if out_unmapped.endswith("gz") else "cat":
+        cmd = "gzip -c" if out_unmapped.endswith("gz") else "cat"
         shell(
             "{cmd} {tmpdir}/Unmapped.out.mate{i} > {snakemake.output.unmapped[i-1]:q}"
         )

--- a/bio/star/align/wrapper.py
+++ b/bio/star/align/wrapper.py
@@ -42,7 +42,7 @@ elif fq1[0].endswith(".bz2"):
 else:
     readcmd = ""
 
-out_unmapped = snakemake.output.get("unmapped", None)
+out_unmapped = snakemake.output.get("unmapped", "")
 if out_unmapped:
     out_unmapped = "--outReadsUnmapped Fastx"
 


### PR DESCRIPTION
<!-- Ensure that the PR title follows conventional commit style (<type>: <description>)-->
<!-- Possible types are here: https://github.com/commitizen/conventional-commit-types/blob/master/index.json -->

### Description

Ability to save unmapped reads in fastq or fastq.gz formats using the `--outReadsUnmapped Fastx` option in STAR

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] I confirm that:

For all wrappers added by this PR, 

* there is a test case which covers any introduced changes,
* `input:` and `output:` file paths in the resulting rule can be changed arbitrarily,
* either the wrapper can only use a single core, or the example rule contains a `threads: x` statement with `x` being a reasonable default,
* rule names in the test case are in [snake_case](https://en.wikipedia.org/wiki/Snake_case) and somehow tell what the rule is about or match the tools purpose or name (e.g., `map_reads` for a step that maps reads),
* all `environment.yaml` specifications follow [the respective best practices](https://stackoverflow.com/a/64594513/2352071),
* wherever possible, command line arguments are inferred and set automatically (e.g. based on file extensions in `input:` or `output:`),
* all fields of the example rules in the `Snakefile`s and their entries are explained via comments (`input:`/`output:`/`params:` etc.),
* `stderr` and/or `stdout` are logged correctly (`log:`), depending on the wrapped tool,
* temporary files are either written to a unique hidden folder in the working directory, or (better) stored where the Python function `tempfile.gettempdir()` points to (see [here](https://docs.python.org/3/library/tempfile.html#tempfile.gettempdir); this also means that using any Python `tempfile` default behavior works),
* the `meta.yaml` contains a link to the documentation of the respective tool or command,
* `Snakefile`s pass the linting (`snakemake --lint`),
* `Snakefile`s are formatted with [snakefmt](https://github.com/snakemake/snakefmt),
* Python wrapper scripts are formatted with [black](https://black.readthedocs.io).
* Conda environments use a minimal amount of channels, in recommended ordering. E.g. for bioconda, use (conda-forge, bioconda, nodefaults, as conda-forge should have highest priority and defaults channels are usually not needed because most packages are in conda-forge nowadays).
