### PR TITLE
fix: download already indexed vep cache tarball

### DIFF
--- a/bio/vep/cache/meta.yaml
+++ b/bio/vep/cache/meta.yaml
@@ -10,3 +10,4 @@ params:
   - species: species to download cache data
   - build: build to download cache data
   - release: release to download cache data
+  - indexed: whether to download an already indexed cache

--- a/bio/vep/cache/test/Snakefile
+++ b/bio/vep/cache/test/Snakefile
@@ -12,6 +12,21 @@ rule get_vep_cache:
         "master/bio/vep/cache"
 
 
+rule get_indexed_vep_cache:
+    output:
+        directory("resources/vep/indexed_cache"),
+    params:
+        species="saccharomyces_cerevisiae",
+        build="R64-1-1",
+        release="98",
+        indexed=True,
+    log:
+        "logs/vep/indexed_cache.log",
+    cache: "omit-software"  # save space and time with between workflow caching (see docs)
+    wrapper:
+        "master/bio/vep/cache"
+
+
 rule get_vep_cache_ebi:
     output:
         directory("resources/vep/cache_ebi"),

--- a/bio/vep/cache/wrapper.py
+++ b/bio/vep/cache/wrapper.py
@@ -25,7 +25,12 @@ with tempfile.TemporaryDirectory() as tmpdir:
     cache_tarball = (
         f"{snakemake.params.species}_vep_{release}_{snakemake.params.build}.tar.gz"
     )
-    vep_dir = "indexed_vep_cache"
+    if snakemake.params.get("indexed"):
+        vep_dir = "indexed_vep_cache"
+        convert = ""
+    else:
+        vep_dir = "vep" if snakemake.params.get("url") or release >= 97 else "VEP"
+        convert = "--CONVERT "
     shell(
         "curl -L {cache_url}/release-{release}/variation/{vep_dir}/{cache_tarball} -o {tmpdir}/{cache_tarball} {log}"
     )
@@ -38,6 +43,7 @@ with tempfile.TemporaryDirectory() as tmpdir:
         "--CACHE_VERSION {release} "
         "--CACHEURL {tmpdir} "
         "--CACHEDIR {snakemake.output} "
+        "{convert}"
         "--NO_UPDATE "
         "{extra} {log}"
     )

--- a/bio/vep/cache/wrapper.py
+++ b/bio/vep/cache/wrapper.py
@@ -25,7 +25,7 @@ with tempfile.TemporaryDirectory() as tmpdir:
     cache_tarball = (
         f"{snakemake.params.species}_vep_{release}_{snakemake.params.build}.tar.gz"
     )
-    vep_dir = "vep" if snakemake.params.get("url") or release >= 97 else "VEP"
+    vep_dir = "indexed_vep_cache"
     shell(
         "curl -L {cache_url}/release-{release}/variation/{vep_dir}/{cache_tarball} -o {tmpdir}/{cache_tarball} {log}"
     )
@@ -38,7 +38,6 @@ with tempfile.TemporaryDirectory() as tmpdir:
         "--CACHE_VERSION {release} "
         "--CACHEURL {tmpdir} "
         "--CACHEDIR {snakemake.output} "
-        "--CONVERT "
         "--NO_UPDATE "
         "{extra} {log}"
     )

--- a/test.py
+++ b/test.py
@@ -6090,6 +6090,11 @@ def test_vep_cache():
 
     run(
         "bio/vep/cache",
+        ["snakemake", "--cores", "1", "resources/vep/indexed_cache", "--use-conda", "-F"],
+    )
+
+    run(
+        "bio/vep/cache",
         ["snakemake", "--cores", "1", "resources/vep/cache_ebi", "--use-conda", "-F"],
     )
 


### PR DESCRIPTION
<!-- Ensure that the PR title follows conventional commit style (<type>: <description>)-->
<!-- Possible types are here: https://github.com/commitizen/conventional-commit-types/blob/master/index.json -->

This PR adds a parameter named `indexed` to the wrapper interface to allow downloading a vep_cache version which has already been indexed and thus needs no additional post-processing via `--CONVERT`.
> Tabix-indexed cache files are available to download for most supported species in our [FTP server](https://ftp.ensembl.org/pub/release-112/variation/indexed_vep_cache/). [[1]](http://www.ensembl.org/info/docs/tools/vep/script/vep_cache.html)

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] I confirm that I have followed the [documentation for contributing to `snakemake-wrappers`](https://snakemake-wrappers.readthedocs.io/en/stable/contributing.html).

While the contributions guidelines are more extensive, please particularly ensure that:
* [x] `test.py` was updated to call any added or updated example rules in a `Snakefile`
* [x] `input:` and `output:` file paths in the rules can be chosen arbitrarily
* [x] wherever possible, command line arguments are inferred and set automatically (e.g. based on file extensions in `input:` or `output:`)
* [x] temporary files are either written to a unique hidden folder in the working directory, or (better) stored where the Python function `tempfile.gettempdir()` points to 
* [x] the `meta.yaml` contains a link to the documentation of the respective tool or command under `url:`
* [x] conda environments use a minimal amount of channels and packages, in recommended ordering
