### PR TITLE
fix: freebayes wrapper

### DIFF
--- a/bio/freebayes/environment.yaml
+++ b/bio/freebayes/environment.yaml
@@ -6,7 +6,7 @@ dependencies:
   - freebayes =1.3.6
   - bcftools =1.15 # pinned to prevent conflicts with vcflib 1.0.3
   - vcflib =1.0.3 # pinned because of bug in v1.0.9 (https://github.com/vcflib/vcflib/issues/389)
-  - parallel =20230522
+  - parallel =20230722
   - bedtools =2.31.0
   - sed =4.8
-  - snakemake-wrapper-utils =0.6.1
+  - snakemake-wrapper-utils =0.6.2

--- a/bio/freebayes/environment.yaml
+++ b/bio/freebayes/environment.yaml
@@ -4,7 +4,7 @@ channels:
   - nodefaults
 dependencies:
   - freebayes =1.3.6
-  - bcftools =1.17
+  - bcftools =1.15
   - parallel =20230522
   - bedtools =2.31.0
   - sed =4.8

--- a/bio/freebayes/environment.yaml
+++ b/bio/freebayes/environment.yaml
@@ -4,7 +4,8 @@ channels:
   - nodefaults
 dependencies:
   - freebayes =1.3.6
-  - bcftools =1.15
+  - bcftools =1.15 # pinned to prevent conflicts with vcflib 1.0.3
+  - vcflib =1.0.3 # pinned because of bug in v1.0.9 (https://github.com/vcflib/vcflib/issues/389)
   - parallel =20230522
   - bedtools =2.31.0
   - sed =4.8


### PR DESCRIPTION
<!-- Ensure that the PR title follows conventional commit style (<type>: <description>)-->
<!-- Possible types are here: https://github.com/commitizen/conventional-commit-types/blob/master/index.json -->

### Description

When running freebayes with multiprocessing the execution fails due to an error in `vcflib=1.0.9`(see https://github.com/vcflib/vcflib/issues/389). As a temporary fix vcflib has been added as dependency and pinned to v1.0.3.
To prevent any solving conflicts bcftools needs to be pinned to 1.15.

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] I confirm that:

For all wrappers added by this PR, 

* there is a test case which covers any introduced changes,
* `input:` and `output:` file paths in the resulting rule can be changed arbitrarily,
* either the wrapper can only use a single core, or the example rule contains a `threads: x` statement with `x` being a reasonable default,
* rule names in the test case are in [snake_case](https://en.wikipedia.org/wiki/Snake_case) and somehow tell what the rule is about or match the tools purpose or name (e.g., `map_reads` for a step that maps reads),
* all `environment.yaml` specifications follow [the respective best practices](https://stackoverflow.com/a/64594513/2352071),
* wherever possible, command line arguments are inferred and set automatically (e.g. based on file extensions in `input:` or `output:`),
* all fields of the example rules in the `Snakefile`s and their entries are explained via comments (`input:`/`output:`/`params:` etc.),
* `stderr` and/or `stdout` are logged correctly (`log:`), depending on the wrapped tool,
* temporary files are either written to a unique hidden folder in the working directory, or (better) stored where the Python function `tempfile.gettempdir()` points to (see [here](https://docs.python.org/3/library/tempfile.html#tempfile.gettempdir); this also means that using any Python `tempfile` default behavior works),
* the `meta.yaml` contains a link to the documentation of the respective tool or command,
* `Snakefile`s pass the linting (`snakemake --lint`),
* `Snakefile`s are formatted with [snakefmt](https://github.com/snakemake/snakefmt),
* Python wrapper scripts are formatted with [black](https://black.readthedocs.io).
* Conda environments use a minimal amount of channels, in recommended ordering. E.g. for bioconda, use (conda-forge, bioconda, nodefaults, as conda-forge should have highest priority and defaults channels are usually not needed because most packages are in conda-forge nowadays).
