### PR TITLE
fix: Update environment.yaml of MultiQC

### DIFF
--- a/bio/multiqc/environment.yaml
+++ b/bio/multiqc/environment.yaml
@@ -3,5 +3,4 @@ channels:
   - bioconda
   - nodefaults
 dependencies:
-  - python >=3.7.0,<3.12.0
-  - multiqc =1.16
+  - multiqc =1.17

--- a/bio/multiqc/environment.yaml
+++ b/bio/multiqc/environment.yaml
@@ -3,4 +3,5 @@ channels:
   - bioconda
   - nodefaults
 dependencies:
-  - multiqc =1.16
+  - python<3.12.0
+  - multiqc=1.16

--- a/bio/multiqc/environment.yaml
+++ b/bio/multiqc/environment.yaml
@@ -3,5 +3,5 @@ channels:
   - bioconda
   - nodefaults
 dependencies:
-  - python<3.12.0
-  - multiqc=1.16
+  - python >=3.7.0,<3.12.0
+  - multiqc =1.16


### PR DESCRIPTION
<!-- Ensure that the PR title follows conventional commit style (<type>: <description>)-->
<!-- Possible types are here: https://github.com/commitizen/conventional-commit-types/blob/master/index.json -->

### Description

<!-- Add a description of your PR here-->
Python version is fixed to versions<3.12.0 to handle dependency on imp-module, which is not available in newer python versions. 
The imp module is [deprecated in favor of importlib, and removed from the standard library since python version 3.12.0](https://docs.python.org/3.11/library/imp.html). Thus, depending on the python version your program-call/conda-environment is using, you will encounter a `ModuleNotFoundError` Error.

For further information, see discussion on StackOverflow:  https://stackoverflow.com/questions/77273344/multiqc-snakemake-wrapper-modulenotfounderror-no-module-named-imp