### PR TITLE
fix: genomepy wrapper

### DIFF
--- a/bio/genomepy/meta.yaml
+++ b/bio/genomepy/meta.yaml
@@ -10,4 +10,3 @@ output: |
   and whether or not it is specified as output.
 params:
   - provider: which provider to download from, defaults to UCSC (choose from UCSC, Ensembl, NCBI).
-blacklisted: fails with ValueError when trying to remove plugin from list

--- a/bio/genomepy/test/Snakefile
+++ b/bio/genomepy/test/Snakefile
@@ -6,13 +6,13 @@ rule genomepy:
             ".fa.fai",
             ".fa.sizes",
             ".gaps.bed",
-            ".annotation.gtf.gz",
+            ".annotation.gtf",
             ".blacklist.bed",
         ),
     log:
         "logs/genomepy_{assembly}.log",
     params:
-        provider="UCSC",  # optional, defaults to ucsc. Choose from ucsc, ensembl, and ncbi
+        provider="ucsc",  # optional, defaults to ucsc. Choose from ucsc, ensembl, and ncbi
     cache: "omit-software"  # mark as eligible for between workflow caching
     wrapper:
         "master/bio/genomepy"

--- a/bio/genomepy/wrapper.py
+++ b/bio/genomepy/wrapper.py
@@ -7,7 +7,7 @@ __license__ = "MIT"
 from snakemake.shell import shell
 
 # Optional parameters
-provider = snakemake.params.get("provider", "ucsc")
+provider = snakemake.params.get("provider", "ucsc").lower()
 
 # set options for plugins
 all_plugins = "blacklist,bowtie2,bwa,gmap,hisat2,minimap2,star"

--- a/bio/genomepy/wrapper.py
+++ b/bio/genomepy/wrapper.py
@@ -7,7 +7,7 @@ __license__ = "MIT"
 from snakemake.shell import shell
 
 # Optional parameters
-provider = f'--provider {snakemake.params.get("provider", "ucsc")}'
+provider = {snakemake.params.get("provider", "ucsc")
 
 # set options for plugins
 all_plugins = "blacklist,bowtie2,bwa,gmap,hisat2,minimap2,star"
@@ -40,6 +40,6 @@ shell(
 
     # install the genome
     genomepy install {snakemake.wildcards.assembly} \
-    {provider} {annotation} -g {genome_dir} >> {log} 2>&1
+    --provider {provider} {annotation} -g {genome_dir} >> {log} 2>&1
     """
 )

--- a/bio/genomepy/wrapper.py
+++ b/bio/genomepy/wrapper.py
@@ -7,7 +7,7 @@ __license__ = "MIT"
 from snakemake.shell import shell
 
 # Optional parameters
-provider = snakemake.params.get("provider", "UCSC")
+provider = f'--provider {snakemake.params.get("provider", "ucsc")}'
 
 # set options for plugins
 all_plugins = "blacklist,bowtie2,bwa,gmap,hisat2,minimap2,star"

--- a/bio/genomepy/wrapper.py
+++ b/bio/genomepy/wrapper.py
@@ -7,7 +7,7 @@ __license__ = "MIT"
 from snakemake.shell import shell
 
 # Optional parameters
-provider = {snakemake.params.get("provider", "ucsc")
+provider = snakemake.params.get("provider", "ucsc")
 
 # set options for plugins
 all_plugins = "blacklist,bowtie2,bwa,gmap,hisat2,minimap2,star"


### PR DESCRIPTION
<!-- Ensure that the PR title follows conventional commit style (<type>: <description>)-->
<!-- Possible types are here: https://github.com/commitizen/conventional-commit-types/blob/master/index.json -->

### Description

fixed the genomepy wrapper :partying_face: 

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] I confirm that:

For all wrappers added by this PR, 

* there is a test case which covers any introduced changes,
* `input:` and `output:` file paths in the resulting rule can be changed arbitrarily,
* either the wrapper can only use a single core, or the example rule contains a `threads: x` statement with `x` being a reasonable default,
* rule names in the test case are in [snake_case](https://en.wikipedia.org/wiki/Snake_case) and somehow tell what the rule is about or match the tools purpose or name (e.g., `map_reads` for a step that maps reads),
* all `environment.yaml` specifications follow [the respective best practices](https://stackoverflow.com/a/64594513/2352071),
* wherever possible, command line arguments are inferred and set automatically (e.g. based on file extensions in `input:` or `output:`),
* all fields of the example rules in the `Snakefile`s and their entries are explained via comments (`input:`/`output:`/`params:` etc.),
* `stderr` and/or `stdout` are logged correctly (`log:`), depending on the wrapped tool,
* temporary files are either written to a unique hidden folder in the working directory, or (better) stored where the Python function `tempfile.gettempdir()` points to (see [here](https://docs.python.org/3/library/tempfile.html#tempfile.gettempdir); this also means that using any Python `tempfile` default behavior works),
* the `meta.yaml` contains a link to the documentation of the respective tool or command,
* `Snakefile`s pass the linting (`snakemake --lint`),
* `Snakefile`s are formatted with [snakefmt](https://github.com/snakemake/snakefmt),
* Python wrapper scripts are formatted with [black](https://black.readthedocs.io).
* Conda environments use a minimal amount of channels, in recommended ordering. E.g. for bioconda, use (conda-forge, bioconda, nodefaults, as conda-forge should have highest priority and defaults channels are usually not needed because most packages are in conda-forge nowadays).
