### PR TITLE
feat: add new ensembl-regulation wrapper to systematically download Ensembl regulatory_features

### DIFF
--- a/bio/reference/ensembl-regulation/environment.linux-64.pin.txt
+++ b/bio/reference/ensembl-regulation/environment.linux-64.pin.txt
@@ -1,0 +1,22 @@
+# This file may be used to create an environment using:
+# $ conda create --name <env> --file <this file>
+# platform: linux-64
+@EXPLICIT
+https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2#d7c89558ba9fa0495403155b64376d81
+https://conda.anaconda.org/conda-forge/linux-64/ca-certificates-2024.6.2-hbcca054_0.conda#847c3c2905cc467cea52c24f9cfa8080
+https://conda.anaconda.org/conda-forge/linux-64/libgomp-13.2.0-h77fa898_13.conda#d370d1855cca14dff6a819c90c77497c
+https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-2_gnu.tar.bz2#73aaf86a425cc6e73fcf236a5a46396d
+https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-13.2.0-h77fa898_13.conda#9358cdd61ef0d600d2a0dde2d53b006c
+https://conda.anaconda.org/conda-forge/linux-64/gettext-tools-0.22.5-h59595ed_2.conda#985f2f453fb72408d6b6f1be0f324033
+https://conda.anaconda.org/conda-forge/linux-64/libgettextpo-0.22.5-h59595ed_2.conda#172bcc51059416e7ce99e7b528cede83
+https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-13.2.0-hc0a3c3a_13.conda#1053882642ed5bbc799e1e866ff86826
+https://conda.anaconda.org/conda-forge/linux-64/libunistring-0.9.10-h7f98852_0.tar.bz2#7245a044b4a1980ed83196176b78b73a
+https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.1-h4ab18f5_1.conda#57d7dc60e9325e3de37ff8dffd18e814
+https://conda.anaconda.org/conda-forge/linux-64/openssl-3.3.1-h4ab18f5_0.conda#a41fa0e391cc9e0d6b78ac69ca047a6c
+https://conda.anaconda.org/conda-forge/linux-64/libasprintf-0.22.5-h661eb56_2.conda#dd197c968bf9760bba0031888d431ede
+https://conda.anaconda.org/conda-forge/linux-64/libgettextpo-devel-0.22.5-h59595ed_2.conda#b63d9b6da3653179a278077f0de20014
+https://conda.anaconda.org/conda-forge/linux-64/zlib-1.3.1-h4ab18f5_1.conda#9653f1bf3766164d0e65fa723cabbc54
+https://conda.anaconda.org/conda-forge/linux-64/libasprintf-devel-0.22.5-h661eb56_2.conda#02e41ab5834dcdcc8590cf29d9526f50
+https://conda.anaconda.org/conda-forge/linux-64/gettext-0.22.5-h59595ed_2.conda#219ba82e95d7614cf7140d2a4afc0926
+https://conda.anaconda.org/conda-forge/linux-64/libidn2-2.3.7-hd590300_0.conda#2b7b0d827c6447cc1d85dc06d5b5de46
+https://conda.anaconda.org/conda-forge/linux-64/wget-1.21.4-hda4d442_0.conda#361e96b664eac64a33c20dfd11affbff

--- a/bio/reference/ensembl-regulation/environment.yaml
+++ b/bio/reference/ensembl-regulation/environment.yaml
@@ -1,0 +1,5 @@
+channels:
+  - conda-forge
+  - nodefaults
+dependencies:
+  - wget =1

--- a/bio/reference/ensembl-regulation/meta.yaml
+++ b/bio/reference/ensembl-regulation/meta.yaml
@@ -1,0 +1,15 @@
+name: ensembl-regulation
+description: >
+  Download annotation of regulatory features (e.g. promotors) for genomes from ENSEMBL FTP servers, and store them in a single .gff or .gff3 file.
+  The output file can be gzipped, which will save space and avoid unzipping during the download.
+  From release 112 onwards, gff3 files are available and the wrapper will require this file extension.
+  For older releases (>=87), only gff files with a different file path are available and the wrapper will require this extension.
+  For the available species (human and mouse as of writing), see the "Regulation (GFF)" column on the FTP download site:
+  ``https://www.ensembl.org/info/data/ftp/index.html``
+authors:
+  - Johannes Köster
+  - David Lähnemann
+output:
+  - Ensembl GFF anotation file for regulatory features.
+params:
+  - url: Base URL from where to download cache data (optional; by default is ``ftp://ftp.ensembl.org/pub``).

--- a/bio/reference/ensembl-regulation/test/Snakefile
+++ b/bio/reference/ensembl-regulation/test/Snakefile
@@ -1,13 +1,13 @@
 rule get_regulatory_features_gff3_gz:
     output:
-        "resources/regulatory_features.gff3.gz",  # presence of .gz determines if downloaded is kept compressed
+        "resources/regulatory_features.gff3.gz", # presence of .gz determines if downloaded is kept compressed
     params:
-        species="homo_sapiens",  # for available species, release and build, search via "Regulation (GFF)" column at: https://www.ensembl.org/info/data/ftp/index.html
+        species="homo_sapiens", # for available species, release and build, search via "Regulation (GFF)" column at: https://www.ensembl.org/info/data/ftp/index.html
         release="112",
         build="GRCh38",
     log:
         "logs/get_regulatory_features.log",
-    cache: "omit-software"  # save space and time with between workflow caching (see docs)
+    cache: "omit-software"  # save space and time with between workflow caching (see docs); for data downloads, software does not affect the resulting data
     wrapper:
         "master/bio/reference/ensembl-regulation"
 
@@ -21,7 +21,7 @@ rule get_regulatory_features_grch37_gff:
         build="GRCh37",
     log:
         "logs/get_regulatory_features.log",
-    cache: "omit-software"  # save space and time with between workflow caching (see docs)
+    cache: "omit-software"  # save space and time with between workflow caching (see docs); for data downloads, software does not affect the resulting data
     wrapper:
         "master/bio/reference/ensembl-regulation"
 
@@ -35,6 +35,6 @@ rule get_regulatory_features_mouse_gff_gz:
         build="GRCm39",
     log:
         "logs/get_regulatory_features.log",
-    cache: "omit-software"  # save space and time with between workflow caching (see docs)
+    cache: "omit-software"  # save space and time with between workflow caching (see docs); for data downloads, software does not affect the resulting data
     wrapper:
         "master/bio/reference/ensembl-regulation"

--- a/bio/reference/ensembl-regulation/test/Snakefile
+++ b/bio/reference/ensembl-regulation/test/Snakefile
@@ -1,8 +1,8 @@
 rule get_regulatory_features_gff3_gz:
     output:
-        "resources/regulatory_features.gff3.gz", # presence of .gz determines if downloaded is kept compressed
+        "resources/regulatory_features.gff3.gz",  # presence of .gz determines if downloaded is kept compressed
     params:
-        species="homo_sapiens", # for available species, release and build, search via "Regulation (GFF)" column at: https://www.ensembl.org/info/data/ftp/index.html
+        species="homo_sapiens",  # for available species, release and build, search via "Regulation (GFF)" column at: https://www.ensembl.org/info/data/ftp/index.html
         release="112",
         build="GRCh38",
     log:

--- a/bio/reference/ensembl-regulation/test/Snakefile
+++ b/bio/reference/ensembl-regulation/test/Snakefile
@@ -1,0 +1,40 @@
+rule get_regulatory_features_gff3_gz:
+    output:
+        "resources/regulatory_features.gff3.gz",
+    params:
+        species="homo_sapiens",
+        release="112",
+        build="GRCh38",
+    log:
+        "logs/get_regulatory_features.log",
+    cache: "omit-software"  # save space and time with between workflow caching (see docs)
+    wrapper:
+        "master/bio/reference/ensembl-regulation"
+
+
+rule get_regulatory_features_grch37_gff:
+    output:
+        "resources/regulatory_features.gff",
+    params:
+        species="homo_sapiens",
+        release="112",
+        build="GRCh37",
+    log:
+        "logs/get_regulatory_features.log",
+    cache: "omit-software"  # save space and time with between workflow caching (see docs)
+    wrapper:
+        "master/bio/reference/ensembl-regulation"
+
+
+rule get_regulatory_features_mouse_gff_gz:
+    output:
+        "resources/regulatory_features.mouse.gff.gz",
+    params:
+        species="mus_musculus",
+        release="98",
+        build="GRCm39",
+    log:
+        "logs/get_regulatory_features.log",
+    cache: "omit-software"  # save space and time with between workflow caching (see docs)
+    wrapper:
+        "master/bio/reference/ensembl-regulation"

--- a/bio/reference/ensembl-regulation/test/Snakefile
+++ b/bio/reference/ensembl-regulation/test/Snakefile
@@ -1,8 +1,8 @@
 rule get_regulatory_features_gff3_gz:
     output:
-        "resources/regulatory_features.gff3.gz",
+        "resources/regulatory_features.gff3.gz", # presence of .gz determines if downloaded is kept compressed
     params:
-        species="homo_sapiens",
+        species="homo_sapiens", # for available species, release and build, search via "Regulation (GFF)" column at: https://www.ensembl.org/info/data/ftp/index.html
         release="112",
         build="GRCh38",
     log:

--- a/bio/reference/ensembl-regulation/wrapper.py
+++ b/bio/reference/ensembl-regulation/wrapper.py
@@ -1,0 +1,77 @@
+__author__ = "Johannes Köster"
+__copyright__ = "Copyright 2024, Johannes Köster"
+__email__ = "johannes.koester@uni-due.de"
+__license__ = "MIT"
+
+import subprocess
+import sys
+from pathlib import Path
+from snakemake.shell import shell
+
+
+log = snakemake.log_fmt_shell(stdout=False, stderr=True)
+
+
+species = snakemake.params.species.lower()
+build = snakemake.params.build
+release = int(snakemake.params.release)
+gtf_release = release
+out_fmt = Path(snakemake.output[0]).suffixes
+out_gz = (out_fmt.pop() and True) if out_fmt[-1] == ".gz" else False
+out_fmt = out_fmt.pop().lstrip(".")
+
+if release < 87:
+    raise ValueError(
+        "Comprehensive GFF files are only available for release 87 or newer."
+    )
+
+if build == "GRCh37":
+    grch37 = "grch37/"
+else:
+    grch37 = ""
+
+
+suffix = ""
+if out_fmt == "gff":
+    suffix = "gff.gz"
+elif out_fmt == "gff3":
+    suffix = "gff3.gz"
+else:
+    raise ValueError(
+        "Invalid format specified."
+        "Only 'gff[.gz]' (for releases before 112, and for build GRCh37) and"
+        "'gff3[.gz]' (for any release from 112 onwards) are currently supported."
+    )
+
+
+url = snakemake.params.get("url", "ftp://ftp.ensembl.org/pub")
+if release < 112 or build == "GRCh37":
+    if out_fmt != "gff":
+        raise ValueError(
+            f"Invalid suffix for output file '{snakemake.output[0]}'."
+            "For releases older than 112 and for human build GRCh37, only .gff or .gff.gz are valid."
+        )
+    url = f"{url}/{grch37}release-{release}/regulation/{species}/{species}.{build}.Regulatory_Build.regulatory_features.*.{suffix}"
+else:
+    if out_fmt != "gff3":
+        raise ValueError(
+            f"Invalid suffix for output file '{snakemake.output[0]}'."
+            "For (non-GRCh37) releases from 112 onwards, only .gff3 or .gff3.gz are valid."
+        )
+    url = f"{url}/release-{release}/regulation/{species}/{build}/annotation/{species.capitalize()}.{build}.regulatory_features.v{release}.{suffix}"
+
+try:
+    if out_gz:
+        shell('wget "{url}" -o {snakemake.output[0]} {log}')
+    else:
+        shell('(wget "{url}" -O - | gzip -d > {snakemake.output[0]}) {log}')
+except subprocess.CalledProcessError as e:
+    if snakemake.log:
+        sys.stderr = open(snakemake.log[0], "a")
+    print(
+        "Unable to download regulatory feature data from Ensembl. "
+        "Did you check that this combination of species, build, and release is actually provided?"
+        "A good entry point for a search is: https://www.ensembl.org/info/data/ftp/index.html",
+        file=sys.stderr,
+    )
+    exit(1)

--- a/test.py
+++ b/test.py
@@ -5599,6 +5599,30 @@ def test_ensembl_annotation_gtf_gz():
 
 
 @skip_if_not_modified
+def test_ensembl_regulatory_gff3_gz():
+    run(
+        "bio/reference/ensembl-regulation",
+        ["snakemake", "--cores", "1", "resources/regulatory_features.gff3.gz", "--use-conda", "-F"],
+    )
+
+
+@skip_if_not_modified
+def test_ensembl_regulatory_features_grch37_gff():
+    run(
+        "bio/reference/ensembl-regulation",
+        ["snakemake", "--cores", "1", "resources/regulatory_features.gff", "--use-conda", "-F"],
+    )
+
+
+@skip_if_not_modified
+def test_ensembl_regulatory_features_mouse_gff_gz():
+    run(
+        "bio/reference/ensembl-regulation",
+        ["snakemake", "--cores", "1", "resources/regulatory_features.mouse.gff.gz", "--use-conda", "-F"],
+    )
+
+
+@skip_if_not_modified
 def test_ensembl_variation():
     run(
         "bio/reference/ensembl-variation",


### PR DESCRIPTION
<!-- Ensure that the PR title follows conventional commit style (<type>: <description>)-->
<!-- Possible types are here: https://github.com/commitizen/conventional-commit-types/blob/master/index.json -->

<!-- Add a description of your PR here-->

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] I confirm that:

For all wrappers added by this PR, 

* there is a test case which covers any introduced changes,
* `input:` and `output:` file paths in the resulting rule can be changed arbitrarily,
* either the wrapper can only use a single core, or the example rule contains a `threads: x` statement with `x` being a reasonable default,
* rule names in the test case are in [snake_case](https://en.wikipedia.org/wiki/Snake_case) and somehow tell what the rule is about or match the tools purpose or name (e.g., `map_reads` for a step that maps reads),
* all `environment.yaml` specifications follow [the respective best practices](https://stackoverflow.com/a/64594513/2352071),
* the `environment.yaml` pinning has been updated by running `snakedeploy pin-conda-envs environment.yaml` on a linux machine,
* wherever possible, command line arguments are inferred and set automatically (e.g. based on file extensions in `input:` or `output:`),
* all fields of the example rules in the `Snakefile`s and their entries are explained via comments (`input:`/`output:`/`params:` etc.),
* `stderr` and/or `stdout` are logged correctly (`log:`), depending on the wrapped tool,
* temporary files are either written to a unique hidden folder in the working directory, or (better) stored where the Python function `tempfile.gettempdir()` points to (see [here](https://docs.python.org/3/library/tempfile.html#tempfile.gettempdir); this also means that using any Python `tempfile` default behavior works),
* the `meta.yaml` contains a link to the documentation of the respective tool or command,
* `Snakefile`s pass the linting (`snakemake --lint`),
* `Snakefile`s are formatted with [snakefmt](https://github.com/snakemake/snakefmt),
* Python wrapper scripts are formatted with [black](https://black.readthedocs.io).
* Conda environments use a minimal amount of channels, in recommended ordering. E.g. for bioconda, use (conda-forge, bioconda, nodefaults, as conda-forge should have highest priority and defaults channels are usually not needed because most packages are in conda-forge nowadays).
