### PR TITLE
fix: bamcoverage without effective genome size

### DIFF
--- a/bio/deeptools/bamcoverage/test/Snakefile
+++ b/bio/deeptools/bamcoverage/test/Snakefile
@@ -28,3 +28,15 @@ rule test_deeptools_bamcoverage_default_eff_len:
         "logs/coverage_efault_eff_len.log",
     wrapper:
         "master/bio/deeptools/bamcoverage"
+
+
+rule test_deeptools_bamcoverage_no_params:
+    input:
+        bam="a.sorted.bam",
+        bai="a.sorted.bam.bai",
+    output:
+        "a.coverage_no_params.bw",
+    log:
+        "logs/coverage.log",
+    wrapper:
+        "master/bio/deeptools/bamcoverage"

--- a/bio/deeptools/bamcoverage/wrapper.py
+++ b/bio/deeptools/bamcoverage/wrapper.py
@@ -100,7 +100,7 @@ default_effective_genome_size = {
     },
 }
 
-effective_genome_size = snakemake.params.get("effective_genome_size")
+effective_genome_size = snakemake.params.get("effective_genome_size", "")
 if not effective_genome_size:
     genome = snakemake.params.get("genome")
     read_length = snakemake.params.get("read_length")

--- a/test.py
+++ b/test.py
@@ -2871,6 +2871,21 @@ def test_deeptools_bamcoverage_eff():
 
 
 @skip_if_not_modified
+def test_deeptools_bamcoverage_no_params():
+    run(
+        "bio/deeptools/bamcoverage",
+        [
+            "snakemake",
+            "--cores",
+            "1",
+            "a.coverage_no_params.bw",
+            "--use-conda",
+            "-F",
+        ],
+    )
+
+
+@skip_if_not_modified
 def test_deeptools_alignmentsieve():
     run(
         "bio/deeptools/alignmentsieve",


### PR DESCRIPTION
Running deeptools bamcoverage without an effective genome size did not work previously. This PR fixes that issue.

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] I confirm that:

For all wrappers added by this PR, 

* there is a test case which covers any introduced changes,
* `input:` and `output:` file paths in the resulting rule can be changed arbitrarily,
* either the wrapper can only use a single core, or the example rule contains a `threads: x` statement with `x` being a reasonable default,
* rule names in the test case are in [snake_case](https://en.wikipedia.org/wiki/Snake_case) and somehow tell what the rule is about or match the tools purpose or name (e.g., `map_reads` for a step that maps reads),
* all `environment.yaml` specifications follow [the respective best practices](https://stackoverflow.com/a/64594513/2352071),
* the `environment.yaml` pinning has been updated by running `snakedeploy pin-conda-envs environment.yaml` on a linux machine,
* wherever possible, command line arguments are inferred and set automatically (e.g. based on file extensions in `input:` or `output:`),
* all fields of the example rules in the `Snakefile`s and their entries are explained via comments (`input:`/`output:`/`params:` etc.),
* `stderr` and/or `stdout` are logged correctly (`log:`), depending on the wrapped tool,
* temporary files are either written to a unique hidden folder in the working directory, or (better) stored where the Python function `tempfile.gettempdir()` points to (see [here](https://docs.python.org/3/library/tempfile.html#tempfile.gettempdir); this also means that using any Python `tempfile` default behavior works),
* the `meta.yaml` contains a link to the documentation of the respective tool or command,
* `Snakefile`s pass the linting (`snakemake --lint`),
* `Snakefile`s are formatted with [snakefmt](https://github.com/snakemake/snakefmt),
* Python wrapper scripts are formatted with [black](https://black.readthedocs.io).
* Conda environments use a minimal amount of channels, in recommended ordering. E.g. for bioconda, use (conda-forge, bioconda, nodefaults, as conda-forge should have highest priority and defaults channels are usually not needed because most packages are in conda-forge nowadays).
