### PR TITLE
fix: add missing raw string in REGEX_RULES

### DIFF
--- a/bio/trim_galore/pe/wrapper.py
+++ b/bio/trim_galore/pe/wrapper.py
@@ -31,7 +31,7 @@ def fasta_filename(infile: str, infix: str, out_gzip: bool) -> str:
     """
     base_input = os.path.basename(infile)
     suffix = ".gz" if out_gzip or infile.endswith(".gz") else ""
-    REGEX_RULES = [r"\.fastq$", "\.fastq\.gz$", r"\.fq$", r"\.fq\.gz$"]
+    REGEX_RULES = [r"\.fastq$", r"\.fastq\.gz$", r"\.fq$", r"\.fq\.gz$"]
     for regex in REGEX_RULES:
         if re.search(regex, base_input):
             return re.sub(regex, f"{infix}.fq", base_input) + suffix


### PR DESCRIPTION
<!-- Ensure that the PR title follows conventional commit style (<type>: <description>)-->
<!-- Possible types are here: https://github.com/commitizen/conventional-commit-types/blob/master/index.json -->

<!-- Add a description of your PR here-->

I ran into an error while trying to use the trim_galore/pe wrapper:
```
/path/to/project/.snakemake/scripts/tmph05pgi_u.wrapper.py:38: SyntaxWarning: invalid escape sequence '\.'
  REGEX_RULES = [r"\.fastq$", "\.fastq\.gz$", r"\.fq$", r"\.fq\.gz$"]
```

The fix for that issue was easy and obvious, I fixed the raw string for `.fastq.gz` files in the list of regex patterns.

### QC
<!-- Make sure that you can tick the boxes below. -->

* [X] I confirm that I have followed the [documentation for contributing to `snakemake-wrappers`](https://snakemake-wrappers.readthedocs.io/en/stable/contributing.html).

While the contributions guidelines are more extensive, please particularly ensure that:
* [ ] `test.py` was updated to call any added or updated example rules in a `Snakefile`
* [ ] `input:` and `output:` file paths in the rules can be chosen arbitrarily
* [ ] wherever possible, command line arguments are inferred and set automatically (e.g. based on file extensions in `input:` or `output:`)
* [ ] temporary files are either written to a unique hidden folder in the working directory, or (better) stored where the Python function `tempfile.gettempdir()` points to 
* [ ] the `meta.yaml` contains a link to the documentation of the respective tool or command under `url:`
* [ ] conda environments use a minimal amount of channels and packages, in recommended ordering
