### PR TITLE
fix: remove hardcoded shrink type, and fix typos

### DIFF
--- a/bio/deseq2/wald/meta.yaml
+++ b/bio/deseq2/wald/meta.yaml
@@ -14,7 +14,7 @@ output:
   - normalized_counts_rds: Optional path to normalized counts (RDS formatted)
 params:
   - deseq_extra: Optional parameters provided to the function `DESeq()`
-  - schrink_extra: Optional parameters provided to the function `lfSchrink()`
+  - shrink_extra: Optional parameters provided to the function `lfcShrink()`
   - results_extra: Optional parameters provided to the function `result()`
   - contrast: List of characters. See notes below.
 note: |

--- a/bio/deseq2/wald/test/Snakefile
+++ b/bio/deseq2/wald/test/Snakefile
@@ -9,7 +9,7 @@ rule test_deseq2_wald:
         normalized_counts_rds="counts.RDS",
     params:
         deseq_extra="",
-        shrink_extra="",
+        shrink_extra="type='ashr'",
         results_extra="",
         contrast=["condition", "A", "B"],
     threads: 1

--- a/bio/deseq2/wald/wrapper.R
+++ b/bio/deseq2/wald/wrapper.R
@@ -134,7 +134,7 @@ if ("deseq2_result_dir" %in% base::names(snakemake@output)) {
   base::message(results_cmd)
 
   shrink_extra <- add_extra(
-    "dds = wald, res = results_frame, contrast = contrast, parallel = parallel, type = 'ashr'",
+    "dds = wald, res = results_frame, contrast = contrast, parallel = parallel",
     "shrink_extra"
   )
   shrink_cmd <- base::paste0("DESeq2::lfcShrink(", shrink_extra, ")")


### PR DESCRIPTION
<!-- Ensure that the PR title follows conventional commit style (<type>: <description>)-->
<!-- Possible types are here: https://github.com/commitizen/conventional-commit-types/blob/master/index.json -->

<!-- Add a description of your PR here-->

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] I confirm that I have followed the [documentation for contributing to `snakemake-wrappers`](https://snakemake-wrappers.readthedocs.io/en/stable/contributing.html).

While the contributions guidelines are more extensive, please particularly ensure that:
* [x] `test.py` was updated to call any added or updated example rules in a `Snakefile`
* [x] `input:` and `output:` file paths in the rules can be chosen arbitrarily
* [x] wherever possible, command line arguments are inferred and set automatically (e.g. based on file extensions in `input:` or `output:`)
* [x] temporary files are either written to a unique hidden folder in the working directory, or (better) stored where the Python function `tempfile.gettempdir()` points to 
* [x] the `meta.yaml` contains a link to the documentation of the respective tool or command under `url:`
* [x] conda environments use a minimal amount of channels and packages, in recommended ordering
