### PR TITLE
fix: allow input access in config rendering for datavzrd

### DIFF
--- a/utils/datavzrd/test/Snakefile
+++ b/utils/datavzrd/test/Snakefile
@@ -5,7 +5,7 @@ rule all:  # [hide]
 
 rule datavzrd:
     input:
-        # the config file may be a yte template, with access to params and wildcards
+        # the config file may be a yte template, with access to input, params and wildcards
         # analogous to Snakemake's generic template support:
         # https://snakemake.readthedocs.io/en/stable/snakefiles/rules.html#template-rendering-integration
         # For template processing, __use_yte__: true has to be stated in the config file

--- a/utils/datavzrd/wrapper.py
+++ b/utils/datavzrd/wrapper.py
@@ -18,7 +18,11 @@ with tempfile.NamedTemporaryFile(mode="w") as processed, open(
     process_yaml(
         f,
         outfile=processed,
-        variables={"params": snakemake.params, "wildcards": snakemake.wildcards},
+        variables={
+            "params": snakemake.params,
+            "wildcards": snakemake.wildcards,
+            "input": snakemake.input,
+        },
         require_use_yte=True,
     )
     processed.flush()


### PR DESCRIPTION
<!-- Ensure that the PR title follows conventional commit style (<type>: <description>)-->
<!-- Possible types are here: https://github.com/commitizen/conventional-commit-types/blob/master/index.json -->

<!-- Add a description of your PR here-->

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] I confirm that:

For all wrappers added by this PR, 

* there is a test case which covers any introduced changes,
* `input:` and `output:` file paths in the resulting rule can be changed arbitrarily,
* either the wrapper can only use a single core, or the example rule contains a `threads: x` statement with `x` being a reasonable default,
* rule names in the test case are in [snake_case](https://en.wikipedia.org/wiki/Snake_case) and somehow tell what the rule is about or match the tools purpose or name (e.g., `map_reads` for a step that maps reads),
* all `environment.yaml` specifications follow [the respective best practices](https://stackoverflow.com/a/64594513/2352071),
* the `environment.yaml` pinning has been updated by running `snakedeploy pin-conda-envs environment.yaml` on a linux machine,
* wherever possible, command line arguments are inferred and set automatically (e.g. based on file extensions in `input:` or `output:`),
* all fields of the example rules in the `Snakefile`s and their entries are explained via comments (`input:`/`output:`/`params:` etc.),
* `stderr` and/or `stdout` are logged correctly (`log:`), depending on the wrapped tool,
* temporary files are either written to a unique hidden folder in the working directory, or (better) stored where the Python function `tempfile.gettempdir()` points to (see [here](https://docs.python.org/3/library/tempfile.html#tempfile.gettempdir); this also means that using any Python `tempfile` default behavior works),
* the `meta.yaml` contains a link to the documentation of the respective tool or command,
* `Snakefile`s pass the linting (`snakemake --lint`),
* `Snakefile`s are formatted with [snakefmt](https://github.com/snakemake/snakefmt),
* Python wrapper scripts are formatted with [black](https://black.readthedocs.io).
* Conda environments use a minimal amount of channels, in recommended ordering. E.g. for bioconda, use (conda-forge, bioconda, nodefaults, as conda-forge should have highest priority and defaults channels are usually not needed because most packages are in conda-forge nowadays).
