### PR TITLE
fix: gffread issue with reading gff files, writing fasta files

### DIFF
--- a/bio/gffread/meta.yaml
+++ b/bio/gffread/meta.yaml
@@ -18,5 +18,6 @@ output:
   - dupinfo: Optional path to clustering/merging information
 params:
   - fasta_flag: Must be specified for FASTA outputs. Use `-w`, `-x`, or `-y` for transcript, CDS or protein sequences respectively, see gffread documentation for details.
+  - extra: additional program arguments (except for `--in-bed`, `--in-tlf`, `-T`, `--bed`, `--tlf`, `-o`, `-w`, `-x`, `-y`, `--ids`, `--nids`, `-s`, `--sort-by`, `--attrs`, `-m`, `-d`, or `-g`).
 notes: |
   With the exception of FASTA files, input/output formats are detected from their file extension.

--- a/bio/gffread/meta.yaml
+++ b/bio/gffread/meta.yaml
@@ -14,10 +14,10 @@ input:
   - attr: Optional text file containing comma-separated list of annotation attributes to keep.
   - chr_replace: Optional path to a TSV-formatted text file containing `<original_ref_ID> <new_ref_ID>`.
 output:
-  - records: Path to genome annotation in the requested format, containing the requested information.
-  - transcript_fasta: Path to FASTA containing gffread `-w` output.
-  - cds_fasta: Path to FASTA containing gffread `-x` output.
-  - protein_fasta: Path to FASTA containing gffread `-y` output.
+  - records: Genome annotation (optional).
+  - transcript_fasta: FASTA containing `-w` output (optional).
+  - cds_fasta: FASTA containing `-x` output (optional).
+  - protein_fasta: FASTA containing `-y` output (optional).
   - dupinfo: Optional path to clustering/merging information
 params:
   - extra: additional program arguments (except for `--in-bed`, `--in-tlf`, `-T`, `--bed`, `--tlf`, `-o`, `-w`, `-x`, `-y`, `--ids`, `--nids`, `-s`, `--sort-by`, `--attrs`, `-m`, `-d`, or `-g`).

--- a/bio/gffread/meta.yaml
+++ b/bio/gffread/meta.yaml
@@ -18,7 +18,7 @@ output:
   - transcript_fasta: FASTA containing `-w` output (optional).
   - cds_fasta: FASTA containing `-x` output (optional).
   - protein_fasta: FASTA containing `-y` output (optional).
-  - dupinfo: Optional path to clustering/merging information
+  - dupinfo: Clustering/merging information (optional).
 params:
   - extra: additional program arguments (except for `--in-bed`, `--in-tlf`, `-T`, `--bed`, `--tlf`, `-o`, `-w`, `-x`, `-y`, `--ids`, `--nids`, `-s`, `--sort-by`, `--attrs`, `-m`, `-d`, or `-g`).
 notes: |

--- a/bio/gffread/meta.yaml
+++ b/bio/gffread/meta.yaml
@@ -14,10 +14,12 @@ input:
   - attr: Optional text file containing comma-separated list of annotation attributes to keep.
   - chr_replace: Optional path to a TSV-formatted text file containing `<original_ref_ID> <new_ref_ID>`.
 output:
-  - records: Path to genome sequence/annotation in the requested format, containing the requested information.
+  - records: Path to genome annotation in the requested format, containing the requested information.
+  - transcript_fasta: Path to FASTA containing gffread `-w` output.
+  - cds_fasta: Path to FASTA containing gffread `-x` output.
+  - protein_fasta: Path to FASTA containing gffread `-y` output.
   - dupinfo: Optional path to clustering/merging information
 params:
-  - fasta_flag: Must be specified for FASTA outputs. Use `-w`, `-x`, or `-y` for transcript, CDS or protein sequences respectively, see gffread documentation for details.
   - extra: additional program arguments (except for `--in-bed`, `--in-tlf`, `-T`, `--bed`, `--tlf`, `-o`, `-w`, `-x`, `-y`, `--ids`, `--nids`, `-s`, `--sort-by`, `--attrs`, `-m`, `-d`, or `-g`).
 notes: |
-  With the exception of FASTA files, input/output formats are detected from their file extension.
+  Input/output formats are detected from their file extension.

--- a/bio/gffread/meta.yaml
+++ b/bio/gffread/meta.yaml
@@ -16,5 +16,7 @@ input:
 output:
   - records: Path to genome sequence/annotation in the requested format, containing the requested information.
   - dupinfo: Optional path to clustering/merging information
+params:
+  - fasta_flag: Must be specified for FASTA outputs. Use `-w`, `-x`, or `-y` for transcript, CDS or protein sequences respectively, see gffread documentation for details.
 notes: |
-  Input/output formats are automatically detected from their file extension.
+  With the exception of FASTA files, input/output formats are detected from their file extension.

--- a/bio/gffread/meta.yaml
+++ b/bio/gffread/meta.yaml
@@ -11,8 +11,8 @@ input:
   - nids: Optional path to records/transcripts to discard.
   - seq_info: Optional path to sequence information, a TSV formatted text file containing `<seq-name> <seq-length> <seq-description>`
   - sort_by: Optional path to a text file containing the ordered list of reference sequences.
-  - attr: Optional text file containing comma-separated list of annotation attributes to keep.
-  - chr_replace: Optional path to a TSV-formatted text file containing `<original_ref_ID> <new_ref_ID>`.
+  - attr: Text file containing comma-separated list of annotation attributes to keep (optional).
+  - chr_replace: TSV-formatted text file containing `<original_ref_ID> <new_ref_ID>` (optional).
 output:
   - records: Genome annotation (optional).
   - transcript_fasta: FASTA containing `-w` output (optional).

--- a/bio/gffread/test/Snakefile
+++ b/bio/gffread/test/Snakefile
@@ -1,4 +1,4 @@
-rule test_gffread:
+rule test_gffread_gtf:
     input:
         fasta="genome.fasta",
         annotation="annotation.gtf",
@@ -15,6 +15,23 @@ rule test_gffread:
     log:
         "logs/gffread.log",
     params:
+        out_flag="-w",
         extra="",
+    wrapper:
+        "master/bio/gffread"
+
+
+rule test_gffread_gff:
+    input:
+        fasta="genome.fasta",
+        annotation="annotation.gff3",
+    output:
+        records="proteins.fa",
+    threads: 1
+    log:
+        "logs/gffread.log",
+    params:
+        out_flag="-y",
+        extra="-S",
     wrapper:
         "master/bio/gffread"

--- a/bio/gffread/test/Snakefile
+++ b/bio/gffread/test/Snakefile
@@ -29,7 +29,7 @@ rule test_gffread_gff:
         records="proteins.fa",
     threads: 1
     log:
-        "logs/gffread.log",
+        "logs/gffread_gff.log",
     params:
         out_flag="-y",
         extra="-S",

--- a/bio/gffread/test/Snakefile
+++ b/bio/gffread/test/Snakefile
@@ -11,8 +11,8 @@ rule test_gffread_gtf:
     output:
         # All optional, select based on desired output
         records="annotation.gff",
-        transcript_fasta="transcripts.fa", # Path containing gffread -w output
-        cds_fasta="cds.fa", # Path containing gffread -x output
+        transcript_fasta="transcripts.fa",  # Path containing gffread -w output
+        cds_fasta="cds.fa",  # Path containing gffread -x output
         # dupinfo="",  # Path to clustering/merging information
     threads: 1
     log:
@@ -29,7 +29,7 @@ rule test_gffread_gff:
         fasta="genome.fasta",
         annotation="annotation.gff3",
     output:
-        protein_fasta="proteins.fa", # Path containing gffread -y output
+        protein_fasta="proteins.fa",  # Path containing gffread -y output
     threads: 1
     log:
         "logs/gffread_gff.log",

--- a/bio/gffread/test/Snakefile
+++ b/bio/gffread/test/Snakefile
@@ -13,7 +13,7 @@ rule test_gffread_gtf:
         # dupinfo="",  # Optional path to clustering/merging information
     threads: 1
     log:
-        "logs/gffread.log",
+        "logs/gffread_gtf.log",
     params:
         out_flag="-w",
         extra="",

--- a/bio/gffread/test/Snakefile
+++ b/bio/gffread/test/Snakefile
@@ -15,7 +15,7 @@ rule test_gffread_gtf:
     log:
         "logs/gffread_gtf.log",
     params:
-        out_flag="-w",
+        fasta_flag="-w",
         extra="",
     wrapper:
         "master/bio/gffread"
@@ -31,7 +31,7 @@ rule test_gffread_gff:
     log:
         "logs/gffread_gff.log",
     params:
-        out_flag="-y",
+        fasta_flag="-y",
         extra="-S",
     wrapper:
         "master/bio/gffread"

--- a/bio/gffread/test/Snakefile
+++ b/bio/gffread/test/Snakefile
@@ -9,8 +9,11 @@ rule test_gffread_gtf:
         # attr="",  # Optional annotation attributes to keep.
         # chr_replace="",  # Optional path to <original_ref_ID> <new_ref_ID>
     output:
-        records="transcripts.fa",
-        # dupinfo="",  # Optional path to clustering/merging information
+        # All optional, select based on desired output
+        records="annotation.gff",
+        transcript_fasta="transcripts.fa", # Path containing gffread -w output
+        cds_fasta="cds.fa", # Path containing gffread -x output
+        # dupinfo="",  # Path to clustering/merging information
     threads: 1
     log:
         "logs/gffread_gtf.log",
@@ -26,12 +29,11 @@ rule test_gffread_gff:
         fasta="genome.fasta",
         annotation="annotation.gff3",
     output:
-        records="proteins.fa",
+        protein_fasta="proteins.fa", # Path containing gffread -y output
     threads: 1
     log:
         "logs/gffread_gff.log",
     params:
-        fasta_flag="-y",
         extra="-S",
     wrapper:
         "master/bio/gffread"

--- a/bio/gffread/test/annotation.gff3
+++ b/bio/gffread/test/annotation.gff3
@@ -1,0 +1,7 @@
+##gff-version 3
+chromosome1	manually_made	transcript	160	208	.	+	.	ID=transcript1;geneID=ENMG01;gene_name=ManuallyMadeGene1
+chromosome1	manually_made	exon	160	208	.	+	.	Parent=transcript1
+chromosome1	manually_made	CDS	160	208	.	+	.	Parent=transcript1
+chromosome1	manually_made	transcript	160	240	.	+	.	ID=transcript2;geneID=ENMG02;gene_name=ManuallyMadeGene2
+chromosome1	manually_made	exon	160	240	.	+	.	Parent=transcript2
+chromosome1	manually_made	CDS	160	240	.	+	.	Parent=transcript2

--- a/bio/gffread/wrapper.py
+++ b/bio/gffread/wrapper.py
@@ -88,4 +88,4 @@ if chr_replace:
     extra += f" -m {chr_replace} "
 
 
-shell("gffread {extra} " "-g {snakemake.input.fasta} " "{annotation} " "{log} ")
+shell("gffread {extra} -g {snakemake.input.fasta} {annotation} {log}")

--- a/bio/gffread/wrapper.py
+++ b/bio/gffread/wrapper.py
@@ -23,7 +23,7 @@ else:
     raise ValueError("Unknown annotation format")
 
 # In most cases, output can be specified with -o
-out_flag = snakemake.params.get("out_flag", " -o ")
+out_flag = snakemake.params.get("fasta_flag", " -o ")
 
 # Output format control
 if records.endswith((".gtf", ".gff", ".gff3")):

--- a/bio/gffread/wrapper.py
+++ b/bio/gffread/wrapper.py
@@ -34,7 +34,7 @@ elif records.endswith(".tlf"):
     extra += " --tlf "
 elif records.endswith((".fasta", ".fa", ".fna")):
     # Fasta output must be specified with -w
-    if out_flag.strip() not in ["-w", "-x", "-y"]:
+    if out_flag not in ["-w", "-x", "-y"]:
         raise ValueError(
             "For fasta output, the fasta_flag parameter must be -w, -x, or -y"
         )

--- a/bio/gffread/wrapper.py
+++ b/bio/gffread/wrapper.py
@@ -14,19 +14,23 @@ annotation = snakemake.input.annotation
 # Output files
 records = snakemake.output.get("records", "")
 if records:
-    extra += f" -o {records} "
+    extra += f" -o {records}"
+
 dupinfo = snakemake.output.get("dupinfo", "")
 if dupinfo:
-    extra += f" -d {dupinfo} "
+    extra += f" -d {dupinfo}"
+
 transcript_fasta = snakemake.output.get("transcript_fasta", "")
 if transcript_fasta:
-    extra += f" -w {transcript_fasta} "
+    extra += f" -w {transcript_fasta}"
+
 cds_fasta = snakemake.output.get("cds_fasta", "")
 if cds_fasta:
-    extra += f" -x {cds_fasta} "
+    extra += f" -x {cds_fasta}"
+
 protein_fasta = snakemake.output.get("protein_fasta", "")
 if protein_fasta:
-    extra += f" -y {protein_fasta} "
+    extra += f" -y {protein_fasta}"
 
 
 # Input format control

--- a/bio/gffread/wrapper.py
+++ b/bio/gffread/wrapper.py
@@ -35,7 +35,9 @@ elif records.endswith(".tlf"):
 elif records.endswith((".fasta", ".fa", ".fna")):
     # Fasta output must be specified with -w
     if out_flag.strip() not in ["-w", "-x", "-y"]:
-        raise ValueError("For fasta output, the out_flag parameter must be -w, -x, or -y")
+        raise ValueError(
+            "For fasta output, the out_flag parameter must be -w, -x, or -y"
+        )
 else:
     raise ValueError("Unknown records format")
 

--- a/bio/gffread/wrapper.py
+++ b/bio/gffread/wrapper.py
@@ -10,7 +10,24 @@ extra = snakemake.params.get("extra", "")
 log = snakemake.log_fmt_shell(stdout=False, stderr=True)
 
 annotation = snakemake.input.annotation
-records = snakemake.output.records
+
+# Output files
+records = snakemake.output.get("records", "")
+if records:
+    extra += f" -o {records} "
+dupinfo = snakemake.output.get("dupinfo", "")
+if dupinfo:
+    extra += f" -d {dupinfo} "
+transcript_fasta = snakemake.output.get("transcript_fasta", "")
+if transcript_fasta:
+    extra += f" -w {transcript_fasta} "
+cds_fasta = snakemake.output.get("cds_fasta", "")
+if cds_fasta:
+    extra += f" -x {cds_fasta} "
+protein_fasta = snakemake.output.get("protein_fasta", "")
+if protein_fasta:
+    extra += f" -y {protein_fasta} "
+
 
 # Input format control
 if annotation.endswith(".bed"):
@@ -22,22 +39,15 @@ elif annotation.endswith((".gtf", ".gff", ".gff3")):
 else:
     raise ValueError("Unknown annotation format")
 
-# In most cases, output can be specified with -o
-out_flag = snakemake.params.get("fasta_flag", "-o").strip()
-
 # Output format control
-if records.endswith((".gtf", ".gff", ".gff3")):
+if not records:
+    pass
+elif records.endswith((".gtf", ".gff", ".gff3")):
     extra += " -T "
 elif records.endswith(".bed"):
     extra += " --bed "
 elif records.endswith(".tlf"):
     extra += " --tlf "
-elif records.endswith((".fasta", ".fa", ".fna")):
-    # Fasta output must be specified with -w
-    if out_flag not in ["-w", "-x", "-y"]:
-        raise ValueError(
-            "For fasta output, the fasta_flag parameter must be -w, -x, or -y"
-        )
 else:
     raise ValueError("Unknown records format")
 
@@ -78,15 +88,8 @@ if chr_replace:
     extra += f" -m {chr_replace} "
 
 
-# Optional output files
-dupinfo = snakemake.output.get("dupinfo", "")
-if dupinfo:
-    extra += f" -d {dupinfo} "
-
-
 shell(
     "gffread {extra} "
-    "{out_flag} {records} "
     "-g {snakemake.input.fasta} "
     "{annotation} "
     "{log} "

--- a/bio/gffread/wrapper.py
+++ b/bio/gffread/wrapper.py
@@ -36,7 +36,7 @@ elif records.endswith((".fasta", ".fa", ".fna")):
     # Fasta output must be specified with -w
     if out_flag.strip() not in ["-w", "-x", "-y"]:
         raise ValueError(
-            "For fasta output, the out_flag parameter must be -w, -x, or -y"
+            "For fasta output, the fasta_flag parameter must be -w, -x, or -y"
         )
 else:
     raise ValueError("Unknown records format")

--- a/bio/gffread/wrapper.py
+++ b/bio/gffread/wrapper.py
@@ -88,9 +88,4 @@ if chr_replace:
     extra += f" -m {chr_replace} "
 
 
-shell(
-    "gffread {extra} "
-    "-g {snakemake.input.fasta} "
-    "{annotation} "
-    "{log} "
-)
+shell("gffread {extra} " "-g {snakemake.input.fasta} " "{annotation} " "{log} ")

--- a/bio/gffread/wrapper.py
+++ b/bio/gffread/wrapper.py
@@ -17,13 +17,13 @@ if annotation.endswith(".bed"):
     extra += " --in-bed "
 elif annotation.endswith(".tlf"):
     extra += " --in-tlf "
-elif annotation.endswith(".gtf"):
+elif annotation.endswith((".gtf", ".gff", ".gff3")):
     pass
 else:
     raise ValueError("Unknown annotation format")
 
 # In most cases, output can be specified with -o
-out_flag = " -o "
+out_flag = snakemake.params.get("out_flag", " -o ")
 
 # Output format control
 if records.endswith((".gtf", ".gff", ".gff3")):
@@ -34,7 +34,8 @@ elif records.endswith(".tlf"):
     extra += " --tlf "
 elif records.endswith((".fasta", ".fa", ".fna")):
     # Fasta output must be specified with -w
-    out_flag = " -w "
+    if out_flag.strip() not in ["-w", "-x", "-y"]:
+        raise ValueError("For fasta output, the out_flag parameter must be -w, -x, or -y")
 else:
     raise ValueError("Unknown records format")
 

--- a/bio/gffread/wrapper.py
+++ b/bio/gffread/wrapper.py
@@ -23,7 +23,7 @@ else:
     raise ValueError("Unknown annotation format")
 
 # In most cases, output can be specified with -o
-out_flag = snakemake.params.get("fasta_flag", " -o ")
+out_flag = snakemake.params.get("fasta_flag", "-o").strip()
 
 # Output format control
 if records.endswith((".gtf", ".gff", ".gff3")):

--- a/test.py
+++ b/test.py
@@ -329,10 +329,18 @@ def test_seqkit_rmdup():
 
 
 @skip_if_not_modified
-def test_gffread():
+def test_gffread_gtf():
     run(
         "bio/gffread",
         ["snakemake", "--cores", "1", "--use-conda", "-F", "transcripts.fa"],
+    )
+
+
+@skip_if_not_modified
+def test_gffread_gff():
+    run(
+        "bio/gffread",
+        ["snakemake", "--cores", "1", "--use-conda", "-F", "proteins.fa"],
     )
 
 


### PR DESCRIPTION
<!-- Ensure that the PR title follows conventional commit style (<type>: <description>)-->
<!-- Possible types are here: https://github.com/commitizen/conventional-commit-types/blob/master/index.json -->

The gffread wrapper raises `ValueError: Unknown annotation format` for gff files. In addition to this, the wrapper assumes that any fasta output contains the spliced exons of each transcript (produced by `-w`), and not e.g. spliced coding sequences or protein fasta sequences. This PR fixes both of these issues.

Unfortunately it also introduces a breaking change to how fasta files are produced. I think defaulting to `-w` output for fasta files is a bad solution, but could implement this if it's required.

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] I confirm that I have followed the [documentation for contributing to `snakemake-wrappers`](https://snakemake-wrappers.readthedocs.io/en/stable/contributing.html).

While the contributions guidelines are more extensive, please particularly ensure that:
* [x] `test.py` was updated to call any added or updated example rules in a `Snakefile`
* [x] `input:` and `output:` file paths in the rules can be chosen arbitrarily
* [x] wherever possible, command line arguments are inferred and set automatically (e.g. based on file extensions in `input:` or `output:`)
* [x] temporary files are either written to a unique hidden folder in the working directory, or (better) stored where the Python function `tempfile.gettempdir()` points to 
* [x] the `meta.yaml` contains a link to the documentation of the respective tool or command under `url:`
* [x] conda environments use a minimal amount of channels and packages, in recommended ordering


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new testing rule for GFF3 files, enhancing compatibility with multiple annotation formats.
	- Added a new GFF3 annotation file defining genomic features for two manually created genes.
	- Expanded test coverage to include validation for GFF and GTF formats.
	- Enhanced output specifications to include new paths for FASTA outputs in the tool's configuration.

- **Bug Fixes**
	- Improved input validation and error handling for various annotation file formats.

- **Documentation**
	- Updated test functions to reflect new naming conventions and added tests for additional bioinformatics tools.
	- Clarified input/output format detection in the tool's documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->