### PR TITLE
fix: remove unnecessary import

### DIFF
--- a/bio/cooltools/insulation/wrapper.py
+++ b/bio/cooltools/insulation/wrapper.py
@@ -3,7 +3,6 @@ __copyright__ = "Copyright 2022, Ilya Flyamer"
 __email__ = "flyamer@gmail.com"
 __license__ = "MIT"
 
-import sndhdr
 from snakemake.shell import shell
 
 ## Extract arguments


### PR DESCRIPTION
Not sure how it got here and this is deprecated for python 3.13
