### PR TITLE
feat: add wrapper for fetching files from EGA

### DIFF
--- a/bio/ega/fetch/environment.yaml
+++ b/bio/ega/fetch/environment.yaml
@@ -1,0 +1,6 @@
+channels:
+  - conda-forge
+  - bioconda
+  - nodefaults
+dependencies:
+  - pyega3 =5.1.0

--- a/bio/ega/fetch/meta.yaml
+++ b/bio/ega/fetch/meta.yaml
@@ -1,0 +1,7 @@
+name: RGA fetch
+description: Fetch files from EGA with pyega3.
+url: https://github.com/EGA-archive/ega-download-client
+authors:
+  - Johannes Köster
+output:
+  - File formats supported by EGA (BAM, CRAM, VCF, BCF)

--- a/bio/ega/fetch/test/Snakefile
+++ b/bio/ega/fetch/test/Snakefile
@@ -1,0 +1,11 @@
+rule download_file:
+    output:
+        "data/{egafile}.cram",
+    log:
+        "logs/ega/fetch/{egafile}.log",
+    params:
+        fileid=lambda wildcards: wildcards.egafile,
+        extra_pyega3="-t", # optional extra args for pyega3
+        extra_fetch="",  # optional extra args for the fetch subcommand
+    wrapper:
+        "master/bio/ega/fetch"

--- a/bio/ega/fetch/wrapper.py
+++ b/bio/ega/fetch/wrapper.py
@@ -10,7 +10,7 @@ if snakemake.log:
 
 fileid = snakemake.params.fileid
 
-fmt = Path(snakemake.output).suffix[1:].upper()
+fmt = Path(snakemake.output[0]).suffix[1:].upper()
 
 extra_pyega3 = shlex.split(snakemake.params.get("extra_pyega3", ""))
 extra_fetch = shlex.split(snakemake.params.get("extra_fetch", ""))

--- a/bio/ega/fetch/wrapper.py
+++ b/bio/ega/fetch/wrapper.py
@@ -1,0 +1,33 @@
+from pathlib import Path
+import shlex
+import shutil
+import subprocess as sp
+import sys
+import tempfile
+
+if snakemake.log:
+    sys.stderr = open(snakemake.log[0], "w")
+
+fileid = snakemake.params.fileid
+
+fmt = Path(snakemake.output).suffix[1:].upper()
+
+extra_pyega3 = shlex.split(snakemake.params.get("extra_pyega3", ""))
+extra_fetch = shlex.split(snakemake.params.get("extra_fetch", ""))
+
+with tempfile.TemporaryDirectory() as tmpdir:
+    cmd = (
+        ["pyega3"]
+        + extra_pyega3
+        + ["fetch", "--output-dir", tmpdir, "--format", fmt, fileid]
+        + extra_fetch
+    )
+    sp.run(
+        cmd,
+        stdout=sys.stderr,
+        stderr=sp.STDOUT,
+        check=True,
+    )
+
+    # Move the file to the output
+    shutil.move(Path(tmpdir).glob(f"*.{fmt.lower()}"), snakemake.output[0])

--- a/bio/ega/fetch/wrapper.py
+++ b/bio/ega/fetch/wrapper.py
@@ -30,7 +30,7 @@ with tempfile.TemporaryDirectory() as tmpdir:
     )
     # obtain path to the downloaded file (it should be the only file with that
     # extension in the temp dir)
-    glob_res = list(Path(tmpdir).glob(f"*.{fmt.lower()}"))
+    glob_res = list((Path(tmpdir) / fileid).glob(f"*.{fmt.lower()}"))
     assert (
         len(glob_res) == 1
     ), "bug: more than one file with desired extension downloaded by pyega3"

--- a/bio/ega/fetch/wrapper.py
+++ b/bio/ega/fetch/wrapper.py
@@ -28,6 +28,11 @@ with tempfile.TemporaryDirectory() as tmpdir:
         stderr=sp.STDOUT,
         check=True,
     )
+    # obtain path to the downloaded file (it should be the only file with that extension in the temp dir)
+    glob_res = list(Path(tmpdir).glob(f"*.{fmt.lower()}"))
+    assert (
+        len(glob_res) == 1
+    ), "bug: more than one file with desired extension downloaded by pyega3"
 
     # Move the file to the output
-    shutil.move(Path(tmpdir).glob(f"*.{fmt.lower()}"), snakemake.output[0])
+    shutil.move(glob_res[0], snakemake.output[0])

--- a/bio/ega/fetch/wrapper.py
+++ b/bio/ega/fetch/wrapper.py
@@ -28,7 +28,8 @@ with tempfile.TemporaryDirectory() as tmpdir:
         stderr=sp.STDOUT,
         check=True,
     )
-    # obtain path to the downloaded file (it should be the only file with that extension in the temp dir)
+    # obtain path to the downloaded file (it should be the only file with that
+    # extension in the temp dir)
     glob_res = list(Path(tmpdir).glob(f"*.{fmt.lower()}"))
     assert (
         len(glob_res) == 1

--- a/test.py
+++ b/test.py
@@ -5424,6 +5424,21 @@ def test_ensembl_variation_with_contig_lengths():
 
 
 @skip_if_not_modified
+def test_ega_fetch():
+    run(
+        "bio/ega/fetch",
+        [
+            "snakemake",
+            "--cores",
+            "1",
+            "--use-conda",
+            "-F",
+            "data/EGAF00007243774.cram"
+        ]
+    )
+
+
+@skip_if_not_modified
 def test_infernal_cmpress():
     run(
         "bio/infernal/cmpress",


### PR DESCRIPTION
<!-- Ensure that the PR title follows conventional commit style (<type>: <description>)-->
<!-- Possible types are here: https://github.com/commitizen/conventional-commit-types/blob/master/index.json -->

<!-- Add a description of your PR here-->

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] I confirm that:

For all wrappers added by this PR, 

* there is a test case which covers any introduced changes,
* `input:` and `output:` file paths in the resulting rule can be changed arbitrarily,
* either the wrapper can only use a single core, or the example rule contains a `threads: x` statement with `x` being a reasonable default,
* rule names in the test case are in [snake_case](https://en.wikipedia.org/wiki/Snake_case) and somehow tell what the rule is about or match the tools purpose or name (e.g., `map_reads` for a step that maps reads),
* all `environment.yaml` specifications follow [the respective best practices](https://stackoverflow.com/a/64594513/2352071),
* the `environment.yaml` pinning has been updated by running `snakedeploy pin-conda-envs environment.yaml` on a linux machine,
* wherever possible, command line arguments are inferred and set automatically (e.g. based on file extensions in `input:` or `output:`),
* all fields of the example rules in the `Snakefile`s and their entries are explained via comments (`input:`/`output:`/`params:` etc.),
* `stderr` and/or `stdout` are logged correctly (`log:`), depending on the wrapped tool,
* temporary files are either written to a unique hidden folder in the working directory, or (better) stored where the Python function `tempfile.gettempdir()` points to (see [here](https://docs.python.org/3/library/tempfile.html#tempfile.gettempdir); this also means that using any Python `tempfile` default behavior works),
* the `meta.yaml` contains a link to the documentation of the respective tool or command,
* `Snakefile`s pass the linting (`snakemake --lint`),
* `Snakefile`s are formatted with [snakefmt](https://github.com/snakemake/snakefmt),
* Python wrapper scripts are formatted with [black](https://black.readthedocs.io).
* Conda environments use a minimal amount of channels, in recommended ordering. E.g. for bioconda, use (conda-forge, bioconda, nodefaults, as conda-forge should have highest priority and defaults channels are usually not needed because most packages are in conda-forge nowadays).
