### PR TITLE
chore: use pytest.skip for skipping tests of unchanged wrappers

### DIFF
--- a/test_wrappers.py
+++ b/test_wrappers.py
@@ -24,13 +24,6 @@ if DIFF_MASTER or DIFF_LAST_COMMIT:
 CONTAINERIZED = os.environ.get("CONTAINERIZED", "false") == "true"
 
 
-class Skipped(Exception):
-    pass
-
-
-pytestmark = pytest.mark.xfail(raises=Skipped)
-
-
 @pytest.fixture
 def tmp_test_dir():
     with tempfile.TemporaryDirectory() as d:
@@ -59,7 +52,7 @@ def run(tmp_test_dir):
             raise ValueError(f"Unable to load or parse {meta_path}.")
 
         if meta.get("blacklisted"):
-            raise Skipped("wrapper blacklisted")
+            pytest.skip("wrapper blacklisted")
 
         dst = os.path.join(tmp_test_subdir, "master")
 
@@ -79,7 +72,7 @@ def run(tmp_test_dir):
             any(f.startswith(w) for f in DIFF_FILES)
             for w in chain(used_wrappers, [wrapper])
         ):
-            raise Skipped("wrappers not modified")
+            pytest.skip("wrappers not modified")
 
         testdir = os.path.join(tmp_test_subdir, "test")
         shutil.copytree(os.path.join(wrapper, "test"), testdir)


### PR DESCRIPTION
<!-- Ensure that the PR title follows conventional commit style (<type>: <description>)-->
<!-- Possible types are here: https://github.com/commitizen/conventional-commit-types/blob/master/index.json -->

<!-- Add a description of your PR here-->

### QC
<!-- Make sure that you can tick the boxes below. -->

* [ ] I confirm that I have followed the [documentation for contributing to `snakemake-wrappers`](https://snakemake-wrappers.readthedocs.io/en/stable/contributing.html).

While the contributions guidelines are more extensive, please particularly ensure that:
* [ ] `test.py` was updated to call any added or updated example rules in a `Snakefile`
* [ ] `input:` and `output:` file paths in the rules can be chosen arbitrarily
* [ ] wherever possible, command line arguments are inferred and set automatically (e.g. based on file extensions in `input:` or `output:`)
* [ ] temporary files are either written to a unique hidden folder in the working directory, or (better) stored where the Python function `tempfile.gettempdir()` points to 
* [ ] the `meta.yaml` contains a link to the documentation of the respective tool or command under `url:`
* [ ] conda environments use a minimal amount of channels and packages, in recommended ordering


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Streamlined test handling by replacing custom error raising with standard test skip functionality, enhancing test clarity and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->