### PR TITLE
fix: Hisat2 index improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+### [4.7.2](https://www.github.com/snakemake/snakemake-wrappers/compare/v4.7.1...v4.7.2) (2024-10-16)
+
+
+### Bug Fixes
+
+* typo, remove unused time call ([#3300](https://www.github.com/snakemake/snakemake-wrappers/issues/3300)) ([a8541f6](https://www.github.com/snakemake/snakemake-wrappers/commit/a8541f6d767ef313d624b2f77e67c4c482a3e980))
+
+
+### Performance Improvements
+
+* update to latest datavzrd ([#3299](https://www.github.com/snakemake/snakemake-wrappers/issues/3299)) ([ef50340](https://www.github.com/snakemake/snakemake-wrappers/commit/ef503400da364d272ed080bb9c4feb5456e1e4a1))
+
 ### [4.7.1](https://www.github.com/snakemake/snakemake-wrappers/compare/v4.7.0...v4.7.1) (2024-10-09)
 
 

--- a/bio/hisat2/index/meta.yaml
+++ b/bio/hisat2/index/meta.yaml
@@ -8,5 +8,5 @@ input:
 output:
   - Directory of the hisat2 custom index.
 params:
-  - prefix: prefix of index file path (required). Must be related to output
+  - prefix: prefix for the index file names (required). Output files will be named with this prefix, inside the directory specified in the output directive.
   - extra: additional parameters

--- a/bio/hisat2/index/meta.yaml
+++ b/bio/hisat2/index/meta.yaml
@@ -1,12 +1,13 @@
 name: hisat2 index
 authors:
   - Joël Simoneau
+  - Hugo Tavares
 description: |
-  Create index with hisat2.
+  Create index files for `hisat2`.
 input:
-  - sequence: list of FASTA files of list of sequences
+  - sequence: list of FASTA files to index
 output:
-  - Directory of the hisat2 custom index.
+  - List of output index file paths. The `hisat2-build` command generates 8 files with `.ht2` extension for small genomes and `.ht2l` for large genomes (greater than ~4 Gbp). This is usually handled automatically, but you must use the correct output file extension (`.ht2` or `.ht2l`) to match your genome size. If needed, you can force the creation of a large index by adding the parameter `extra = "--large-index"`, and use `.ht2l` as the output file extension.
 params:
-  - prefix: prefix for the index file names (required). Output files will be named with this prefix, inside the directory specified in the output directive.
-  - extra: additional parameters
+  - extra: additional parameters that will be passed to `hisat2-build`.
+url: http://daehwankimlab.github.io/hisat2/manual/

--- a/bio/hisat2/index/test/Snakefile
+++ b/bio/hisat2/index/test/Snakefile
@@ -4,7 +4,7 @@ rule hisat2_index:
     output:
         directory("index_{genome}")
     params:
-        prefix = "index_{genome}/"
+        prefix = "{genome}"
     log:
         "logs/hisat2_index_{genome}.log"
     threads: 2

--- a/bio/hisat2/index/test/Snakefile
+++ b/bio/hisat2/index/test/Snakefile
@@ -2,9 +2,19 @@ rule hisat2_index:
     input:
         fasta = "{genome}.fasta"
     output:
-        directory("index_{genome}")
+        multiext(
+            "hisat2_index/{genome}",
+            ".1.ht2",
+            ".2.ht2",
+            ".3.ht2",
+            ".4.ht2",
+            ".5.ht2",
+            ".6.ht2",
+            ".7.ht2",
+            ".8.ht2",
+        )
     params:
-        prefix = "{genome}"
+        extra = ""
     log:
         "logs/hisat2_index_{genome}.log"
     threads: 2

--- a/bio/hisat2/index/wrapper.py
+++ b/bio/hisat2/index/wrapper.py
@@ -22,14 +22,17 @@ if not "." in fasta:
     input_seq += "-c "
 input_seq += ",".join(fasta) if isinstance(fasta, list) else fasta
 
-hisat_dir = snakemake.params.get("prefix", "")
-if hisat_dir:
-    os.makedirs(hisat_dir)
+# check that file prefix is not a path
+prefix = snakemake.params.get("prefix", "")
+assert "/" not in prefix, "params 'prefix' should be a filename prefix, not a path (do not include '/')."
+
+# make output directory
+os.makedirs(snakemake.output, exist_ok=True)
 
 shell(
     "hisat2-build {extra} "
     "-p {snakemake.threads} "
     "{input_seq} "
-    "{snakemake.params.prefix} "
+    "{snakemake.output}/{prefix} "
     "{log}"
 )

--- a/bio/hisat2/index/wrapper.py
+++ b/bio/hisat2/index/wrapper.py
@@ -27,12 +27,13 @@ prefix = snakemake.params.get("prefix", "")
 assert "/" not in prefix, "params 'prefix' should be a filename prefix, not a path (do not include '/')."
 
 # make output directory
-os.makedirs(snakemake.output, exist_ok=True)
+outdir = snakemake.output[0]
+os.makedirs(outdir, exist_ok=True)
 
 shell(
     "hisat2-build {extra} "
     "-p {snakemake.threads} "
     "{input_seq} "
-    "{snakemake.output}/{prefix} "
+    "{outdir}/{prefix} "
     "{log}"
 )

--- a/bio/hisat2/index/wrapper.py
+++ b/bio/hisat2/index/wrapper.py
@@ -22,49 +22,13 @@ if not "." in fasta:
     input_seq += "-c "
 input_seq += ",".join(fasta) if isinstance(fasta, list) else fasta
 
-
-# Function to validate output file extensions and get common prefix
-def get_prefix(files):
-    # Check all files have the same dirname
-    dirname = os.path.dirname(files[0])
-    if not all(os.path.dirname(f) == dirname for f in files):
-        raise ValueError("Output files must all share the same output directory path.")
-
-    # Valid file extensions from hisat2-build docs
-    ht2_extensions = {f".{i}.ht2" for i in range(1, 9)}
-    ht2l_extensions = {f".{i}.ht2l" for i in range(1, 9)}
-    all_extensions = ht2_extensions | ht2l_extensions
-
-    # Get user file extensions
-    extensions = []
-    for file in files:
-        for ext in all_extensions:
-            if file.endswith(ext):
-                extensions.append(ext)
-
-    # Check all 8 files are specified in the output with the correct extensions
-    if all(ht2 in extensions for ht2 in ht2_extensions) or all(
-        ht2l in extensions for ht2l in ht2l_extensions
-    ):
-        prefix = os.path.commonprefix(list(files)).rstrip(".")
-    else:
-        raise ValueError(
-            "Output files must have either '.ht2' or '.ht2l' extensions for all 8 files."
-        )
-
-    if not prefix:
-        raise ValueError("All output files must share the same prefix.")
-
-    return prefix
-
-
 # get common prefix
-prefix = get_prefix(snakemake.output)
-
-# make output directory
-if os.path.dirname(prefix):
-    os.makedirs(os.path.dirname(prefix), exist_ok=True)
+prefix = os.path.commonprefix(snakemake.output).rstrip(".")
 
 shell(
-    "hisat2-build {extra} " "-p {snakemake.threads} " "{input_seq} " "{prefix} " "{log}"
+    "hisat2-build {extra}"
+    " -p {snakemake.threads}"
+    " {input_seq}"
+    " {prefix}"
+    " {log}"
 )

--- a/bio/hisat2/index/wrapper.py
+++ b/bio/hisat2/index/wrapper.py
@@ -22,18 +22,49 @@ if not "." in fasta:
     input_seq += "-c "
 input_seq += ",".join(fasta) if isinstance(fasta, list) else fasta
 
-# check that file prefix is not a path
-prefix = snakemake.params.get("prefix", "")
-assert "/" not in prefix, "params 'prefix' should be a filename prefix, not a path (do not include '/')."
+
+# Function to validate output file extensions and get common prefix
+def get_prefix(files):
+    # Check all files have the same dirname
+    dirname = os.path.dirname(files[0])
+    if not all(os.path.dirname(f) == dirname for f in files):
+        raise ValueError("Output files must all share the same output directory path.")
+
+    # Valid file extensions from hisat2-build docs
+    ht2_extensions = {f".{i}.ht2" for i in range(1, 9)}
+    ht2l_extensions = {f".{i}.ht2l" for i in range(1, 9)}
+    all_extensions = ht2_extensions | ht2l_extensions
+
+    # Get user file extensions
+    extensions = []
+    for file in files:
+        for ext in all_extensions:
+            if file.endswith(ext):
+                extensions.append(ext)
+
+    # Check all 8 files are specified in the output with the correct extensions
+    if all(ht2 in extensions for ht2 in ht2_extensions) or all(
+        ht2l in extensions for ht2l in ht2l_extensions
+    ):
+        prefix = os.path.commonprefix(list(files)).rstrip(".")
+    else:
+        raise ValueError(
+            "Output files must have either '.ht2' or '.ht2l' extensions for all 8 files."
+        )
+
+    if not prefix:
+        raise ValueError("All output files must share the same prefix.")
+
+    return prefix
+
+
+# get common prefix
+prefix = get_prefix(snakemake.output)
 
 # make output directory
-outdir = snakemake.output[0]
-os.makedirs(outdir, exist_ok=True)
+if os.path.dirname(prefix):
+    os.makedirs(os.path.dirname(prefix), exist_ok=True)
 
 shell(
-    "hisat2-build {extra} "
-    "-p {snakemake.threads} "
-    "{input_seq} "
-    "{outdir}/{prefix} "
-    "{log}"
+    "hisat2-build {extra} " "-p {snakemake.threads} " "{input_seq} " "{prefix} " "{log}"
 )

--- a/bio/hisat2/index/wrapper.py
+++ b/bio/hisat2/index/wrapper.py
@@ -25,10 +25,4 @@ input_seq += ",".join(fasta) if isinstance(fasta, list) else fasta
 # get common prefix
 prefix = os.path.commonprefix(snakemake.output).rstrip(".")
 
-shell(
-    "hisat2-build {extra}"
-    " -p {snakemake.threads}"
-    " {input_seq}"
-    " {prefix}"
-    " {log}"
-)
+shell("hisat2-build --threads {snakemake.threads} {input_seq} {extra} {prefix} {log}")

--- a/test.py
+++ b/test.py
@@ -3368,7 +3368,14 @@ def test_happy_prepy():
 def test_hisat2_index():
     run(
         "bio/hisat2/index",
-        ["snakemake", "--cores", "1", "index_genome", "--use-conda", "-F"],
+        [
+            "snakemake",
+            "--cores",
+            "1",
+            *[f"hisat2_index/genome.{i}.ht2" for i in range(1, 9)],
+            "--use-conda",
+            "-F",
+        ],
     )
 
 


### PR DESCRIPTION
<!-- Ensure that the PR title follows conventional commit style (<type>: <description>)-->
<!-- Possible types are here: https://github.com/commitizen/conventional-commit-types/blob/master/index.json -->

The previous version of this script created an output directory based on the file name prefix of the index file, which resulted in an empty directory being created. 
The current changes make sure that: 

* The output directory is instead created from the directory specified in `snakemake.output`.
* The `params.prefix` is used as a file prefix for the output files.
* The documentation clarifies its use.
* Ran `pytest test.py -v -k test_hisat2_index` which passed

Tagging @simojoe as the original author of the wrapper. 


### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] I confirm that I have followed the [documentation for contributing to `snakemake-wrappers`](https://snakemake-wrappers.readthedocs.io/en/stable/contributing.html).

While the contributions guidelines are more extensive, please particularly ensure that:
* [x] `test.py` was updated to call any added or updated example rules in a `Snakefile`
* [x] `input:` and `output:` file paths in the rules can be chosen arbitrarily
* [x] wherever possible, command line arguments are inferred and set automatically (e.g. based on file extensions in `input:` or `output:`)
* [x] temporary files are either written to a unique hidden folder in the working directory, or (better) stored where the Python function `tempfile.gettempdir()` points to 
* [ ] the `meta.yaml` contains a link to the documentation of the respective tool or command under `url:`
* [x] conda environments use a minimal amount of channels and packages, in recommended ordering


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added a new author, Hugo Tavares, to the HISAT2 index documentation.
	- Enhanced output specifications for HISAT2 index files, allowing for multiple specific file extensions.
	- Improved the indexing process by enabling the handling of multiple FASTA files in a single command.

- **Bug Fixes**
	- Corrected output directory handling to ensure proper file extension generation based on genome size.

- **Documentation**
	- Updated descriptions for input and output sections in the HISAT2 index configuration for better clarity.
	- Added a reference URL for further information on HISAT2 usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->