### PR TITLE
feat: allow snakemake object access in datavzrd config template

### DIFF
--- a/utils/datavzrd/meta.yaml
+++ b/utils/datavzrd/meta.yaml
@@ -1,8 +1,8 @@
 name: datavzrd
 description: |
-  datavzrd allows to render tables by providing a configuration file. 
-  Configuration templates can be dynamically customized by utilizing the 
-  `rendering integration <https://snakemake.readthedocs.io/en/stable/snakefiles/rules.html#template-rendering-integration>`_.
+  Datavzrd allows to render tables by providing a configuration file.
+  The configuration file can be a yte template.
+  Inside of the template, the snakemake object is accessible (see [docs](https://snakemake.readthedocs.io/en/stable/snakefiles/rules.html#python)).
   Any files specified in the configuration file have to be also specified as additional input files in the
   datavzrd rule.
 url: https://github.com/datavzrd/datavzrd

--- a/utils/datavzrd/wrapper.py
+++ b/utils/datavzrd/wrapper.py
@@ -20,6 +20,8 @@ with tempfile.NamedTemporaryFile(mode="w") as processed, open(
         f,
         outfile=processed,
         variables={
+            "snakemake": snakemake,
+            # keep the ones below for backwards compatibility
             "params": snakemake.params,
             "wildcards": snakemake.wildcards,
             "input": snakemake.input,


### PR DESCRIPTION
<!-- Ensure that the PR title follows conventional commit style (<type>: <description>)-->
<!-- Possible types are here: https://github.com/commitizen/conventional-commit-types/blob/master/index.json -->

<!-- Add a description of your PR here-->

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] I confirm that I have followed the [documentation for contributing to `snakemake-wrappers`](https://snakemake-wrappers.readthedocs.io/en/stable/contributing.html).

While the contributions guidelines are more extensive, please particularly ensure that:
* [x] `test.py` was updated to call any added or updated example rules in a `Snakefile`
* [x] `input:` and `output:` file paths in the rules can be chosen arbitrarily
* [x] wherever possible, command line arguments are inferred and set automatically (e.g. based on file extensions in `input:` or `output:`)
* [x] temporary files are either written to a unique hidden folder in the working directory, or (better) stored where the Python function `tempfile.gettempdir()` points to 
* [x] the `meta.yaml` contains a link to the documentation of the respective tool or command under `url:`
* [x] conda environments use a minimal amount of channels and packages, in recommended ordering


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated `datavzrd` description with improved capitalization and clarity
	- Added information about yte template configuration
	- Clarified accessibility of snakemake object in template

- **Enhancement**
	- Modified `wrapper.py` to include `snakemake` object in processing context
	- Maintained backwards compatibility with existing parameters

<!-- end of auto-generated comment: release notes by coderabbit.ai -->