### PR TITLE
fix: in seqkit wrapper, allow multiple inputs for stats

### DIFF
--- a/bio/seqkit/meta.yaml
+++ b/bio/seqkit/meta.yaml
@@ -12,5 +12,5 @@ params:
   - command: SeqKit command to use.
   - extra: Optional parameters.
 notes: |
-  * First `input` and `output` file is considered to be the main one.
+  * First `input` and `output` file is considered to be the main one (except for commands `concat`, `common`, and `stats` that take all input files).
   * Keys for extra `input` and `output` files need to match `seqkit` arguments without the `-file` suffix (if present).

--- a/bio/seqkit/wrapper.py
+++ b/bio/seqkit/wrapper.py
@@ -10,7 +10,7 @@ extra = snakemake.params.get("extra", "")
 log = snakemake.log_fmt_shell(stdout=False, stderr=True)
 
 # subcommands concat and common use multiple input files
-if snakemake.params.command in ["concat", "common"]:
+if snakemake.params.command in ["concat", "common", "stats"]:
     input = " ".join(snakemake.input)
 else:
     input = snakemake.input[0]


### PR DESCRIPTION
<!-- Ensure that the PR title follows conventional commit style (<type>: <description>)-->
<!-- Possible types are here: https://github.com/commitizen/conventional-commit-types/blob/master/index.json -->

<!-- Add a description of your PR here-->

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] I confirm that I have followed the [documentation for contributing to `snakemake-wrappers`](https://snakemake-wrappers.readthedocs.io/en/stable/contributing.html).

While the contributions guidelines are more extensive, please particularly ensure that:
* [x] `test.py` was updated to call any added or updated example rules in a `Snakefile`
* [x] `input:` and `output:` file paths in the rules can be chosen arbitrarily
* [x] wherever possible, command line arguments are inferred and set automatically (e.g. based on file extensions in `input:` or `output:`)
* [x] temporary files are either written to a unique hidden folder in the working directory, or (better) stored where the Python function `tempfile.gettempdir()` points to 
* [x] the `meta.yaml` contains a link to the documentation of the respective tool or command under `url:`
* [x] conda environments use a minimal amount of channels and packages, in recommended ordering


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced support for a new "stats" command, allowing the processing of multiple input files.
	- Clarified handling of input and output files in documentation, specifying exceptions for certain commands.

- **Bug Fixes**
	- Maintained existing error handling for output file extensions to ensure valid formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->