### PR TITLE
chore: Name wrapper "BBmap-suite" instead of Generic. 

### DIFF
--- a/bio/bbtools/meta.yaml
+++ b/bio/bbtools/meta.yaml
@@ -1,7 +1,7 @@
-name: Generic
+name: BBmap-suite
 url: https://jgi.doe.gov/data-and-tools/software-tools/bbtools/bb-tools-user-guide/
 description: |
-  Generic wrapper for BBTools. One pattern to run them all.
+  Wrapper for all tools in the BBmap suite. One pattern to run them all.
 authors:
   - Silas Kieser
 input:
@@ -21,118 +21,19 @@ notes: |
   Take care that they are valid for the bbtool.
 
   As it is not possible to define 'in' as a keyword, the keyword 'input' is used instead. Allowed aliases are 'sample' and 'reads'.
-  ### Paired input/output files
+
+  **Paired input/output files**
 
   If exactly two files are provides for 'input' the wrapper parses them as in1, in2.
   The same holds for the output keywords 'out', 'outm', 'outu'.
   For all parameters, if more than two files are provided, the wrapper parses them as key=value1,value2,value3... 
 
-  ### Logging
+  **Logging**
+
   The wrapper makes a detailed log of how he parse the parameters. If you want to use the log of a bbtool, 
   e.g. for parsing how many reads where processed, you have to specify a 'stdout', and 'stderr' log file. 
   The wrapper will then write only to the stderr-log file.
 
-  ### List of all the tools in the bbtools suite 39.01
-
-  In theory all of them are sported by this wrapper, but we didn't test them all.
+  In theory all of the tools in the bbmap-suite v39.01 are sported by this wrapper, but we didn't test them all.
   Scripts with different input/output might not be supported by this wrapper.
   If you find one that is not yet supported, please feel free to adjust this wrapper accordingly and include a test case.
-
-  - bbmap.sh
-  - removehuman.sh
-  - removehuman2.sh
-  - mapnt.sh
-  - mapPacBio.sh
-  - bbmapskimmer.sh
-  - bbsplit.sh
-  - bbwrap.sh
-  - pileup.sh
-  - summarizescafstats.sh
-  - filterbycoverage.sh
-  - mergeOTUs.sh
-  - bbest.sh
-  - postfilter.sh
-  - bbduk.sh
-  - bbduk2.sh
-  - seal.sh
-  - summarizeseal.sh
-  - loglog.sh
-  - kmercountexact.sh
-  - bbnorm.sh
-  - ecc.sh
-  - khist.sh
-  - bbcountunique.sh
-  - commonkmers.sh
-  - kmercoverage.sh
-  - callpeaks.sh
-  - tadpole.sh
-  - tadwrapper.sh
-  - kcompress.sh
-  - stats.sh
-  - statswrapper.sh
-  - countgc.sh
-  - fungalrelease.sh
-  - filterbytaxa.sh
-  - gi2taxid.sh
-  - gitable.sh
-  - sortbytaxa.sh
-  - splitbytaxa.sh
-  - taxonomy.sh
-  - taxtree.sh
-  - reducesilva.sh
-  - synthmda.sh
-  - crosscontaminate.sh
-  - decontaminate.sh
-  - crossblock.sh
-  - dedupe.sh
-  - dedupe2.sh
-  - dedupebymapping.sh
-  - clumpify.sh
-  - bbmerge.sh
-  - bbmerge-auto.sh
-  - bbmergegapped.sh
-  - randomreads.sh
-  - bbfakereads.sh
-  - gradesam.sh
-  - samtoroc.sh
-  - addadapters.sh
-  - grademerge.sh
-  - printtime.sh
-  - msa.sh
-  - cutprimers.sh
-  - idmatrix.sh
-  - matrixtocolumns.sh
-  - countbarcodes.sh
-  - filterbarcodes.sh
-  - mergebarcodes.sh
-  - removebadbarcodes.sh
-  - demuxbyname.sh
-  - filterbysequence.sh
-  - filterbyname.sh
-  - filtersubs.sh
-  - getreads.sh
-  - estherfilter.sh
-  - bbqc.sh
-  - rqcfilter.sh
-  - shred.sh
-  - fuse.sh
-  - shuffle.sh
-  - calcmem.sh
-  - textfile.sh
-  - countsharedlines.sh
-  - filterlines.sh
-  - a_sample_mt.sh
-  - bbmask.sh
-  - calctruequality.sh
-  - makechimeras.sh
-  - phylip2fasta.sh
-  - readlength.sh
-  - reformat.sh
-  - removesmartbell.sh
-  - rename.sh
-  - repair.sh
-  - bbsplitpairs.sh
-  - splitnextera.sh
-  - splitsam.sh
-  - testformat.sh
-  - translate6frames.sh

--- a/bio/bbtools/meta.yaml
+++ b/bio/bbtools/meta.yaml
@@ -19,21 +19,14 @@ notes: |
   This wrapper allows to run any of the bbtools. The command is defined by the 'command' parameter, which is required.
   **All keywords in input, output, params are passed as key value pairs to the command!**
   Take care that they are valid for the bbtool.
-
-  As it is not possible to define 'in' as a keyword, the keyword 'input' is used instead. Allowed aliases are 'sample' and 'reads'.
-
-  **Paired input/output files**
-
-  If exactly two files are provides for 'input' the wrapper parses them as in1, in2.
-  The same holds for the output keywords 'out', 'outm', 'outu'.
-  For all parameters, if more than two files are provided, the wrapper parses them as key=value1,value2,value3... 
-
-  **Logging**
-
-  The wrapper makes a detailed log of how he parse the parameters. If you want to use the log of a bbtool, 
-  e.g. for parsing how many reads where processed, you have to specify a 'stdout', and 'stderr' log file. 
-  The wrapper will then write only to the stderr-log file.
-
   In theory all of the tools in the bbmap-suite v39.01 are sported by this wrapper, but we didn't test them all.
   Scripts with different input/output might not be supported by this wrapper.
   If you find one that is not yet supported, please feel free to adjust this wrapper accordingly and include a test case.
+
+  **Paired input/output files**
+
+  As it is not possible to define 'in' as a keyword, the keyword 'input' is used instead. Allowed aliases are 'sample' and 'reads'.
+  If exactly two files are provides for 'input' the wrapper parses them as in1, in2.
+  The same holds for the output keywords 'out', 'outm', 'outu'.
+  For all parameters, if more than two files are provided, the wrapper parses them as key=value1,value2,value3... 
+  The wrapper makes a detailed log of how he parsed the parameters in the log file.

--- a/bio/bbtools/test/Snakefile
+++ b/bio/bbtools/test/Snakefile
@@ -12,11 +12,11 @@ rule loglog:
     input:
         expand("reads/raw/{{sample}}_{fraction}.fastq.gz", fraction=get_fractions()),
     log:
-        stdout="logs/loglog/{sample}.log",
-        stderr="logs/loglog/{sample}.err",  # Captures the error output of the command and the log of the wrapper
+        "logs/loglog/{sample}.log",  # Captures the error output of the command and the log of the wrapper
     params:
         command="loglog.sh",
-        extra="buckets=2048 seed=1234",
+        buckets=2048,
+        seed=1234,
     threads: 2
     resources:
         mem_mb=1024,
@@ -75,7 +75,7 @@ rule tadpole_correct:
         ),
         outd="reads/discarded/{sample}.fastq.gz",
     log:
-        err="logs/correct/{sample}.log",
+        "logs/correct/{sample}.log",
     params:
         command="tadpole.sh",
         mode="correct",
@@ -118,12 +118,11 @@ rule map_reads_with_bbmap:
     output:
         out="mapped/{sample}.bam",
     log:
-        stderr="logs/bbmap/{sample}.log",  # Split stdout and stderr into separate files to have a nice log file
-        stdout="logs/bbmap/{sample}.out",
+        "logs/bbmap/{sample}.log",
     params:
         command="bbmap.sh",
         machineout=True,
-        overwrite=True,  # reccomended
+        overwrite=True,  # recommended
         unpigz=True,
         nodisk=True,  # Don't write a index
     threads: 12
@@ -141,8 +140,7 @@ rule pileup:
         covstats="covstats/{sample}.tsv",
         basecov="basecov/{sample}.tsv",
     log:
-        stderr="logs/pileup/{sample}.log",
-        stdout="logs/pileup/{sample}.out",
+        "logs/pileup/{sample}.log",
     params:
         command="pileup.sh",
         nzo=True,


### PR DESCRIPTION
<!-- Ensure that the PR title follows conventional commit style (<type>: <description>)-->
<!-- Possible types are here: https://github.com/commitizen/conventional-commit-types/blob/master/index.json -->

<!-- Add a description of your PR here-->

The BBmap - generic wrapper appears as only "Generic" Here I renamedit to "BBmap-suite"
BBmap print's everything into stderr, so the effort to split sdout/ stderr is futile.
I adapted the example


### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] I confirm that:

For all wrappers added by this PR, 

* there is a test case which covers any introduced changes,
* `input:` and `output:` file paths in the resulting rule can be changed arbitrarily,
* either the wrapper can only use a single core, or the example rule contains a `threads: x` statement with `x` being a reasonable default,
* rule names in the test case are in [snake_case](https://en.wikipedia.org/wiki/Snake_case) and somehow tell what the rule is about or match the tools purpose or name (e.g., `map_reads` for a step that maps reads),
* all `environment.yaml` specifications follow [the respective best practices](https://stackoverflow.com/a/64594513/2352071),
* the `environment.yaml` pinning has been updated by running `snakedeploy pin-conda-envs environment.yaml` on a linux machine,
* wherever possible, command line arguments are inferred and set automatically (e.g. based on file extensions in `input:` or `output:`),
* all fields of the example rules in the `Snakefile`s and their entries are explained via comments (`input:`/`output:`/`params:` etc.),
* `stderr` and/or `stdout` are logged correctly (`log:`), depending on the wrapped tool,
* temporary files are either written to a unique hidden folder in the working directory, or (better) stored where the Python function `tempfile.gettempdir()` points to (see [here](https://docs.python.org/3/library/tempfile.html#tempfile.gettempdir); this also means that using any Python `tempfile` default behavior works),
* the `meta.yaml` contains a link to the documentation of the respective tool or command,
* `Snakefile`s pass the linting (`snakemake --lint`),
* `Snakefile`s are formatted with [snakefmt](https://github.com/snakemake/snakefmt),
* Python wrapper scripts are formatted with [black](https://black.readthedocs.io).
* Conda environments use a minimal amount of channels, in recommended ordering. E.g. for bioconda, use (conda-forge, bioconda, nodefaults, as conda-forge should have highest priority and defaults channels are usually not needed because most packages are in conda-forge nowadays).
