### PR TITLE
feat: add support for multiple input file subcommands in seqkit wrapper (subcommands "common" and "concat")

### DIFF
--- a/bio/seqkit/test/Snakefile
+++ b/bio/seqkit/test/Snakefile
@@ -160,7 +160,7 @@ rule seqkit_common:
         fastas=[
             "data/{sample1}.fa",
             "data/{sample2}.fa",
-        ]
+        ],
     output:
         fasta="out/common/{sample1}_{sample2}.fa.gz",
     log:
@@ -178,7 +178,7 @@ rule seqkit_concat:
         fastas=[
             "data/{sample1}.fa",
             "data/{sample2}.fa",
-        ]
+        ],
     output:
         fasta="out/concat/{sample1}_{sample2}.fa.gz",
     log:

--- a/bio/seqkit/test/Snakefile
+++ b/bio/seqkit/test/Snakefile
@@ -153,3 +153,39 @@ rule seqkit_stats:
     threads: 2
     wrapper:
         "master/bio/seqkit"
+
+
+rule seqkit_common:
+    input:
+        fastas=[
+            "data/{sample1}.fa",
+            "data/{sample2}.fa",
+        ]
+    output:
+        fasta="out/common/{sample1}_{sample2}.fa.gz",
+    log:
+        "logs/common/{sample1}_{sample2}.log",
+    params:
+        command="common",
+        extra="",
+    threads: 2
+    wrapper:
+        "master/bio/seqkit"
+
+
+rule seqkit_concat:
+    input:
+        fastas=[
+            "data/{sample1}.fa",
+            "data/{sample2}.fa",
+        ]
+    output:
+        fasta="out/concat/{sample1}_{sample2}.fa.gz",
+    log:
+        "logs/concat/{sample1}_{sample2}.log",
+    params:
+        command="concat",
+        extra="",
+    threads: 2
+    wrapper:
+        "master/bio/seqkit"

--- a/bio/seqkit/test/data/b.fa
+++ b/bio/seqkit/test/data/b.fa
@@ -1,0 +1,4 @@
+>seq1
+tgACTGac
+>seq3
+actg

--- a/bio/seqkit/wrapper.py
+++ b/bio/seqkit/wrapper.py
@@ -8,6 +8,11 @@ from snakemake.shell import shell
 extra = snakemake.params.get("extra", "")
 log = snakemake.log_fmt_shell(stdout=True, stderr=True)
 
+# subcommands concat and common use multiple input files
+if snakemake.params.command in ["concat", "common"]:
+    input = " ".join(snakemake.input)
+else:
+    input = snakemake.input[0]
 
 extra_input = " ".join(
     [
@@ -39,6 +44,6 @@ shell(
     " {extra_output}"
     " {extra}"
     " --out-file {snakemake.output[0]}"
-    " {snakemake.input[0]}"
+    " {input}"
     " {log}"
 )

--- a/test.py
+++ b/test.py
@@ -430,6 +430,36 @@ def test_seqkit_seq():
 
 
 @skip_if_not_modified
+def test_seqkit_common():
+    run(
+        "bio/seqkit",
+        [
+            "snakemake",
+            "--cores",
+            "2",
+            "--use-conda",
+            "-F",
+            "out/common/a_b.fa.gz",
+        ],
+    )
+
+
+@skip_if_not_modified
+def test_seqkit_concat():
+    run(
+        "bio/seqkit",
+        [
+            "snakemake",
+            "--cores",
+            "2",
+            "--use-conda",
+            "-F",
+            "out/concat/a_b.fa.gz",
+        ],
+    )
+
+
+@skip_if_not_modified
 def test_sickle_pe():
     run(
         "bio/sickle/pe",


### PR DESCRIPTION


<!-- Ensure that the PR title follows conventional commit style (<type>: <description>)-->
<!-- Possible types are here: https://github.com/commitizen/conventional-commit-types/blob/master/index.json -->

<!-- Add a description of your PR here-->

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] I confirm that I have followed the [documentation for contributing to `snakemake-wrappers`](https://snakemake-wrappers.readthedocs.io/en/stable/contributing.html).

While the contributions guidelines are more extensive, please particularly ensure that:
* [x] `test.py` was updated to call any added or updated example rules in a `Snakefile`
* [x] `input:` and `output:` file paths in the rules can be chosen arbitrarily
* [x] wherever possible, command line arguments are inferred and set automatically (e.g. based on file extensions in `input:` or `output:`)
* [x] temporary files are either written to a unique hidden folder in the working directory, or (better) stored where the Python function `tempfile.gettempdir()` points to 
* [x] the `meta.yaml` contains a link to the documentation of the respective tool or command under `url:`
* [x] conda environments use a minimal amount of channels and packages, in recommended ordering


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced two new processing rules for FASTA files: `seqkit_common` for extracting common sequences and `seqkit_concat` for concatenating sequences.
	- Added a new FASTA file (`b.fa`) containing two nucleotide sequences for analysis.

- **Tests**
	- Added new test functions to validate the functionality of the new `seqkit_common` and `seqkit_concat` rules. 

These updates enhance the bioinformatics pipeline's capabilities and improve testing coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->