### PR TITLE
fix: test case for reference-ensembl-sequence wrapper

### DIFF
--- a/bio/reference/ensembl-sequence/test/Snakefile
+++ b/bio/reference/ensembl-sequence/test/Snakefile
@@ -21,7 +21,7 @@ rule get_single_chromosome:
         datatype="dna",
         build="R64-1-1",
         release="101",
-        chromosome="II",  # optional: restrict to one or multiple chromosomes, for multiple see below
+        chromosome=["II"],  # optional: restrict to one or multiple chromosomes, for multiple see below
         # branch="plants",  # optional: specify branch
     log:
         "logs/get_genome.log",


### PR DESCRIPTION
In the test case rule **_`get_single_chromosome`_** the parameter `chromosome` requires to be an array. Otherwise, if one passes a multi-char string, the wrapper splits the string into its chars and iterates over the chars instead of interpreting the string as a whole.

