### PR TITLE
fix: Bump version

### DIFF
--- a/bio/picard/markduplicates/environment.yaml
+++ b/bio/picard/markduplicates/environment.yaml
@@ -4,5 +4,5 @@ channels:
   - nodefaults
 dependencies:
   - picard =3.1.0
-  - samtools =1.17
+  - samtools =1.18
   - snakemake-wrapper-utils =0.6.2

--- a/bio/picard/markduplicates/meta.yaml
+++ b/bio/picard/markduplicates/meta.yaml
@@ -14,6 +14,6 @@ params:
   - java_opts: allows for additional arguments to be passed to the java compiler, e.g. "-XX:ParallelGCThreads=10" (not for `-XmX` or `-Djava.io.tmpdir`, since they are handled automatically).
   - extra: allows for additional program arguments.
   - embed_ref: allows to embed the fasta reference into the cram
-  - withmatecigar: allows to run `MarkDuplicatesWithMateCigar <https://broadinstitute.github.io/picard/command-line-overview.html#MarkDuplicatesWithMateCigar>`_ instead.
+  - withmatecigar: runs `MarkDuplicatesWithMateCigar <https://broadinstitute.github.io/picard/command-line-overview.html#MarkDuplicatesWithMateCigar>`_ instead.
 notes: |
   * `--TMP_DIR` is automatically set by `resources.tmpdir`

--- a/bio/picard/markduplicates/test/Snakefile
+++ b/bio/picard/markduplicates/test/Snakefile
@@ -5,7 +5,7 @@ rule markduplicates_bam:
     # of marking duplicates on separate read groups for a sample
     # and then merging
     output:
-        bam="dedup_bam/{sample}.bam",
+        aln="dedup_bam/{sample}.bam",
         metrics="dedup_bam/{sample}.metrics.txt",
     log:
         "logs/dedup_bam/{sample}.log",
@@ -23,7 +23,7 @@ rule markduplicates_bam:
 
 use rule markduplicates_bam as markduplicateswithmatecigar_bam with:
     output:
-        bam="dedup_bam/{sample}.matecigar.bam",
+        aln="dedup_bam/{sample}.matecigar.bam",
         idx="dedup_bam/{sample}.mcigar.bai",
         metrics="dedup_bam/{sample}.matecigar.metrics.txt",
     log:
@@ -35,7 +35,7 @@ use rule markduplicates_bam as markduplicateswithmatecigar_bam with:
 
 use rule markduplicates_bam as markduplicates_sam with:
     output:
-        bam="dedup_sam/{sample}.sam",
+        aln="dedup_sam/{sample}.sam",
         metrics="dedup_sam/{sample}.metrics.txt",
     log:
         "logs/dedup_sam/{sample}.log",
@@ -45,10 +45,10 @@ use rule markduplicates_bam as markduplicates_sam with:
 
 use rule markduplicates_bam as markduplicates_cram with:
     input:
-        bams="mapped/{sample}.bam",
+        alns="mapped/{sample}.bam",
         ref="ref/genome.fasta",
     output:
-        bam="dedup_cram/{sample}.cram",
+        aln="dedup_cram/{sample}.cram",
         idx="dedup_cram/{sample}.cram.crai",
         metrics="dedup_cram/{sample}.metrics.txt",
     log:

--- a/bio/picard/markduplicates/test/Snakefile
+++ b/bio/picard/markduplicates/test/Snakefile
@@ -1,6 +1,6 @@
 rule markduplicates_bam:
     input:
-        "mapped/{sample}.bam",
+        alns="mapped/{sample}.bam",
     # optional to specify a list of BAMs; this has the same effect
     # of marking duplicates on separate read groups for a sample
     # and then merging

--- a/bio/picard/markduplicates/test/Snakefile
+++ b/bio/picard/markduplicates/test/Snakefile
@@ -1,6 +1,6 @@
 rule markduplicates_bam:
     input:
-        bams="mapped/{sample}.bam",
+        "mapped/{sample}.bam",
     # optional to specify a list of BAMs; this has the same effect
     # of marking duplicates on separate read groups for a sample
     # and then merging

--- a/bio/picard/markduplicates/wrapper.py
+++ b/bio/picard/markduplicates/wrapper.py
@@ -30,7 +30,7 @@ if isinstance(alns, str):
 alns = list(map("--INPUT {}".format, alns))
 
 
-output = snakemake.output.bam
+output = snakemake.output.aln
 output_fmt = infer_out_format(output)
 convert = ""
 if output_fmt == "CRAM":
@@ -58,7 +58,7 @@ with tempfile.TemporaryDirectory() as tmpdir:
     )
 
 
-output_prefix = Path(snakemake.output.bam).with_suffix("")
+output_prefix = Path(snakemake.output.aln).with_suffix("")
 if snakemake.output.get("idx"):
     if output_fmt == "BAM" and snakemake.output.idx != str(output_prefix) + ".bai":
         shell("mv {output_prefix}.bai {snakemake.output.idx}")

--- a/bio/picard/markduplicates/wrapper.py
+++ b/bio/picard/markduplicates/wrapper.py
@@ -24,10 +24,10 @@ if snakemake.params.get("withmatecigar", False):
     tool = "MarkDuplicatesWithMateCigar"
 
 
-bams = snakemake.input.bams
-if isinstance(bams, str):
-    bams = [bams]
-bams = list(map("--INPUT {}".format, bams))
+alns = snakemake.input
+if isinstance(alns, str):
+    alns = [alns]
+alns = list(map("--INPUT {}".format, alns))
 
 
 output = snakemake.output.bam
@@ -50,7 +50,7 @@ with tempfile.TemporaryDirectory() as tmpdir:
         "(picard {tool}"  # Tool and its subcommand
         " {java_opts}"  # Automatic java option
         " {extra}"  # User defined parmeters
-        " {bams}"  # Input bam(s)
+        " {alns}"  # Input aln(s)
         " --TMP_DIR {tmpdir}"
         " --OUTPUT {output}"  # Output bam
         " --METRICS_FILE {snakemake.output.metrics}"  # Output metrics

--- a/bio/picard/markduplicates/wrapper.py
+++ b/bio/picard/markduplicates/wrapper.py
@@ -24,7 +24,7 @@ if snakemake.params.get("withmatecigar", False):
     tool = "MarkDuplicatesWithMateCigar"
 
 
-alns = snakemake.input
+alns = snakemake.input.alns
 if isinstance(alns, str):
     alns = [alns]
 alns = list(map("--INPUT {}".format, alns))


### PR DESCRIPTION
<!-- Ensure that the PR title follows conventional commit style (<type>: <description>)-->
<!-- Possible types are here: https://github.com/commitizen/conventional-commit-types/blob/master/index.json -->

### Description

<!-- Add a description of your PR here-->

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] I confirm that:

For all wrappers added by this PR, 

* there is a test case which covers any introduced changes,
* `input:` and `output:` file paths in the resulting rule can be changed arbitrarily,
* either the wrapper can only use a single core, or the example rule contains a `threads: x` statement with `x` being a reasonable default,
* rule names in the test case are in [snake_case](https://en.wikipedia.org/wiki/Snake_case) and somehow tell what the rule is about or match the tools purpose or name (e.g., `map_reads` for a step that maps reads),
* all `environment.yaml` specifications follow [the respective best practices](https://stackoverflow.com/a/64594513/2352071),
* wherever possible, command line arguments are inferred and set automatically (e.g. based on file extensions in `input:` or `output:`),
* all fields of the example rules in the `Snakefile`s and their entries are explained via comments (`input:`/`output:`/`params:` etc.),
* `stderr` and/or `stdout` are logged correctly (`log:`), depending on the wrapped tool,
* temporary files are either written to a unique hidden folder in the working directory, or (better) stored where the Python function `tempfile.gettempdir()` points to (see [here](https://docs.python.org/3/library/tempfile.html#tempfile.gettempdir); this also means that using any Python `tempfile` default behavior works),
* the `meta.yaml` contains a link to the documentation of the respective tool or command,
* `Snakefile`s pass the linting (`snakemake --lint`),
* `Snakefile`s are formatted with [snakefmt](https://github.com/snakemake/snakefmt),
* Python wrapper scripts are formatted with [black](https://black.readthedocs.io).
* Conda environments use a minimal amount of channels, in recommended ordering. E.g. for bioconda, use (conda-forge, bioconda, nodefaults, as conda-forge should have highest priority and defaults channels are usually not needed because most packages are in conda-forge nowadays).
