### PR TITLE
feat: new inphared-db wrapper

### DIFF
--- a/bio/reference/inphared-db/environment.yaml
+++ b/bio/reference/inphared-db/environment.yaml
@@ -1,0 +1,5 @@
+channels:
+  - conda-forge
+  - nodefaults
+dependencies:
+  - curl

--- a/bio/reference/inphared-db/meta.yaml
+++ b/bio/reference/inphared-db/meta.yaml
@@ -1,0 +1,4 @@
+name: inphared-db
+description: Download sequence file from the Inphared database (https://github.com/RyanCook94/inphared/blob/main/README.md), and store them in a single .fasta file. Please check the current database available at the above link and adjust the config file. 
+authors:
+  - Noriko A. Cassman

--- a/bio/reference/inphared-db/old_wrapper.py
+++ b/bio/reference/inphared-db/old_wrapper.py
@@ -1,0 +1,80 @@
+__author__ = "Johannes Köster"
+__copyright__ = "Copyright 2019, Johannes Köster"
+__email__ = "johannes.koester@uni-due.de"
+__license__ = "MIT"
+
+import subprocess as sp
+import sys
+from itertools import product
+from snakemake.shell import shell
+
+species = snakemake.params.species.lower()
+release = int(snakemake.params.release)
+build = snakemake.params.build
+
+branch = ""
+if release >= 81 and build == "GRCh37":
+    # use the special grch37 branch for new releases
+    branch = "grch37/"
+elif snakemake.params.get("branch"):
+    branch = snakemake.params.branch + "/"
+
+log = snakemake.log_fmt_shell(stdout=False, stderr=True)
+
+spec = ("{build}" if int(release) > 75 else "{build}.{release}").format(
+    build=build, release=release
+)
+
+suffixes = ""
+datatype = snakemake.params.get("datatype", "")
+chromosome = snakemake.params.get("chromosome", "")
+if datatype == "dna":
+    if chromosome:
+        suffixes = ["dna.chromosome.{}.fa.gz".format(chromosome)]
+    else:
+        suffixes = ["dna.primary_assembly.fa.gz", "dna.toplevel.fa.gz"]
+elif datatype == "cdna":
+    suffixes = ["cdna.all.fa.gz"]
+elif datatype == "cds":
+    suffixes = ["cds.all.fa.gz"]
+elif datatype == "ncrna":
+    suffixes = ["ncrna.fa.gz"]
+elif datatype == "pep":
+    suffixes = ["pep.all.fa.gz"]
+else:
+    raise ValueError("invalid datatype, must be one of dna, cdna, cds, ncrna, pep")
+
+if chromosome:
+    if not datatype == "dna":
+        raise ValueError(
+            "invalid datatype, to select a single chromosome the datatype must be dna"
+        )
+
+spec = spec.format(build=build, release=release)
+url_prefix = f"ftp://ftp.ensembl.org/pub/{branch}release-{release}/fasta/{species}/{datatype}/{species.capitalize()}.{spec}"
+
+success = False
+for suffix in suffixes:
+    url = f"{url_prefix}.{suffix}"
+
+    try:
+        shell("curl -sSf {url} > /dev/null 2> /dev/null")
+    except sp.CalledProcessError:
+        continue
+
+    shell("(curl -L {url} | gzip -d > {snakemake.output[0]}) {log}")
+    success = True
+    break
+
+if not success:
+    if len(suffixes) > 1:
+        url = f"{url_prefix}.[{'|'.join(suffixes)}]"
+    else:
+        url = f"{url_prefix}.{suffixes[0]}"
+    print(
+        f"Unable to download requested sequence data from Ensembl ({url}). "
+        "Please check whether above URL is currently available (might be a temporal server issue). "
+        "Apart from that, did you check that this combination of species, build, and release is actually provided?",
+        file=sys.stderr,
+    )
+    exit(1)

--- a/bio/reference/inphared-db/test/Snakefile
+++ b/bio/reference/inphared-db/test/Snakefile
@@ -1,0 +1,12 @@
+configfile: "config.yaml"
+
+rule get_inphareddb:
+    output:
+        expand("{date}{suffix}", date=config["date"], suffix=config["suffix"])    
+    params:
+        prefix = config["prefix"], 
+        date = config["date"],
+        suffix = config["suffix"]
+    wrapper:
+        "master/bio/reference/inphared-db"
+

--- a/bio/reference/inphared-db/test/config.yaml
+++ b/bio/reference/inphared-db/test/config.yaml
@@ -1,0 +1,9 @@
+date:
+    "2Jul2023"
+
+suffix:
+    "_refseq_genomes.fa"
+    #"_genomes_excluding_refseq.fa"
+
+prefix:
+    "https://millardlab-inphared.s3.climb.ac.uk/"

--- a/bio/reference/inphared-db/test/old_release.smk
+++ b/bio/reference/inphared-db/test/old_release.smk
@@ -1,0 +1,29 @@
+rule get_genome:
+    output:
+        "refs/genome.fasta",
+    params:
+        species="saccharomyces_cerevisiae",
+        datatype="dna",
+        build="R64-1-1",
+        release="75",
+    log:
+        "logs/get_genome.log",
+    cache: "omit-software"  # save space and time with between workflow caching (see docs)
+    wrapper:
+        "master/bio/reference/ensembl-sequence"
+
+
+rule get_chromosome:
+    output:
+        "refs/old_release.chr1.fasta",
+    params:
+        species="saccharomyces_cerevisiae",
+        datatype="dna",
+        build="R64-1-1",
+        release="75",
+        chromosome="I",
+    log:
+        "logs/get_genome.log",
+    cache: "omit-software"  # save space and time with between workflow caching (see docs)
+    wrapper:
+        "master/bio/reference/ensembl-sequence"

--- a/bio/reference/inphared-db/test/old_snakefile.smk
+++ b/bio/reference/inphared-db/test/old_snakefile.smk
@@ -1,0 +1,30 @@
+rule get_genome:
+    output:
+        "refs/genome.fasta",
+    params:
+        species="saccharomyces_cerevisiae",
+        datatype="dna",
+        build="R64-1-1",
+        release="98",
+    log:
+        "logs/get_genome.log",
+    cache: "mit-software"  # save space and time with between workflow caching (see docs)
+    wrapper:
+        "master/bio/reference/ensembl-sequence"
+
+
+rule get_chromosome:
+    output:
+        "refs/chr1.fasta",
+    params:
+        species="saccharomyces_cerevisiae",
+        datatype="dna",
+        build="R64-1-1",
+        release="101",
+        chromosome="I",  # optional: restrict to chromosome
+        # branch="plants",  # optional: specify branch
+    log:
+        "logs/get_genome.log",
+    cache: "omit-software"  # save space and time with between workflow caching (see docs)
+    wrapper:
+        "master/bio/reference/ensembl-sequence"

--- a/bio/reference/inphared-db/wrapper.py
+++ b/bio/reference/inphared-db/wrapper.py
@@ -1,0 +1,9 @@
+__author__ = "Noriko A. Cassman"
+__copyright__ = "Copyright 2023, Noriko A. Cassman"
+__email__ = "noriko.cassman@gmail.com"
+__license__ = "MIT"
+
+from snakemake.shell import shell
+
+    shell:
+        "curl {params.prefix}{params.date}{params.suffix} -o {params.date}{params.suffix}"


### PR DESCRIPTION
<!-- Ensure that the PR title follows conventional commit style (<type>: <description>)-->
<!-- Possible types are here: https://github.com/commitizen/conventional-commit-types/blob/master/index.json -->

### Description

<!-- Add a description of your PR here-->
Adding a new wrapper to download the current inphared database. 

### QC
<!-- Make sure that you can tick the boxes below. -->

* [ ] I confirm that:

For all wrappers added by this PR, 

* there is a test case which covers any introduced changes,
* `input:` and `output:` file paths in the resulting rule can be changed arbitrarily,
* either the wrapper can only use a single core, or the example rule contains a `threads: x` statement with `x` being a reasonable default,
* rule names in the test case are in [snake_case](https://en.wikipedia.org/wiki/Snake_case) and somehow tell what the rule is about or match the tools purpose or name (e.g., `map_reads` for a step that maps reads),
* all `environment.yaml` specifications follow [the respective best practices](https://stackoverflow.com/a/64594513/2352071),
* wherever possible, command line arguments are inferred and set automatically (e.g. based on file extensions in `input:` or `output:`),
* all fields of the example rules in the `Snakefile`s and their entries are explained via comments (`input:`/`output:`/`params:` etc.),
* `stderr` and/or `stdout` are logged correctly (`log:`), depending on the wrapped tool,
* temporary files are either written to a unique hidden folder in the working directory, or (better) stored where the Python function `tempfile.gettempdir()` points to (see [here](https://docs.python.org/3/library/tempfile.html#tempfile.gettempdir); this also means that using any Python `tempfile` default behavior works),
* the `meta.yaml` contains a link to the documentation of the respective tool or command,
* `Snakefile`s pass the linting (`snakemake --lint`),
* `Snakefile`s are formatted with [snakefmt](https://github.com/snakemake/snakefmt),
* Python wrapper scripts are formatted with [black](https://black.readthedocs.io).
* Conda environments use a minimal amount of channels, in recommended ordering. E.g. for bioconda, use (conda-forge, bioconda, nodefaults, as conda-forge should have highest priority and defaults channels are usually not needed because most packages are in conda-forge nowadays).
