### PR TITLE
feat: Allow outputting of rendered yte config in Datavzrd wrapper

### DIFF
--- a/utils/datavzrd/meta.yaml
+++ b/utils/datavzrd/meta.yaml
@@ -6,5 +6,7 @@ description: |
   Any files specified in the configuration file have to be also specified as additional input files in the
   datavzrd rule.
 url: https://github.com/datavzrd/datavzrd
+output:
+- config: Path to the rendered yte config
 authors:
   - Felix Mölder

--- a/utils/datavzrd/test/Snakefile
+++ b/utils/datavzrd/test/Snakefile
@@ -22,7 +22,7 @@ rule datavzrd:
             # for additional options like caption, categories and labels
         ),
         # optionally output the rendered config
-        config = logs/datavzrd_report/{sample}/rendered_config.yaml
+        config = "logs/datavzrd_report/{sample}/rendered_config.yaml"
     log:
         "logs/datavzrd_report/{sample}.log",
     wrapper:

--- a/utils/datavzrd/test/Snakefile
+++ b/utils/datavzrd/test/Snakefile
@@ -21,6 +21,8 @@ rule datavzrd:
             # see https://snakemake.readthedocs.io/en/stable/snakefiles/reporting.html
             # for additional options like caption, categories and labels
         ),
+        # optionally output the rendered config
+        config = logs/datavzrd_report/{sample}/rendered_config.yaml
     log:
         "logs/datavzrd_report/{sample}.log",
     wrapper:

--- a/utils/datavzrd/test/Snakefile
+++ b/utils/datavzrd/test/Snakefile
@@ -22,7 +22,7 @@ rule datavzrd:
             # for additional options like caption, categories and labels
         ),
         # optionally output the rendered config
-        config = "logs/datavzrd_report/{sample}/rendered_config.yaml"
+        config = "resources/datavzrd/{sample}.rendered_config.yaml"
     log:
         "logs/datavzrd_report/{sample}.log",
     wrapper:

--- a/utils/datavzrd/wrapper.py
+++ b/utils/datavzrd/wrapper.py
@@ -6,10 +6,12 @@ __license__ = "MIT"
 import tempfile
 from yte import process_yaml
 from snakemake.shell import shell
+import shutil
 
 log = snakemake.log_fmt_shell(stdout=True, stderr=True)
 
 extra = snakemake.params.get("extra", "")
+output_config = snakemake.params.get("output_config", False)
 
 with tempfile.NamedTemporaryFile(mode="w") as processed, open(
     snakemake.input.config
@@ -27,4 +29,6 @@ with tempfile.NamedTemporaryFile(mode="w") as processed, open(
     )
     processed.flush()
 
+    if output_config:
+        shutil.copy(processed.name, snakemake.output[1])
     shell("datavzrd {processed.name} {extra} --output {snakemake.output[0]} {log}")

--- a/utils/datavzrd/wrapper.py
+++ b/utils/datavzrd/wrapper.py
@@ -11,7 +11,6 @@ import shutil
 log = snakemake.log_fmt_shell(stdout=True, stderr=True)
 
 extra = snakemake.params.get("extra", "")
-output_config = snakemake.params.get("output_config", False)
 
 with tempfile.NamedTemporaryFile(mode="w") as processed, open(
     snakemake.input.config
@@ -29,6 +28,6 @@ with tempfile.NamedTemporaryFile(mode="w") as processed, open(
     )
     processed.flush()
 
-    if output_config:
-        shutil.copy(processed.name, snakemake.output[1])
+    if snakemake.output.config:
+        shutil.copy(processed.name, snakemake.output.config)
     shell("datavzrd {processed.name} {extra} --output {snakemake.output[0]} {log}")


### PR DESCRIPTION
<!-- Ensure that the PR title follows conventional commit style (<type>: <description>)-->
<!-- Possible types are here: https://github.com/commitizen/conventional-commit-types/blob/master/index.json -->

<!-- Add a description of your PR here-->

### QC
<!-- Make sure that you can tick the boxes below. -->

* [ ] I confirm that I have followed the [documentation for contributing to `snakemake-wrappers`](https://snakemake-wrappers.readthedocs.io/en/stable/contributing.html).

While the contributions guidelines are more extensive, please particularly ensure that:
* [ ] `test.py` was updated to call any added or updated example rules in a `Snakefile`
* [ ] `input:` and `output:` file paths in the rules can be chosen arbitrarily
* [ ] wherever possible, command line arguments are inferred and set automatically (e.g. based on file extensions in `input:` or `output:`)
* [ ] temporary files are either written to a unique hidden folder in the working directory, or (better) stored where the Python function `tempfile.gettempdir()` points to 
* [ ] the `meta.yaml` contains a link to the documentation of the respective tool or command under `url:`
* [ ] conda environments use a minimal amount of channels and packages, in recommended ordering


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Added an optional output configuration file in YAML format for enhanced tracking of pipeline parameters and settings.
	- Implemented functionality to save processed data to a specified output configuration path, improving workflow management.
	- Enhanced metadata in the configuration file with additional context regarding the output structure and location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->