### PR TITLE
Ensembl reference collections

### DIFF
--- a/bio/reference/ensembl-annotation/meta.yaml
+++ b/bio/reference/ensembl-annotation/meta.yaml
@@ -6,3 +6,5 @@ output:
   - Ensemble GTF or GFF3 anotation file
 params:
   - url: URL from where to download cache data (optional; by default is ``ftp://ftp.ensembl.org/pub``)
+  - branch: branch of ftp server to download cache data if required (optional; e.g. "plants")
+  - collection: collection of ftp server to download cache data if required (optional; e.g. "bacteria_0_collection")

--- a/bio/reference/ensembl-annotation/test/Snakefile
+++ b/bio/reference/ensembl-annotation/test/Snakefile
@@ -6,7 +6,6 @@ rule get_annotation:
         release="105",
         build="GRCh37",
         flavor="",  # optional, e.g. chr_patch_hapl_scaff, see Ensembl FTP.
-        # branch="plants",  # optional: specify branch
     log:
         "logs/get_annotation.log",
     cache: "omit-software"  # save space and time with between workflow caching (see docs)
@@ -22,12 +21,25 @@ rule get_annotation_gz:
         release="105",
         build="GRCh37",
         flavor="",  # optional, e.g. chr_patch_hapl_scaff, see Ensembl FTP.
-        # branch="plants" or "bacteria",  # optional: specify branch
-        # collection="bacteria_0_collection", # optional: specify collection
     log:
         "logs/get_annotation.log",
+    cache: "omit-software"  # save space and time with between workflow caching (see docs)
+    wrapper:
+        "master/bio/reference/ensembl-annotation"
+
+
+rule get_off_branch_annotation:
+    output:
+        "refs/annotation.gtf",
     params:
-        url="http://ftp.ensembl.org/pub",
+        species="bacillus_subtilis_subsp_subtilis_str_168_gca_000009045",
+        release="59", # note latest release varies with url
+        build="ASM904v1",
+        branch="bacteria", # optional for off branch genomes
+        url="ftp://ftp.ensemblgenomes.org/pub/", # optional set ftp server source
+        collection="bacteria_0_collection", # optional set collection source for genome
+    log:
+        "logs/get_annotation.log",
     cache: "omit-software"  # save space and time with between workflow caching (see docs)
     wrapper:
         "master/bio/reference/ensembl-annotation"

--- a/bio/reference/ensembl-annotation/test/Snakefile
+++ b/bio/reference/ensembl-annotation/test/Snakefile
@@ -22,7 +22,8 @@ rule get_annotation_gz:
         release="105",
         build="GRCh37",
         flavor="",  # optional, e.g. chr_patch_hapl_scaff, see Ensembl FTP.
-        # branch="plants",  # optional: specify branch
+        # branch="plants" or "bacteria",  # optional: specify branch
+        # collection="bacteria_0_collection", # optional: specify collection
     log:
         "logs/get_annotation.log",
     params:

--- a/bio/reference/ensembl-annotation/test/Snakefile
+++ b/bio/reference/ensembl-annotation/test/Snakefile
@@ -30,7 +30,7 @@ rule get_annotation_gz:
 
 rule get_off_branch_annotation:
     output:
-        "refs/annotation.gtf",
+        "refs/off_branch_annotation.gtf",
     params:
         species="bacillus_subtilis_subsp_subtilis_str_168_gca_000009045",
         release="59", # note latest release varies with url

--- a/bio/reference/ensembl-annotation/wrapper.py
+++ b/bio/reference/ensembl-annotation/wrapper.py
@@ -31,6 +31,9 @@ if build == "GRCh37":
 elif snakemake.params.get("branch"):
     branch = snakemake.params.branch + "/"
 
+collection = ""
+if snakemake.params.get("collection"):
+    collection = snakemake.params.collection + "/"
 
 flavor = snakemake.params.get("flavor", "")
 if flavor:
@@ -49,7 +52,7 @@ else:
 
 
 url = snakemake.params.get("url", "ftp://ftp.ensembl.org/pub")
-url = f"{url}/{branch}release-{release}/{out_fmt}/{species}/{species.capitalize()}.{build}.{gtf_release}.{flavor}{suffix}"
+url = f"{url}/{branch}release-{release}/{out_fmt}/{collection}{species}/{species.capitalize()}.{build}.{gtf_release}.{flavor}{suffix}"
 
 
 try:

--- a/bio/reference/ensembl-sequence/meta.yaml
+++ b/bio/reference/ensembl-sequence/meta.yaml
@@ -6,3 +6,5 @@ output:
   - fasta file
 params:
   - url: URL from where to download cache data (optional; by default is ``ftp://ftp.ensembl.org/pub``)
+  - branch: branch of ftp server to download cache data if required (optional; e.g. "plants")
+  - collection: collection of ftp server to download cache data if required (optional; e.g. "bacteria_0_collection")

--- a/bio/reference/ensembl-sequence/test/Snakefile
+++ b/bio/reference/ensembl-sequence/test/Snakefile
@@ -22,11 +22,8 @@ rule get_single_chromosome:
         build="R64-1-1",
         release="101",
         chromosome=["II"],  # optional: restrict to one or multiple chromosomes, for multiple see below
-        # branch="plants",  # optional: specify branch
     log:
         "logs/get_genome.log",
-    params:
-        url="http://ftp.ensembl.org/pub",
     cache: "omit-software"  # save space and time with between workflow caching (see docs)
     wrapper:
         "master/bio/reference/ensembl-sequence"
@@ -40,8 +37,24 @@ rule get_multiple_chromosome:
         build="R64-1-1",
         release="101",
         chromosome=["I", "II"],  # optional: restrict to one or multiple chromosomes
-        # branch="bacteria",  # optional: specify branch
-        # collection="bacteria_0_collection", # optional: specify collection
+    log:
+        "logs/get_genome.log",
+    cache: "omit-software"  # save space and time with between workflow caching (see docs)
+    wrapper:
+        "master/bio/reference/ensembl-sequence"
+
+
+rule get_off_branch_genome:
+    output:
+        "refs/genome.fasta",
+    params:
+        species="bacillus_subtilis_subsp_subtilis_str_168_gca_000009045",
+        datatype="dna",
+        build="ASM904v1",
+        release="59", # note latest release varies with url
+        branch="bacteria", # optional for off branch genomes
+        url="ftp://ftp.ensemblgenomes.org/pub/", # optional set ftp server source
+        collection="bacteria_0_collection", # optional set collection source for genome
     log:
         "logs/get_genome.log",
     cache: "omit-software"  # save space and time with between workflow caching (see docs)

--- a/bio/reference/ensembl-sequence/test/Snakefile
+++ b/bio/reference/ensembl-sequence/test/Snakefile
@@ -46,7 +46,7 @@ rule get_multiple_chromosome:
 
 rule get_off_branch_genome:
     output:
-        "refs/genome.fasta",
+        "refs/off_branch_genome.fasta",
     params:
         species="bacillus_subtilis_subsp_subtilis_str_168_gca_000009045",
         datatype="dna",

--- a/bio/reference/ensembl-sequence/test/Snakefile
+++ b/bio/reference/ensembl-sequence/test/Snakefile
@@ -40,7 +40,8 @@ rule get_multiple_chromosome:
         build="R64-1-1",
         release="101",
         chromosome=["I", "II"],  # optional: restrict to one or multiple chromosomes
-        # branch="plants",  # optional: specify branch
+        # branch="bacteria",  # optional: specify branch
+        # collection="bacteria_0_collection", # optional: specify collection
     log:
         "logs/get_genome.log",
     cache: "omit-software"  # save space and time with between workflow caching (see docs)

--- a/bio/reference/ensembl-sequence/wrapper.py
+++ b/bio/reference/ensembl-sequence/wrapper.py
@@ -25,7 +25,7 @@ if snakemake.params.get("collection"):
 
 log = snakemake.log_fmt_shell(stdout=False, stderr=True)
 
-if branch=="" or branch == "grch37/":
+if branch == "" or branch == "grch37/":
     spec = ("{build}" if int(release) > 75 else "{build}.{release}").format(
         build=build, release=release
     )

--- a/bio/reference/ensembl-sequence/wrapper.py
+++ b/bio/reference/ensembl-sequence/wrapper.py
@@ -19,11 +19,20 @@ if release >= 81 and build == "GRCh37":
 elif snakemake.params.get("branch"):
     branch = snakemake.params.branch + "/"
 
+collection = ""
+if snakemake.params.get("collection"):
+    collection = snakemake.params.collection + "/"
+
 log = snakemake.log_fmt_shell(stdout=False, stderr=True)
 
-spec = ("{build}" if int(release) > 75 else "{build}.{release}").format(
-    build=build, release=release
-)
+if branch=="" or branch == "grch37/":
+    spec = ("{build}" if int(release) > 75 else "{build}.{release}").format(
+        build=build, release=release
+    )
+else:
+    spec = ("{build}" if int(release) > 30 else "{build}.{release}").format(
+        build=build, release=release
+    )
 
 suffixes = ""
 datatype = snakemake.params.get("datatype", "")
@@ -52,7 +61,7 @@ if chromosome:
 
 url = snakemake.params.get("url", "ftp://ftp.ensembl.org/pub")
 spec = spec.format(build=build, release=release)
-url_prefix = f"{url}/{branch}release-{release}/fasta/{species}/{datatype}/{species.capitalize()}.{spec}"
+url_prefix = f"{url}/{branch}release-{release}/fasta/{collection}{species}/{datatype}/{species.capitalize()}.{spec}"
 
 success = False
 for suffix in suffixes:

--- a/test.py
+++ b/test.py
@@ -5565,6 +5565,14 @@ def test_ensembl_sequence_chromosomes():
 
 
 @skip_if_not_modified
+def test_ensembl_sequence_off_branch():
+    run(
+        "bio/reference/ensembl-sequence",
+        ["snakemake", "--cores", "1", "refs/off_branch_genome.fasta", "--use-conda", "-F"],
+    )
+
+
+@skip_if_not_modified
 def test_ensembl_sequence_chromosome_old_release():
     run(
         "bio/reference/ensembl-sequence",
@@ -5594,6 +5602,14 @@ def test_ensembl_annotation_gtf_gz():
     run(
         "bio/reference/ensembl-annotation",
         ["snakemake", "--cores", "1", "refs/annotation.gtf.gz", "--use-conda", "-F"],
+    )
+
+
+@skip_if_not_modified
+def test_ensembl_off_branch_annotation_gtf():
+    run(
+        "bio/reference/ensembl-annotation",
+        ["snakemake", "--cores", "1", "refs/off_branch_annotation.gtf", "--use-conda", "-F"],
     )
 
 


### PR DESCRIPTION
<!-- Ensure that the PR title follows conventional commit style (<type>: <description>)-->
# feat: collections optional reference parameter(i.e. bacterial references)
<!-- Possible types are here: https://github.com/commitizen/conventional-commit-types/blob/master/index.json -->

<!-- Add a description of your PR here-->
This PR builds on the recently pushed (https://github.com/snakemake/snakemake-wrappers/pull/2928) where branches and specific url can be defined as parameters. The previous method  was unable to find data from [bacteria ensembl](https://bacteria.ensembl.org/index.html) due to data in it containing one more folder level. There is also a fix for the spec variable in in ensembl-sequence where the release version would not match for branches other than the default.

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] I confirm that:

For all wrappers added by this PR, 

* there is a test case which covers any introduced changes,
* `input:` and `output:` file paths in the resulting rule can be changed arbitrarily,
* either the wrapper can only use a single core, or the example rule contains a `threads: x` statement with `x` being a reasonable default,
* rule names in the test case are in [snake_case](https://en.wikipedia.org/wiki/Snake_case) and somehow tell what the rule is about or match the tools purpose or name (e.g., `map_reads` for a step that maps reads),
* all `environment.yaml` specifications follow [the respective best practices](https://stackoverflow.com/a/64594513/2352071),
* the `environment.yaml` pinning has been updated by running `snakedeploy pin-conda-envs environment.yaml` on a linux machine,
* wherever possible, command line arguments are inferred and set automatically (e.g. based on file extensions in `input:` or `output:`),
* all fields of the example rules in the `Snakefile`s and their entries are explained via comments (`input:`/`output:`/`params:` etc.),
* `stderr` and/or `stdout` are logged correctly (`log:`), depending on the wrapped tool,
* temporary files are either written to a unique hidden folder in the working directory, or (better) stored where the Python function `tempfile.gettempdir()` points to (see [here](https://docs.python.org/3/library/tempfile.html#tempfile.gettempdir); this also means that using any Python `tempfile` default behavior works),
* the `meta.yaml` contains a link to the documentation of the respective tool or command,
* `Snakefile`s pass the linting (`snakemake --lint`),
* `Snakefile`s are formatted with [snakefmt](https://github.com/snakemake/snakefmt),
* Python wrapper scripts are formatted with [black](https://black.readthedocs.io).
* Conda environments use a minimal amount of channels, in recommended ordering. E.g. for bioconda, use (conda-forge, bioconda, nodefaults, as conda-forge should have highest priority and defaults channels are usually not needed because most packages are in conda-forge nowadays).
