### PR TITLE
perf: don't run code quality checks if only `CHANGELOG.md` modified

### DIFF
--- a/.github/workflows/qc.yml
+++ b/.github/workflows/qc.yml
@@ -2,7 +2,6 @@ name: Code quality
 
 on:
   pull_request:
-    branches-ignore: []
     paths-ignore:
       - 'CHANGELOG.md'
 

--- a/.github/workflows/qc.yml
+++ b/.github/workflows/qc.yml
@@ -2,7 +2,9 @@ name: Code quality
 
 on:
   pull_request:
-    branches_ignore: []
+    branches-ignore: []
+    paths-ignore:
+      - 'CHANGELOG.md'
 
 jobs:
   formatting:


### PR DESCRIPTION
This basically stops the non-required checks on release-please branches, saving a bit of CI resources.

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] I confirm that I have followed the [documentation for contributing to `snakemake-wrappers`](https://snakemake-wrappers.readthedocs.io/en/stable/contributing.html).

While the contributions guidelines are more extensive, please particularly ensure that:
* [x] `test.py` was updated to call any added or updated example rules in a `Snakefile`
* [x] `input:` and `output:` file paths in the rules can be chosen arbitrarily
* [x] wherever possible, command line arguments are inferred and set automatically (e.g. based on file extensions in `input:` or `output:`)
* [x] temporary files are either written to a unique hidden folder in the working directory, or (better) stored where the Python function `tempfile.gettempdir()` points to 
* [x] the `meta.yaml` contains a link to the documentation of the respective tool or command under `url:`
* [x] conda environments use a minimal amount of channels and packages, in recommended ordering


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Simplified the criteria for triggering quality control checks by removing branch-related conditions, ensuring that only specific path changes will activate the workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->