### PR TITLE
fix: for vsearch, fixed bug with bz2 output and added general log

### DIFF
--- a/bio/vsearch/environment.linux-64.pin.txt
+++ b/bio/vsearch/environment.linux-64.pin.txt
@@ -8,7 +8,8 @@ https://conda.anaconda.org/conda-forge/linux-64/libgomp-13.2.0-h807b86a_3.conda#
 https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-2_gnu.tar.bz2#73aaf86a425cc6e73fcf236a5a46396d
 https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-13.2.0-h807b86a_3.conda#23fdf1fef05baeb7eadc2aed5fb0011f
 https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hd590300_5.conda#69b8b6202a07720f448be700e300ccf4
-https://conda.anaconda.org/conda-forge/linux-64/gzip-1.13-hd590300_0.conda#cb8143aa2e59e9684c41dfdf74af38ac
 https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.2.13-hd590300_5.conda#f36c115f1ee199da648e0597ec2047ad
+https://conda.anaconda.org/conda-forge/linux-64/pbzip2-1.1.13-h1fcc475_2.conda#e1bf3c0868789f3ddf5d1aeb47bc60a6
+https://conda.anaconda.org/conda-forge/linux-64/pigz-2.8-h2797004_0.conda#1832561770273ca7cf52b989dd83e6c3
 https://conda.anaconda.org/conda-forge/linux-64/zlib-1.2.13-hd590300_5.conda#68c34ec6149623be41a1933ab996a209
 https://conda.anaconda.org/bioconda/linux-64/vsearch-2.26.1-h6a68c12_0.tar.bz2#c68cb1de8ca3df2c8fa9c3234d775d0c

--- a/bio/vsearch/environment.yaml
+++ b/bio/vsearch/environment.yaml
@@ -4,5 +4,5 @@ channels:
   - nodefaults
 dependencies:
   - vsearch =2.26.1
-  - gzip
-  - bzip2
+  - pigz
+  - pbzip2

--- a/bio/vsearch/meta.yaml
+++ b/bio/vsearch/meta.yaml
@@ -12,3 +12,4 @@ params:
   - extra: additional program arguments
 notes: |
   * Keys for `input` and `output` files need to match `vsearch` arguments, (e.g. input) `uchime_denovo`, `cluster_fast`, `fastx_uniques`, `maskfasta`, `fastq_convert`, `fastq_mergepairs`, or (e.g. output) `chimeras`, `fastaout`, `fastqout`, `output`.
+  * An extra `log` file (named `verbose`) can be specified that will be passed to `vsearch` option `--log`.

--- a/bio/vsearch/meta.yaml
+++ b/bio/vsearch/meta.yaml
@@ -12,4 +12,4 @@ params:
   - extra: additional program arguments
 notes: |
   * Keys for `input` and `output` files need to match `vsearch` arguments, (e.g. input) `uchime_denovo`, `cluster_fast`, `fastx_uniques`, `maskfasta`, `fastq_convert`, `fastq_mergepairs`, or (e.g. output) `chimeras`, `fastaout`, `fastqout`, `output`.
-  * An extra `log` file (named `verbose`) can be specified that will be passed to `vsearch` option `--log`.
+  * An extra `log` file (named `vsearch`) can be specified that will be passed to `vsearch` option `--log`.

--- a/bio/vsearch/test/Snakefile
+++ b/bio/vsearch/test/Snakefile
@@ -3,6 +3,7 @@ rule vsearch_cluster_fast:
         cluster_fast="reads/{sample}.fasta",
     output:
         profile="out/cluster_fast/{sample}.profile",
+        log="out/cluster_fast/{sample}.log",
     log:
         "logs/vsearch/cluster_fast/{sample}.log",
     params:
@@ -17,6 +18,7 @@ rule vsearch_maskfasta:
         maskfasta="reads/{sample}.fasta",
     output:
         output="out/maskfasta/{sample}.fasta",
+        log="out/maskfasta/{sample}.log",
     log:
         "logs/vsearch/maskfasta/{sample}.log",
     params:
@@ -31,6 +33,7 @@ rule vsearch_fastx_uniques:
         fastx_uniques="reads/{sample}.fastq",
     output:
         fastqout="out/fastx_uniques/{sample}.fastq",
+        log="out/fastx_uniques/{sample}.log",
     log:
         "logs/vsearch/fastx_uniques/{sample}.log",
     params:
@@ -45,6 +48,7 @@ rule vsearch_fastx_uniques_gzip:
         fastx_uniques="reads/{sample}.fastq",
     output:
         fastqout="out/fastx_uniques/{sample}.fastq.gz",
+        log="out/fastx_uniques/{sample}.log",
     log:
         "logs/vsearch/fastx_uniques/{sample}.log",
     params:
@@ -59,6 +63,7 @@ rule vsearch_fastx_uniques_bzip2:
         fastx_uniques="reads/{sample}.fastq",
     output:
         fastqout="out/fastx_uniques/{sample}.fastq.bz2",
+        log="out/fastx_uniques/{sample}.log",
     log:
         "logs/vsearch/fastx_uniques/{sample}.log",
     params:
@@ -73,6 +78,7 @@ rule vsearch_fastq_convert:
         fastq_convert="reads/{sample}.fastq",
     output:
         fastqout="out/fastq_convert/{sample}.fastq",
+        log="out/fastq_convert/{sample}.log",
     log:
         "logs/vsearch/fastq_convert/{sample}.log",
     params:

--- a/bio/vsearch/test/Snakefile
+++ b/bio/vsearch/test/Snakefile
@@ -12,7 +12,7 @@ rule vsearch_cluster_fast:
         "master/bio/vsearch"
 
 
-use rule vsearch_cluster_fast as vsearch_maskfasta with:
+rule vsearch_maskfasta:
     input:
         maskfasta="reads/{sample}.fasta",
     output:
@@ -22,9 +22,12 @@ use rule vsearch_cluster_fast as vsearch_maskfasta with:
         verbose="out/maskfasta/{sample}.log",
     params:
         extra="--hardmask",
+    threads: 1
+    wrapper:
+        "master/bio/vsearch"
 
 
-use rule vsearch_cluster_fast as vsearch_fastx_uniques with:
+rule vsearch_fastx_uniques:
     input:
         fastx_uniques="reads/{sample}.fastq",
     output:
@@ -34,9 +37,12 @@ use rule vsearch_cluster_fast as vsearch_fastx_uniques with:
         verbose="out/fastx_uniques/{sample}.log",
     params:
         extra="--strand both --minseqlength 5",
+    threads: 1
+    wrapper:
+        "master/bio/vsearch"
 
 
-use rule vsearch_cluster_fast as vsearch_fastx_uniques_gzip with:
+rule vsearch_fastx_uniques_gzip:
     input:
         fastx_uniques="reads/{sample}.fastq",
     output:
@@ -47,9 +53,11 @@ use rule vsearch_cluster_fast as vsearch_fastx_uniques_gzip with:
     params:
         extra="--strand both --minseqlength 5",
     threads: 2
+    wrapper:
+        "master/bio/vsearch"
 
 
-use rule vsearch_cluster_fast as vsearch_fastx_uniques_bzip2 with:
+rule vsearch_fastx_uniques_bzip2:
     input:
         fastx_uniques="reads/{sample}.fastq",
     output:
@@ -60,9 +68,11 @@ use rule vsearch_cluster_fast as vsearch_fastx_uniques_bzip2 with:
     params:
         extra="--strand both --minseqlength 5",
     threads: 2
+    wrapper:
+        "master/bio/vsearch"
 
 
-use rule vsearch_cluster_fast as vsearch_fastq_convert with:
+rule vsearch_fastq_convert:
     input:
         fastq_convert="reads/{sample}.fastq",
     output:
@@ -73,3 +83,5 @@ use rule vsearch_cluster_fast as vsearch_fastq_convert with:
     params:
         extra="--fastq_ascii 33 --fastq_asciiout 64",
     threads: 2
+    wrapper:
+        "master/bio/vsearch"

--- a/bio/vsearch/test/Snakefile
+++ b/bio/vsearch/test/Snakefile
@@ -38,7 +38,7 @@ rule vsearch_fastx_uniques:
         "logs/vsearch/fastx_uniques/{sample}.log",
     params:
         extra="--strand both --minseqlength 5",
-    threads: 2
+    threads: 1
     wrapper:
         "master/bio/vsearch"
 

--- a/bio/vsearch/test/Snakefile
+++ b/bio/vsearch/test/Snakefile
@@ -3,7 +3,6 @@ rule vsearch_cluster_fast:
         cluster_fast="reads/{sample}.fasta",
     output:
         profile="out/cluster_fast/{sample}.profile",
-        log="out/cluster_fast/{sample}.log",
     log:
         "logs/vsearch/cluster_fast/{sample}.log",
     params:
@@ -13,76 +12,64 @@ rule vsearch_cluster_fast:
         "master/bio/vsearch"
 
 
-rule vsearch_maskfasta:
+use rule vsearch_cluster_fast as vsearch_maskfasta with:
     input:
         maskfasta="reads/{sample}.fasta",
     output:
         output="out/maskfasta/{sample}.fasta",
-        log="out/maskfasta/{sample}.log",
     log:
         "logs/vsearch/maskfasta/{sample}.log",
+        verbose="out/maskfasta/{sample}.log",
     params:
         extra="--hardmask",
-    threads: 1
-    wrapper:
-        "master/bio/vsearch"
 
 
-rule vsearch_fastx_uniques:
+use rule vsearch_cluster_fast as vsearch_fastx_uniques with:
     input:
         fastx_uniques="reads/{sample}.fastq",
     output:
         fastqout="out/fastx_uniques/{sample}.fastq",
-        log="out/fastx_uniques/{sample}.log",
     log:
         "logs/vsearch/fastx_uniques/{sample}.log",
+        verbose="out/fastx_uniques/{sample}.log",
     params:
         extra="--strand both --minseqlength 5",
-    threads: 1
-    wrapper:
-        "master/bio/vsearch"
 
 
-rule vsearch_fastx_uniques_gzip:
+use rule vsearch_cluster_fast as vsearch_fastx_uniques_gzip with:
     input:
         fastx_uniques="reads/{sample}.fastq",
     output:
         fastqout="out/fastx_uniques/{sample}.fastq.gz",
-        log="out/fastx_uniques/{sample}.log",
     log:
         "logs/vsearch/fastx_uniques/{sample}.log",
+        verbose="out/fastx_uniques/{sample}.log",
     params:
         extra="--strand both --minseqlength 5",
     threads: 2
-    wrapper:
-        "master/bio/vsearch"
 
 
-rule vsearch_fastx_uniques_bzip2:
+use rule vsearch_cluster_fast as vsearch_fastx_uniques_bzip2 with:
     input:
         fastx_uniques="reads/{sample}.fastq",
     output:
         fastqout="out/fastx_uniques/{sample}.fastq.bz2",
-        log="out/fastx_uniques/{sample}.log",
     log:
         "logs/vsearch/fastx_uniques/{sample}.log",
+        verbose="out/fastx_uniques/{sample}.log",
     params:
         extra="--strand both --minseqlength 5",
     threads: 2
-    wrapper:
-        "master/bio/vsearch"
 
 
-rule vsearch_fastq_convert:
+use rule vsearch_cluster_fast as vsearch_fastq_convert with:
     input:
         fastq_convert="reads/{sample}.fastq",
     output:
         fastqout="out/fastq_convert/{sample}.fastq",
-        log="out/fastq_convert/{sample}.log",
     log:
         "logs/vsearch/fastq_convert/{sample}.log",
+        verbose="out/fastq_convert/{sample}.log",
     params:
         extra="--fastq_ascii 33 --fastq_asciiout 64",
     threads: 2
-    wrapper:
-        "master/bio/vsearch"

--- a/bio/vsearch/test/Snakefile
+++ b/bio/vsearch/test/Snakefile
@@ -5,6 +5,7 @@ rule vsearch_cluster_fast:
         profile="out/cluster_fast/{sample}.profile",
     log:
         "logs/vsearch/cluster_fast/{sample}.log",
+        vsearch="out/maskfasta/{sample}.log",
     params:
         extra="--id 0.2 --sizeout --minseqlength 5",
     threads: 1
@@ -19,7 +20,7 @@ rule vsearch_maskfasta:
         output="out/maskfasta/{sample}.fasta",
     log:
         "logs/vsearch/maskfasta/{sample}.log",
-        verbose="out/maskfasta/{sample}.log",
+        vsearch="out/maskfasta/{sample}.log",
     params:
         extra="--hardmask",
     threads: 1
@@ -34,7 +35,7 @@ rule vsearch_fastx_uniques:
         fastqout="out/fastx_uniques/{sample}.fastq",
     log:
         "logs/vsearch/fastx_uniques/{sample}.log",
-        verbose="out/fastx_uniques/{sample}.log",
+        vsearch="out/fastx_uniques/{sample}.log",
     params:
         extra="--strand both --minseqlength 5",
     threads: 1
@@ -49,7 +50,7 @@ rule vsearch_fastx_uniques_gzip:
         fastqout="out/fastx_uniques/{sample}.fastq.gz",
     log:
         "logs/vsearch/fastx_uniques/{sample}.log",
-        verbose="out/fastx_uniques/{sample}.log",
+        vsearch="out/fastx_uniques/{sample}.log",
     params:
         extra="--strand both --minseqlength 5",
     threads: 2
@@ -64,7 +65,7 @@ rule vsearch_fastx_uniques_bzip2:
         fastqout="out/fastx_uniques/{sample}.fastq.bz2",
     log:
         "logs/vsearch/fastx_uniques/{sample}.log",
-        verbose="out/fastx_uniques/{sample}.log",
+        vsearch="out/fastx_uniques/{sample}.log",
     params:
         extra="--strand both --minseqlength 5",
     threads: 2
@@ -79,7 +80,7 @@ rule vsearch_fastq_convert:
         fastqout="out/fastq_convert/{sample}.fastq",
     log:
         "logs/vsearch/fastq_convert/{sample}.log",
-        verbose="out/fastq_convert/{sample}.log",
+        vsearch="out/fastq_convert/{sample}.log",
     params:
         extra="--fastq_ascii 33 --fastq_asciiout 64",
     threads: 2

--- a/bio/vsearch/wrapper.py
+++ b/bio/vsearch/wrapper.py
@@ -17,7 +17,7 @@ out_list = list()
 for key, value in snakemake.output.items():
     if value.endswith(".gz"):
         out_list.append(
-            f"--{key} /dev/stdout | pigz --processes {snakemake.threads} --compress --stdout > {value}"
+            f"--{key} /dev/stdout | pigz --processes {snakemake.threads} --stdout > {value}"
         )
     elif value.endswith(".bz2"):
         out_list.append(

--- a/bio/vsearch/wrapper.py
+++ b/bio/vsearch/wrapper.py
@@ -28,7 +28,9 @@ out_bz2 = [out.endswith(".bz2") for out in out_list]
 assert sum(out_gz + out_bz2) <= 1, "only one output can be compressed"
 
 # Move compressed file (if any) to last
-output = [out for _, out in sorted(zip(out_gz or out_bz2, out_list))]
+output = [
+    out for _, out in sorted(zip([x | y for x, y in zip(out_gz, out_bz2)], out_list))
+]
 
 
 shell("(vsearch --threads {snakemake.threads} {input} {extra} {output}) {log}")

--- a/bio/vsearch/wrapper.py
+++ b/bio/vsearch/wrapper.py
@@ -16,9 +16,13 @@ input = " ".join([f"--{key} {value}" for key, value in snakemake.input.items()])
 out_list = list()
 for key, value in snakemake.output.items():
     if value.endswith(".gz"):
-        out_list.append(f"--{key} /dev/stdout | gzip > {value}")
+        out_list.append(
+            f"--{key} /dev/stdout | pigz --processes {snakemake.threads} --stdout > {value}"
+        )
     elif value.endswith(".bz2"):
-        out_list.append(f"--{key} /dev/stdout | bzip2 > {value}")
+        out_list.append(
+            f"--{key} /dev/stdout | pbzip2 -p{snakemake.threads} --stdout > {value}"
+        )
     else:
         out_list.append(f"--{key} {value}")
 

--- a/bio/vsearch/wrapper.py
+++ b/bio/vsearch/wrapper.py
@@ -6,9 +6,9 @@ from snakemake.shell import shell
 
 
 extra = snakemake.params.get("extra", "")
-log = snakemake.log.get("verbose", "")
+log = snakemake.log.get("vsearch", "")
 if log:
-    log = f"--log {log}"
+    extra += f" --log {log}"
 
 
 # Parse input files
@@ -40,5 +40,5 @@ output = [
 
 
 shell(
-    "(vsearch --threads {snakemake.threads} {log} {input} {extra} {output}) 2> {snakemake.log[0]}"
+    "(vsearch --threads {snakemake.threads} {input} {extra} {output}) 2> {snakemake.log[0]}"
 )

--- a/bio/vsearch/wrapper.py
+++ b/bio/vsearch/wrapper.py
@@ -6,7 +6,9 @@ from snakemake.shell import shell
 
 
 extra = snakemake.params.get("extra", "")
-log = snakemake.log_fmt_shell(stdout=False, stderr=True)
+log = snakemake.log.get("verbose", "")
+if log:
+    log = f"--log {log}"
 
 
 # Parse input files
@@ -37,4 +39,6 @@ output = [
 ]
 
 
-shell("(vsearch --threads {snakemake.threads} {input} {extra} {output}) {log}")
+shell(
+    "(vsearch --threads {snakemake.threads} {log} {input} {extra} {output}) 2> {snakemake.log[0]}"
+)

--- a/bio/vsearch/wrapper.py
+++ b/bio/vsearch/wrapper.py
@@ -31,4 +31,4 @@ assert sum(out_gz + out_bz2) <= 1, "only one output can be compressed"
 output = [out for _, out in sorted(zip(out_gz or out_bz2, out_list))]
 
 
-shell("vsearch --threads {snakemake.threads} {input} {extra} {output} {log}")
+shell("(vsearch --threads {snakemake.threads} {input} {extra} {output}) {log}")

--- a/bio/vsearch/wrapper.py
+++ b/bio/vsearch/wrapper.py
@@ -6,13 +6,13 @@ from snakemake.shell import shell
 
 
 extra = snakemake.params.get("extra", "")
-if snakemake.log:
-    log = f"--log {snakemake.log}"
+log = snakemake.log_fmt_shell(stdout=False, stderr=True)
 
 
+# Parse input files
 input = " ".join([f"--{key} {value}" for key, value in snakemake.input.items()])
 
-
+# Parse output files
 out_list = list()
 for key, value in snakemake.output.items():
     if value.endswith(".gz"):
@@ -31,4 +31,4 @@ assert sum(out_gz + out_bz2) <= 1, "only one output can be compressed"
 output = [out for _, out in sorted(zip(out_gz or out_bz2, out_list))]
 
 
-shell("vsearch --threads {snakemake.threads} {input} {extra} {log} {output}")
+shell("vsearch --threads {snakemake.threads} {input} {extra} {log} {output} {log}")

--- a/bio/vsearch/wrapper.py
+++ b/bio/vsearch/wrapper.py
@@ -31,4 +31,4 @@ assert sum(out_gz + out_bz2) <= 1, "only one output can be compressed"
 output = [out for _, out in sorted(zip(out_gz or out_bz2, out_list))]
 
 
-shell("vsearch --threads {snakemake.threads} {input} {extra} {log} {output} {log}")
+shell("vsearch --threads {snakemake.threads} {input} {extra} {output} {log}")

--- a/bio/vsearch/wrapper.py
+++ b/bio/vsearch/wrapper.py
@@ -17,11 +17,11 @@ out_list = list()
 for key, value in snakemake.output.items():
     if value.endswith(".gz"):
         out_list.append(
-            f"--{key} /dev/stdout | pigz --processes {snakemake.threads} --stdout > {value}"
+            f"--{key} /dev/stdout | pigz --processes {snakemake.threads} --compress --stdout > {value}"
         )
     elif value.endswith(".bz2"):
         out_list.append(
-            f"--{key} /dev/stdout | pbzip2 -p{snakemake.threads} --stdout > {value}"
+            f"--{key} /dev/stdout | pbzip2 -p{snakemake.threads} --compress --stdout > {value}"
         )
     else:
         out_list.append(f"--{key} {value}")


### PR DESCRIPTION
<!-- Ensure that the PR title follows conventional commit style (<type>: <description>)-->
<!-- Possible types are here: https://github.com/commitizen/conventional-commit-types/blob/master/index.json -->

### Description

<!-- Add a description of your PR here-->
Fixed bug with `bz2` output and added the general log too keep console clean and be able to keep track of progress.

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] I confirm that:

For all wrappers added by this PR, 

* there is a test case which covers any introduced changes,
* `input:` and `output:` file paths in the resulting rule can be changed arbitrarily,
* either the wrapper can only use a single core, or the example rule contains a `threads: x` statement with `x` being a reasonable default,
* rule names in the test case are in [snake_case](https://en.wikipedia.org/wiki/Snake_case) and somehow tell what the rule is about or match the tools purpose or name (e.g., `map_reads` for a step that maps reads),
* all `environment.yaml` specifications follow [the respective best practices](https://stackoverflow.com/a/64594513/2352071),
* wherever possible, command line arguments are inferred and set automatically (e.g. based on file extensions in `input:` or `output:`),
* all fields of the example rules in the `Snakefile`s and their entries are explained via comments (`input:`/`output:`/`params:` etc.),
* `stderr` and/or `stdout` are logged correctly (`log:`), depending on the wrapped tool,
* temporary files are either written to a unique hidden folder in the working directory, or (better) stored where the Python function `tempfile.gettempdir()` points to (see [here](https://docs.python.org/3/library/tempfile.html#tempfile.gettempdir); this also means that using any Python `tempfile` default behavior works),
* the `meta.yaml` contains a link to the documentation of the respective tool or command,
* `Snakefile`s pass the linting (`snakemake --lint`),
* `Snakefile`s are formatted with [snakefmt](https://github.com/snakemake/snakefmt),
* Python wrapper scripts are formatted with [black](https://black.readthedocs.io).
* Conda environments use a minimal amount of channels, in recommended ordering. E.g. for bioconda, use (conda-forge, bioconda, nodefaults, as conda-forge should have highest priority and defaults channels are usually not needed because most packages are in conda-forge nowadays).
