### PR TITLE
fix: add support for multiple samples to bcftools mpileup

### DIFF
--- a/bio/bcftools/mpileup/meta.yaml
+++ b/bio/bcftools/mpileup/meta.yaml
@@ -4,6 +4,12 @@ url: http://www.htslib.org/doc/bcftools.html#mpileup
 authors:
   - Michael Hall
   - Filipe G. Vieira
-notes: |
-  * The `uncompressed_bcf` param allows to specify that a BCF output should be uncompressed (ignored otherwise).
-  * The `extra` param allows for additional program arguments (not `--threads`, `-f/--fasta-ref`, `-o/--output`, or `-O/--output-type`).
+input:
+  - alns: SAM/BAM/CRAM file(s)
+  - ref: reference genome
+  - reference genome index
+output:
+  - pileup file
+params:
+  - uncompressed_bcf: uncompressed BCF (ignored otherwise)
+  - extra: additional program arguments

--- a/bio/bcftools/mpileup/meta.yaml
+++ b/bio/bcftools/mpileup/meta.yaml
@@ -5,7 +5,7 @@ authors:
   - Michael Hall
   - Filipe G. Vieira
 input:
-  - alns: SAM/BAM/CRAM file(s)
+  - alignments: SAM/BAM/CRAM file(s)
   - ref: reference genome
   - reference genome index
 output:

--- a/bio/bcftools/mpileup/test/Snakefile
+++ b/bio/bcftools/mpileup/test/Snakefile
@@ -1,6 +1,6 @@
 rule bcftools_mpileup:
     input:
-        alns=["mapped/{sample}.bam", "mapped/{sample}.bam"],
+        alignments=["mapped/{sample}.bam", "mapped/{sample}.bam"],
         ref="genome.fasta",  # this can be left out if --no-reference is in options
         index="genome.fasta.fai",
     output:

--- a/bio/bcftools/mpileup/test/Snakefile
+++ b/bio/bcftools/mpileup/test/Snakefile
@@ -1,6 +1,6 @@
 rule bcftools_mpileup:
     input:
-        alignments="mapped/{sample}.bam",
+        alns=["mapped/{sample}.bam", "mapped/{sample}.bam"],
         ref="genome.fasta",  # this can be left out if --no-reference is in options
         index="genome.fasta.fai",
     output:

--- a/bio/bcftools/mpileup/wrapper.py
+++ b/bio/bcftools/mpileup/wrapper.py
@@ -19,4 +19,4 @@ class MissingReferenceError(Exception):
     pass
 
 
-shell("bcftools mpileup {bcftools_opts} {extra} {snakemake.input.alns} {log}")
+shell("bcftools mpileup {bcftools_opts} {extra} {snakemake.input.alignments} {log}")

--- a/bio/bcftools/mpileup/wrapper.py
+++ b/bio/bcftools/mpileup/wrapper.py
@@ -19,4 +19,4 @@ class MissingReferenceError(Exception):
     pass
 
 
-shell("bcftools mpileup {bcftools_opts} {extra} {snakemake.input[0]} {log}")
+shell("bcftools mpileup {bcftools_opts} {extra} {snakemake.input.alns} {log}")


### PR DESCRIPTION
<!-- Ensure that the PR title follows conventional commit style (<type>: <description>)-->
<!-- Possible types are here: https://github.com/commitizen/conventional-commit-types/blob/master/index.json -->

### Description

<!-- Add a description of your PR here-->

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] I confirm that:

For all wrappers added by this PR, 

* there is a test case which covers any introduced changes,
* `input:` and `output:` file paths in the resulting rule can be changed arbitrarily,
* either the wrapper can only use a single core, or the example rule contains a `threads: x` statement with `x` being a reasonable default,
* rule names in the test case are in [snake_case](https://en.wikipedia.org/wiki/Snake_case) and somehow tell what the rule is about or match the tools purpose or name (e.g., `map_reads` for a step that maps reads),
* all `environment.yaml` specifications follow [the respective best practices](https://stackoverflow.com/a/64594513/2352071),
* wherever possible, command line arguments are inferred and set automatically (e.g. based on file extensions in `input:` or `output:`),
* all fields of the example rules in the `Snakefile`s and their entries are explained via comments (`input:`/`output:`/`params:` etc.),
* `stderr` and/or `stdout` are logged correctly (`log:`), depending on the wrapped tool,
* temporary files are either written to a unique hidden folder in the working directory, or (better) stored where the Python function `tempfile.gettempdir()` points to (see [here](https://docs.python.org/3/library/tempfile.html#tempfile.gettempdir); this also means that using any Python `tempfile` default behavior works),
* the `meta.yaml` contains a link to the documentation of the respective tool or command,
* `Snakefile`s pass the linting (`snakemake --lint`),
* `Snakefile`s are formatted with [snakefmt](https://github.com/snakemake/snakefmt),
* Python wrapper scripts are formatted with [black](https://black.readthedocs.io).
* Conda environments use a minimal amount of channels, in recommended ordering. E.g. for bioconda, use (conda-forge, bioconda, nodefaults, as conda-forge should have highest priority and defaults channels are usually not needed because most packages are in conda-forge nowadays).
