### PR TITLE
docs: switch back to only conda for contribution recommendations

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -35,10 +35,10 @@ And then, contributions should:
 
 .. _development environment:
 
-``conda``/``mamba`` environment for development
+``conda`` environment for development
 -----------------------------------------------
 
-To have all the tools you need for developing and testing wrappers in one single ``conda``/``mamba`` environment:
+To have all the tools you need for developing and testing wrappers in one single ``conda`` environment:
 
 1. `Install miniforge <https://github.com/conda-forge/miniforge?tab=readme-ov-file#install>`_.
 2. Set up the channels as `described for bioconda <https://bioconda.github.io/#using-bioconda>`_.
@@ -46,13 +46,13 @@ To have all the tools you need for developing and testing wrappers in one single
 
 .. code-block:: bash
 
-  mamba create -n snakemake-wrappers-development -c conda-forge -c bioconda snakemake snakefmt snakedeploy black mamba pytest
+  conda create -n snakemake-wrappers-development -c conda-forge -c bioconda snakemake snakefmt snakedeploy black conda pytest
 
 4. Activate the environment with:
 
 .. code-block:: bash
 
-  mamba activate snakemake-wrappers-development
+  conda activate snakemake-wrappers-development
 
 
 .. _meta:
@@ -121,9 +121,9 @@ Example
 This file needs to list all the software that the wrapper code needes to run successfully.
 
 For all software following `semantic versioning <https://semver.org/>`_ conventions, specify (and thus pin) the major and minor version, but leave the patch version unspecified.
-Also, unless this is needed to work around version incompatibilities not properly handled by the conda packages themselves, only specify the actual software needed and let ``conda``/``mamba`` determine the dependencies.
+Also, unless this is needed to work around version incompatibilities not properly handled by the conda packages themselves, only specify the actual software needed and let ``conda`` determine the dependencies.
 
-To make sure that ``conda``/``mamba`` knows where to look for the package, include a list of all of the conda channels that the software and its dependencies require.
+To make sure that ``conda`` knows where to look for the package, include a list of all of the conda channels that the software and its dependencies require.
 This will usually include `conda-forge <https://conda-forge.org/>`_, as it contains many essential libraries that other packages and tools depend on.
 This channel should usually be specified first, to make sure it takes precedence (``snakemake`` asks users to ``conda config --set channel_priority strict``).
 In addition, you may need to include other sustainable community maintained channels (like `bioconda <https://bioconda.github.io/>`_).
@@ -131,7 +131,7 @@ And as the last channel specification, always include ``nodefaults``.
 This avoids software dependency conflicts between the ``conda-forge`` channel and the ``default`` channels that should not be needed nowadays.
 
 Finally, make sure to run ``snakedeploy pin-conda-envs environment.yaml`` on the finished environment specification.
-This will generate a file called ``environment.linux-64.pin.txt`` with all the dependency versions determined by ``conda``/``mamba``, ensuring that a particular wrapper version will always generate the exact same environment with the exact package versions from this file.
+This will generate a file called ``environment.linux-64.pin.txt`` with all the dependency versions determined by ``conda``, ensuring that a particular wrapper version will always generate the exact same environment with the exact package versions from this file.
 You should include this pinning file in the pull request for your wrapper.
 
 Example
@@ -266,8 +266,8 @@ and activate it:
 
 .. code-block:: bash
 
-  mamba create -n test-snakemake-wrapper-docs -c conda-forge sphinx sphinx_rtd_theme pyyaml sphinx-copybutton sphinxawesome_theme myst-parser
-  mamba activate test-snakemake-wrapper-docs
+  conda create -n test-snakemake-wrapper-docs -c conda-forge sphinx sphinx_rtd_theme pyyaml sphinx-copybutton sphinxawesome_theme myst-parser
+  conda activate test-snakemake-wrapper-docs
 
 Then, enter the respective directory and build the docs:
 
@@ -279,8 +279,5 @@ Then, enter the respective directory and build the docs:
 If it runs through, you can open the main page at ``docs/_build/html/index.html`` in a web browser.
 If you want to start fresh, you can clean up the build with ``make clean``.
 
-
-.. |mamba| replace:: ``mamba``
-.. _mamba: https://github.com/mamba-org/mamba
 .. |conda| replace:: ``conda``
 .. _conda: https://conda.io


### PR DESCRIPTION
Recent versions of snakemake switched back to using `conda` instead of `mamba`, since the `libmamba` improvements got incorporated into `conda` itself. To make the `Contribution` docs work, we need to switch them back to `conda` only.

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] I confirm that I have followed the [documentation for contributing to `snakemake-wrappers`](https://snakemake-wrappers.readthedocs.io/en/stable/contributing.html).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated contributing guidelines to use only conda commands for environment setup and dependency management.
  - Revised instructions for creating, activating, and managing development environments by removing mamba references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->