### PR TITLE
feat: add fgbio sorting to bwa mem

### DIFF
--- a/bio/bwa/mem/environment.linux-64.pin.txt
+++ b/bio/bwa/mem/environment.linux-64.pin.txt
@@ -92,3 +92,4 @@ https://conda.anaconda.org/bioconda/linux-64/samtools-1.19.2-h50ea8bc_0.tar.bz2#
 https://conda.anaconda.org/conda-forge/linux-64/xorg-libxtst-1.2.3-h7f98852_1002.tar.bz2#a220b1a513e19d5cb56c1311d44f12e6
 https://conda.anaconda.org/conda-forge/linux-64/openjdk-20.0.2-hfea2f88_1.conda#3954914fc7a3b0b8f706d243fa532946
 https://conda.anaconda.org/bioconda/noarch/picard-slim-3.1.1-hdfd78af_0.tar.bz2#093941b035b9052072190f1a3cc50cfc
+https://conda.anaconda.org/bioconda/noarch/fgbio-minimal-2.2.1-hdfd78af_0.tar.bz2#baed6bfb163c27c118bbbea2ece183bb

--- a/bio/bwa/mem/environment.yaml
+++ b/bio/bwa/mem/environment.yaml
@@ -4,6 +4,7 @@ channels:
   - nodefaults
 dependencies:
   - bwa =0.7.17
+  - fgbio-minimal =2.2
   - samtools =1.19.2
   - picard-slim =3.1.1
   - snakemake-wrapper-utils =0.6.2

--- a/bio/bwa/mem/meta.yaml
+++ b/bio/bwa/mem/meta.yaml
@@ -13,5 +13,5 @@ output:
   - SAM/BAM/CRAM file
 notes: |
   * The `extra` param allows for additional arguments for bwa-mem.
-  * The `sorting` param allows to enable sorting, and can be either 'none', 'samtools' or 'picard'.
+  * The `sorting` param allows to enable sorting, and can be either 'none', 'samtools', 'fgbio' or 'picard'.
   * The `sort_extra` allows for extra arguments for samtools/picard

--- a/bio/bwa/mem/test/Snakefile_fgbio
+++ b/bio/bwa/mem/test/Snakefile_fgbio
@@ -1,0 +1,16 @@
+rule bwa_mem:
+    input:
+        reads=["reads/{sample}.1.fastq", "reads/{sample}.2.fastq"],
+        idx=multiext("genome", ".amb", ".ann", ".bwt", ".pac", ".sa"),
+    output:
+        "mapped/{sample}.bam",
+    log:
+        "logs/bwa_mem/{sample}.log",
+    params:
+        extra=r"-R '@RG\tID:{sample}\tSM:{sample}'",
+        sort="fgbio",  # Can be 'none', 'samtools' or 'picard'.
+        sort_order="queryname",  # Can be 'queryname' or 'coordinate'.
+        sort_extra="",  # Extra args for samtools/fgbio/picard.
+    threads: 8
+    wrapper:
+        "master/bio/bwa/mem"

--- a/bio/bwa/mem/wrapper.py
+++ b/bio/bwa/mem/wrapper.py
@@ -53,6 +53,11 @@ elif sort == "samtools":
     # Sort alignments using samtools sort.
     pipe_cmd = "samtools sort {samtools_opts} {sort_extra} -T {tmpdir}"
 
+elif sort == "fgbio":
+    if sort_order == "queryname":
+        sort_extra += " -s Queryname"
+    pipe_cmd = "fgbio SortBam -i /dev/stdin -o {snakemake.output[0]} {sort_extra}"
+
 elif sort == "picard":
     # Sort alignments using picard SortSam.
     pipe_cmd = "picard SortSam {java_opts} {sort_extra} --INPUT /dev/stdin --TMP_DIR {tmpdir} --SORT_ORDER {sort_order} --OUTPUT {snakemake.output[0]}"

--- a/test.py
+++ b/test.py
@@ -2145,6 +2145,23 @@ def test_bwa_mem_sort_samtools_write_index():
 
 
 @skip_if_not_modified
+def test_bwa_mem_sort_fgbio():
+    run(
+        "bio/bwa/mem",
+        [
+            "snakemake",
+            "--cores",
+            "1",
+            "mapped/a.bam",
+            "--use-conda",
+            "-F",
+            "-s",
+            "Snakefile_fgbio",
+        ],
+    )
+
+
+@skip_if_not_modified
 def test_bwa_mem_sort_picard():
     run(
         "bio/bwa/mem",


### PR DESCRIPTION
<!-- Ensure that the PR title follows conventional commit style (<type>: <description>)-->
<!-- Possible types are here: https://github.com/commitizen/conventional-commit-types/blob/master/index.json -->

In some cases sorting reads by `fgbio SortBam` is required as queryname sorting performed by `samtools` results in a different sorting order (see https://github.com/snakemake-workflows/dna-seq-varlociraptor/pull/296). I therefore propose to add `fgbio-minimal` as an addition to the wrapper.  

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] I confirm that:

For all wrappers added by this PR, 

* there is a test case which covers any introduced changes,
* `input:` and `output:` file paths in the resulting rule can be changed arbitrarily,
* either the wrapper can only use a single core, or the example rule contains a `threads: x` statement with `x` being a reasonable default,
* rule names in the test case are in [snake_case](https://en.wikipedia.org/wiki/Snake_case) and somehow tell what the rule is about or match the tools purpose or name (e.g., `map_reads` for a step that maps reads),
* all `environment.yaml` specifications follow [the respective best practices](https://stackoverflow.com/a/64594513/2352071),
* the `environment.yaml` pinning has been updated by running `snakedeploy pin-conda-envs environment.yaml` on a linux machine,
* wherever possible, command line arguments are inferred and set automatically (e.g. based on file extensions in `input:` or `output:`),
* all fields of the example rules in the `Snakefile`s and their entries are explained via comments (`input:`/`output:`/`params:` etc.),
* `stderr` and/or `stdout` are logged correctly (`log:`), depending on the wrapped tool,
* temporary files are either written to a unique hidden folder in the working directory, or (better) stored where the Python function `tempfile.gettempdir()` points to (see [here](https://docs.python.org/3/library/tempfile.html#tempfile.gettempdir); this also means that using any Python `tempfile` default behavior works),
* the `meta.yaml` contains a link to the documentation of the respective tool or command,
* `Snakefile`s pass the linting (`snakemake --lint`),
* `Snakefile`s are formatted with [snakefmt](https://github.com/snakemake/snakefmt),
* Python wrapper scripts are formatted with [black](https://black.readthedocs.io).
* Conda environments use a minimal amount of channels, in recommended ordering. E.g. for bioconda, use (conda-forge, bioconda, nodefaults, as conda-forge should have highest priority and defaults channels are usually not needed because most packages are in conda-forge nowadays).
