### PR TITLE
feat: Add configurable protocol support to ensembl reference download

### DIFF
--- a/bio/reference/ensembl-annotation/wrapper.py
+++ b/bio/reference/ensembl-annotation/wrapper.py
@@ -19,6 +19,7 @@ gtf_release = release
 out_fmt = Path(snakemake.output[0]).suffixes
 out_gz = (out_fmt.pop() and True) if out_fmt[-1] == ".gz" else False
 out_fmt = out_fmt.pop().lstrip(".")
+protocol = snakemake.params.get("protocol", "ftp")
 
 
 branch = ""
@@ -48,7 +49,7 @@ else:
     )
 
 
-url = "ftp://ftp.ensembl.org/pub/{branch}release-{release}/{out_fmt}/{species}/{species_cap}.{build}.{gtf_release}.{flavor}{suffix}".format(
+url = "{protocol}://ftp.ensembl.org/pub/{branch}release-{release}/{out_fmt}/{species}/{species_cap}.{build}.{gtf_release}.{flavor}{suffix}".format(
     release=release,
     gtf_release=gtf_release,
     build=build,
@@ -58,6 +59,7 @@ url = "ftp://ftp.ensembl.org/pub/{branch}release-{release}/{out_fmt}/{species}/{
     suffix=suffix,
     flavor=flavor,
     branch=branch,
+    protocol=protocol,
 )
 
 

--- a/bio/reference/ensembl-sequence/wrapper.py
+++ b/bio/reference/ensembl-sequence/wrapper.py
@@ -11,6 +11,7 @@ from snakemake.shell import shell
 species = snakemake.params.species.lower()
 release = int(snakemake.params.release)
 build = snakemake.params.build
+protocol = snakemake.params.get("protocol", "ftp")
 
 branch = ""
 if release >= 81 and build == "GRCh37":
@@ -51,7 +52,7 @@ if chromosome:
         )
 
 spec = spec.format(build=build, release=release)
-url_prefix = f"ftp://ftp.ensembl.org/pub/{branch}release-{release}/fasta/{species}/{datatype}/{species.capitalize()}.{spec}"
+url_prefix = f"{protocol}://ftp.ensembl.org/pub/{branch}release-{release}/fasta/{species}/{datatype}/{species.capitalize()}.{spec}"
 
 success = False
 for suffix in suffixes:

--- a/bio/reference/ensembl-variation/wrapper.py
+++ b/bio/reference/ensembl-variation/wrapper.py
@@ -15,6 +15,7 @@ release = int(snakemake.params.release)
 build = snakemake.params.build
 type = snakemake.params.type
 chromosome = snakemake.params.get("chromosome", "")
+protocol = snakemake.params.get("protocol", "ftp")
 
 
 branch = ""
@@ -63,12 +64,13 @@ else:
 species_filename = species if release >= 91 else species.capitalize()
 
 urls = [
-    "ftp://ftp.ensembl.org/pub/{branch}release-{release}/variation/vcf/{species}/{species_filename}{suffix}.vcf.gz".format(
+    "{protocol}://ftp.ensembl.org/pub/{branch}release-{release}/variation/vcf/{species}/{species_filename}{suffix}.vcf.gz".format(
         release=release,
         species=species,
         suffix=suffix,
         species_filename=species_filename,
         branch=branch,
+        protocol=protocol,
     )
     for suffix in suffixes
 ]

--- a/bio/vep/cache/wrapper.py
+++ b/bio/vep/cache/wrapper.py
@@ -9,6 +9,7 @@ from snakemake.shell import shell
 
 
 extra = snakemake.params.get("extra", "")
+protocol = snakemake.params.get("protocol", "ftp")
 
 try:
     release = int(snakemake.params.release)
@@ -24,7 +25,7 @@ with tempfile.TemporaryDirectory() as tmpdir:
     )
     log = snakemake.log_fmt_shell(stdout=True, stderr=True)
     shell(
-        "curl -L ftp://ftp.ensembl.org/pub/release-{snakemake.params.release}/"
+        "curl -L {protocol}://ftp.ensembl.org/pub/release-{snakemake.params.release}/"
         "variation/{vep_dir}/{cache_tarball} "
         "-o {tmpdir}/{cache_tarball} {log}"
     )


### PR DESCRIPTION
This PR adds support for configurable protocol, ftp, http, or https to ensembl reference data download and vep cache download.

I was evaluating snakemake-wrapper and widely used workflows as a tool for my group to potentially use, and immediately ran into our firewall rules. By default we're able to make outgoing HTTP and HTTPS requests, but not FTP. I can request a change to our firewall, but it also would be helpful if these rules that download reference files were able to download them over HTTP, as ftp.ensembl.org has has been available over HTTP for a very long time.

If you'd prefer, I can create an issue to track this. I also intend to update test cases on these wrappers, and if you are happy with this pattern I could apply it across all wrappers in this repository that are currently hard-coded to make ftp requests.


### QC
<!-- Make sure that you can tick the boxes below. -->

* [ ] I confirm that:

For all wrappers added by this PR, 

* there is a test case which covers any introduced changes,
* `input:` and `output:` file paths in the resulting rule can be changed arbitrarily,
* either the wrapper can only use a single core, or the example rule contains a `threads: x` statement with `x` being a reasonable default,
* rule names in the test case are in [snake_case](https://en.wikipedia.org/wiki/Snake_case) and somehow tell what the rule is about or match the tools purpose or name (e.g., `map_reads` for a step that maps reads),
* all `environment.yaml` specifications follow [the respective best practices](https://stackoverflow.com/a/64594513/2352071),
* the `environment.yaml` pinning has been updated by running `snakedeploy pin-conda-envs environment.yaml` on a linux machine,
* wherever possible, command line arguments are inferred and set automatically (e.g. based on file extensions in `input:` or `output:`),
* all fields of the example rules in the `Snakefile`s and their entries are explained via comments (`input:`/`output:`/`params:` etc.),
* `stderr` and/or `stdout` are logged correctly (`log:`), depending on the wrapped tool,
* temporary files are either written to a unique hidden folder in the working directory, or (better) stored where the Python function `tempfile.gettempdir()` points to (see [here](https://docs.python.org/3/library/tempfile.html#tempfile.gettempdir); this also means that using any Python `tempfile` default behavior works),
* the `meta.yaml` contains a link to the documentation of the respective tool or command,
* `Snakefile`s pass the linting (`snakemake --lint`),
* `Snakefile`s are formatted with [snakefmt](https://github.com/snakemake/snakefmt),
* Python wrapper scripts are formatted with [black](https://black.readthedocs.io).
* Conda environments use a minimal amount of channels, in recommended ordering. E.g. for bioconda, use (conda-forge, bioconda, nodefaults, as conda-forge should have highest priority and defaults channels are usually not needed because most packages are in conda-forge nowadays).
