### PR TITLE
fix: typo, remove unused time call

### DIFF
--- a/bio/spades/metaspades/test/Snakefile
+++ b/bio/spades/metaspades/test/Snakefile
@@ -3,23 +3,22 @@ container: "docker://continuumio/miniconda3:4.4.10"
 
 rule run_metaspades:
     input:
-        reads=["test_reads/sample1_R1.fastq.gz", "test_reads/sample1_R2.fastq.gz"],
+        reads=["test_reads/sample1_R1.fastq.gz", "test_reads/sample1_R2.fastq.gz"]
     output:
         contigs="assembly/contigs.fasta",
         scaffolds="assembly/scaffolds.fasta",
-        dir=directory("assembly/intermediate_files"),
+        dir=directory("assembly/intermediate_files")
     benchmark:
         "logs/benchmarks/assembly/spades.txt"
     params:
         # all parameters are optional
         k="auto",
-        extra="--only-assembler",
+        extra="--only-assembler"
     log:
-        "log/spades.log",
+        "log/spades.log"
     threads: 8
     resources:
-        mem_mem=250000,
-        time=60 * 24,
+        mem_mb=250000,
     wrapper:
         "master/bio/spades/metaspades"
 


### PR DESCRIPTION
<!-- Ensure that the PR title follows conventional commit style (<type>: <description>)-->
<!-- Possible types are here: https://github.com/commitizen/conventional-commit-types/blob/master/index.json -->

<!-- Add a description of your PR here-->
The example snakemake rule had two issues:
1. under `resources` the parameter was provided as `mem_mem` and should be `mem_mb`
2. under `resources` the parameter `time` is not used in `wrapper.py` and was thus removed

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] I confirm that I have followed the [documentation for contributing to `snakemake-wrappers`](https://snakemake-wrappers.readthedocs.io/en/stable/contributing.html).

While the contributions guidelines are more extensive, please particularly ensure that:
* [x] `test.py` was updated to call any added or updated example rules in a `Snakefile`
* [x] `input:` and `output:` file paths in the rules can be chosen arbitrarily
* [x] wherever possible, command line arguments are inferred and set automatically (e.g. based on file extensions in `input:` or `output:`)
* [x] temporary files are either written to a unique hidden folder in the working directory, or (better) stored where the Python function `tempfile.gettempdir()` points to 
* [x] the `meta.yaml` contains a link to the documentation of the respective tool or command under `url:`
* [x] conda environments use a minimal amount of channels and packages, in recommended ordering


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Removed trailing commas in multiple sections for improved syntax.
	- Updated resource key from `mem_mem` to `mem_mb` for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->