### PR TITLE
fix: fgbio annotatebamwithumis allow multiple umi fastq files

### DIFF
--- a/bio/fgbio/annotatebamwithumis/test/Snakefile
+++ b/bio/fgbio/annotatebamwithumis/test/Snakefile
@@ -21,8 +21,8 @@ rule annotate_bam_multiple_fastqs:
     input:
         bam="mapped/{sample}.bam",
         umi=[
-            "umi/a.fastq",
-            "umi/a.fastq",
+            "umi/{sample}.fastq",
+            "umi/{sample}.fastq",
         ],
     output:
         "mapped/{sample}-{sample}.annotated.bam",

--- a/bio/fgbio/annotatebamwithumis/test/Snakefile
+++ b/bio/fgbio/annotatebamwithumis/test/Snakefile
@@ -4,16 +4,18 @@ rule annotate_bam_single_fastq:
         umi="umi/{sample}.fastq",
     output:
         "mapped/{sample}.annotated.bam",
-    params: ""
+    params:
+        "",
     resources:
         # suggestion assuming unsorted input, so that memory should
         # be proportional to input size:
         # https://fulcrumgenomics.github.io/fgbio/tools/latest/AnnotateBamWithUmis.html
-        mem_mb=lambda wildcards, input: max([input.size_mb * 1.3, 200])
+        mem_mb=lambda wildcards, input: max([input.size_mb * 1.3, 200]),
     log:
         "logs/fgbio/annotate_bam/{sample}.log",
     wrapper:
         "master/bio/fgbio/annotatebamwithumis"
+
 
 rule annotate_bam_multiple_fastqs:
     input:
@@ -24,12 +26,13 @@ rule annotate_bam_multiple_fastqs:
         ],
     output:
         "mapped/{sample}.annotated.bam",
-    params: ""
+    params:
+        "",
     resources:
         # suggestion assuming unsorted input, so that memory should
         # be proportional to input size:
         # https://fulcrumgenomics.github.io/fgbio/tools/latest/AnnotateBamWithUmis.html
-        mem_mb=lambda wildcards, input: max([input.size_mb * 1.3, 200])
+        mem_mb=lambda wildcards, input: max([input.size_mb * 1.3, 200]),
     log:
         "logs/fgbio/annotate_bam/{sample}.log",
     wrapper:

--- a/bio/fgbio/annotatebamwithumis/test/Snakefile
+++ b/bio/fgbio/annotatebamwithumis/test/Snakefile
@@ -25,7 +25,7 @@ rule annotate_bam_multiple_fastqs:
             "umi/a.fastq",
         ],
     output:
-        "mapped/{sample}.annotated.bam",
+        "mapped/{sample}-{sample}.annotated.bam",
     params:
         "",
     resources:
@@ -34,6 +34,6 @@ rule annotate_bam_multiple_fastqs:
         # https://fulcrumgenomics.github.io/fgbio/tools/latest/AnnotateBamWithUmis.html
         mem_mb=lambda wildcards, input: max([input.size_mb * 1.3, 200]),
     log:
-        "logs/fgbio/annotate_bam/{sample}.log",
+        "logs/fgbio/annotate_bam/{sample}-{sample}.log",
     wrapper:
         "master/bio/fgbio/annotatebamwithumis"

--- a/bio/fgbio/annotatebamwithumis/test/Snakefile
+++ b/bio/fgbio/annotatebamwithumis/test/Snakefile
@@ -1,7 +1,27 @@
-rule AnnotateBam:
+rule annotate_bam_single_fastq:
     input:
         bam="mapped/{sample}.bam",
         umi="umi/{sample}.fastq",
+    output:
+        "mapped/{sample}.annotated.bam",
+    params: ""
+    resources:
+        # suggestion assuming unsorted input, so that memory should
+        # be proportional to input size:
+        # https://fulcrumgenomics.github.io/fgbio/tools/latest/AnnotateBamWithUmis.html
+        mem_mb=lambda wildcards, input: max([input.size_mb * 1.3, 200])
+    log:
+        "logs/fgbio/annotate_bam/{sample}.log",
+    wrapper:
+        "master/bio/fgbio/annotatebamwithumis"
+
+rule annotate_bam_multiple_fastqs:
+    input:
+        bam="mapped/{sample}.bam",
+        umi=[
+            "umi/a.fastq",
+            "umi/a.fastq",
+        ],
     output:
         "mapped/{sample}.annotated.bam",
     params: ""

--- a/bio/fgbio/annotatebamwithumis/wrapper.py
+++ b/bio/fgbio/annotatebamwithumis/wrapper.py
@@ -5,6 +5,7 @@ __license__ = "MIT"
 
 
 from snakemake.shell import shell
+from snakemake.io import Namedlist
 from snakemake_wrapper_utils.java import get_java_opts
 
 log = snakemake.log_fmt_shell(stdout=False, stderr=True)
@@ -22,9 +23,9 @@ umi_input = snakemake.input.umi
 
 if umi_input is None:
     raise ValueError("Missing input file with UMIs")
-elif not isinstance(umi_input, str) or isinstance(umi_input, list):
+elif not (isinstance(umi_input, str) or isinstance(umi_input, Namedlist)):
     raise ValueError(
-        "Input UMIs-file should be a string or a list of strings: "
+        "Input UMIs-file should be a string or a snakemake io list: "
         + str(umi_input)
         + "!"
     )

--- a/bio/fgbio/annotatebamwithumis/wrapper.py
+++ b/bio/fgbio/annotatebamwithumis/wrapper.py
@@ -23,7 +23,11 @@ umi_input = snakemake.input.umi
 if umi_input is None:
     raise ValueError("Missing input file with UMIs")
 elif not isinstance(umi_input, str) or isinstance(umi_input, list):
-    raise ValueError("Input UMIs-file should be a string or a list of strings: " + str(umi_input) + "!")
+    raise ValueError(
+        "Input UMIs-file should be a string or a list of strings: "
+        + str(umi_input)
+        + "!"
+    )
 
 if not len(snakemake.output) == 1:
     raise ValueError("Only one output value expected: " + str(snakemake.output) + "!")

--- a/bio/fgbio/annotatebamwithumis/wrapper.py
+++ b/bio/fgbio/annotatebamwithumis/wrapper.py
@@ -22,8 +22,8 @@ umi_input = snakemake.input.umi
 
 if umi_input is None:
     raise ValueError("Missing input file with UMIs")
-elif not isinstance(umi_input, str):
-    raise ValueError("Input UMIs-file should be a string: " + str(umi_input) + "!")
+elif not isinstance(umi_input, str) or isinstance(umi_input, list):
+    raise ValueError("Input UMIs-file should be a string or a list of strings: " + str(umi_input) + "!")
 
 if not len(snakemake.output) == 1:
     raise ValueError("Only one output value expected: " + str(snakemake.output) + "!")

--- a/test.py
+++ b/test.py
@@ -170,9 +170,9 @@ def test_nonpareil_plot():
             "--use-conda",
             "-F",
             "results/a.pdf",
-# Test disabled due to bug in nonpareil (#62)
-#            "results/a.nomodel.pdf",
-        ]
+            # Test disabled due to bug in nonpareil (#62)
+            #            "results/a.nomodel.pdf",
+        ],
     )
 
 
@@ -1080,10 +1080,7 @@ def test_deseq2_deseqdataset():
 
 @skip_if_not_modified
 def test_deseq2_wald():
-    run(
-        "bio/deseq2/wald",
-        ["snakemake", "--cores", "1", "--use-conda", "dge.tsv"]
-    )
+    run("bio/deseq2/wald", ["snakemake", "--cores", "1", "--use-conda", "dge.tsv"])
 
 
 @skip_if_not_modified
@@ -2653,7 +2650,14 @@ def test_fasttree():
 def test_fgbio_annotate():
     run(
         "bio/fgbio/annotatebamwithumis",
-        ["snakemake", "--cores", "1", "mapped/a.annotated.bam", "--use-conda", "-F"],
+        [
+            "snakemake",
+            "--cores",
+            "1",
+            ["mapped/a.annotated.bam", "mapped/a-a.annotated.bam"],
+            "--use-conda",
+            "-F",
+        ],
     )
 
 
@@ -5688,7 +5692,6 @@ def test_calc_consensus_reads():
     )
 
 
-
 @skip_if_not_modified
 def test_bowtie2_sambamba_meta():
     run(
@@ -5699,8 +5702,8 @@ def test_bowtie2_sambamba_meta():
             "2",
             "--use-conda",
             "-F",
-            "mapped/Sample1.rmdup.bam.bai"
-        ]
+            "mapped/Sample1.rmdup.bam.bai",
+        ],
     )
 
 
@@ -5725,6 +5728,7 @@ def test_bazam_separated():
             "results/reads/a.r1.fastq.gz",
         ],
     )
+
 
 @skip_if_not_modified
 def test_ragtag_correction():
@@ -5784,6 +5788,7 @@ def test_ragtag_merge():
             "-F",
         ],
     )
+
 
 @skip_if_not_modified
 def test_barrnap():

--- a/test.py
+++ b/test.py
@@ -2654,7 +2654,7 @@ def test_fgbio_annotate():
             "snakemake",
             "--cores",
             "1",
-            ["mapped/a.annotated.bam", "mapped/a-a.annotated.bam"],
+            "mapped/a.annotated.bam mapped/a-a.annotated.bam",
             "--use-conda",
             "-F",
         ],

--- a/test.py
+++ b/test.py
@@ -2654,7 +2654,22 @@ def test_fgbio_annotate():
             "snakemake",
             "--cores",
             "1",
-            "mapped/a.annotated.bam mapped/a-a.annotated.bam",
+            "mapped/a.annotated.bam",
+            "--use-conda",
+            "-F",
+        ],
+    )
+
+
+@skip_if_not_modified
+def test_fgbio_annotate_two_umi_fastqs():
+    run(
+        "bio/fgbio/annotatebamwithumis",
+        [
+            "snakemake",
+            "--cores",
+            "1",
+            "mapped/a-a.annotated.bam",
             "--use-conda",
             "-F",
         ],


### PR DESCRIPTION
<!-- Ensure that the PR title follows conventional commit style (<type>: <description>)-->
<!-- Possible types are here: https://github.com/commitizen/conventional-commit-types/blob/master/index.json -->

### Description

Currently, the wrapper tests that `input: umi:` is exactly one file specified as string, but [`fgbio AnnotateBamWithUmis` allows for multiple fastqs specified](https://fulcrumgenomics.github.io/fgbio/tools/latest/AnnotateBamWithUmis.html), which is needed when UMIs are present in multiple reads of the same fragment. Thus, this PR relaxes the testing and tests the scenario with another example rule specifying two fastqs.

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] I confirm that:

For all wrappers added by this PR, 

* there is a test case which covers any introduced changes,
* `input:` and `output:` file paths in the resulting rule can be changed arbitrarily,
* either the wrapper can only use a single core, or the example rule contains a `threads: x` statement with `x` being a reasonable default,
* rule names in the test case are in [snake_case](https://en.wikipedia.org/wiki/Snake_case) and somehow tell what the rule is about or match the tools purpose or name (e.g., `map_reads` for a step that maps reads),
* all `environment.yaml` specifications follow [the respective best practices](https://stackoverflow.com/a/64594513/2352071),
* wherever possible, command line arguments are inferred and set automatically (e.g. based on file extensions in `input:` or `output:`),
* all fields of the example rules in the `Snakefile`s and their entries are explained via comments (`input:`/`output:`/`params:` etc.),
* `stderr` and/or `stdout` are logged correctly (`log:`), depending on the wrapped tool,
* temporary files are either written to a unique hidden folder in the working directory, or (better) stored where the Python function `tempfile.gettempdir()` points to (see [here](https://docs.python.org/3/library/tempfile.html#tempfile.gettempdir); this also means that using any Python `tempfile` default behavior works),
* the `meta.yaml` contains a link to the documentation of the respective tool or command,
* `Snakefile`s pass the linting (`snakemake --lint`),
* `Snakefile`s are formatted with [snakefmt](https://github.com/snakemake/snakefmt),
* Python wrapper scripts are formatted with [black](https://black.readthedocs.io).
* Conda environments use a minimal amount of channels, in recommended ordering. E.g. for bioconda, use (conda-forge, bioconda, nodefaults, as conda-forge should have highest priority and defaults channels are usually not needed because most packages are in conda-forge nowadays).
