### PR TITLE
feat: add wrapper for MEGAHIT

### DIFF
--- a/bio/megahit/environment.linux-64.pin.txt
+++ b/bio/megahit/environment.linux-64.pin.txt
@@ -1,0 +1,32 @@
+# This file may be used to create an environment using:
+# $ conda create --name <env> --file <this file>
+# platform: linux-64
+# created-by: conda 25.3.1
+@EXPLICIT
+https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2#d7c89558ba9fa0495403155b64376d81
+https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2025.4.26-hbd8a1cb_0.conda#95db94f75ba080a22eb623590993167b
+https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.43-h712a8e2_4.conda#01f8d123c96816249efd255a31ad7712
+https://conda.anaconda.org/conda-forge/linux-64/libgomp-15.1.0-h767d61c_2.conda#fbe7d535ff9d3a168c148e07358cd5b1
+https://conda.anaconda.org/conda-forge/noarch/python_abi-3.13-7_cp313.conda#e84b44e6300f1703cb25d29120c5b1d8
+https://conda.anaconda.org/conda-forge/noarch/tzdata-2025b-h78e105d_0.conda#4222072737ccff51314b5ece9c7d6f5a
+https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-2_gnu.tar.bz2#73aaf86a425cc6e73fcf236a5a46396d
+https://conda.anaconda.org/conda-forge/linux-64/libgcc-15.1.0-h767d61c_2.conda#ea8ac52380885ed41c1baa8f1d6d2b93
+https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.7.0-h5888daf_0.conda#db0bfbe7dd197b68ad5f30333bae6ce0
+https://conda.anaconda.org/conda-forge/linux-64/libffi-3.4.6-h2dba641_1.conda#ede4673863426c0883c0063d853bbd85
+https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-15.1.0-h69a702a_2.conda#ddca86c7040dd0e73b2b69bd7833d225
+https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.1-hb9d3cd8_1.conda#a76fd702c93cd2dfd89eff30a5fd45a8
+https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.1.0-h8f9b012_2.conda#1cb1c67961f6dd257eae9e9691b341aa
+https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.1-hb9d3cd8_2.conda#edb0dca6bc32e4f4789199455a1dbeb8
+https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.5-h2d0b736_3.conda#47e340acb35de30501a76c7c799c41d7
+https://conda.anaconda.org/conda-forge/linux-64/openssl-3.5.0-h7b32b05_1.conda#de356753cfdbffcde5bb1e86e3aa6cd0
+https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-h4bc722e_7.conda#62ee74e96c5ebb0af99386de58cf9553
+https://conda.anaconda.org/conda-forge/linux-64/libmpdec-4.0.0-h4bc722e_0.conda#aeb98fdeb2e8f25d43ef71fbacbeec80
+https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.49.2-hee588c1_0.conda#93048463501053a00739215ea3f36324
+https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.38.1-h0b41bf4_0.conda#40b61aab5c7ba9ff276c41cfffe6b80b
+https://conda.anaconda.org/conda-forge/linux-64/readline-8.2-h8c095d6_2.conda#283b96675859b20a825f8fa30f311446
+https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h4845f30_101.conda#d453b98d9c83e71da0741bb0ff4d76bc
+https://conda.anaconda.org/conda-forge/linux-64/zlib-1.3.1-hb9d3cd8_2.conda#c9f075ab2f33b3bbee9e62d4ad0a6cd8
+https://conda.anaconda.org/conda-forge/linux-64/python-3.13.3-hf636f53_101_cp313.conda#10622e12d649154af0bd76bcf33a7c5c
+https://conda.anaconda.org/bioconda/linux-64/megahit-1.2.9-h5ca1c30_6.tar.bz2#55b229a859441b4c7de743280f492975
+https://conda.anaconda.org/conda-forge/noarch/pip-25.1.1-pyh145f28c_0.conda#01384ff1639c6330a0924791413b8714
+https://conda.anaconda.org/bioconda/noarch/snakemake-wrapper-utils-0.7.2-pyhdfd78af_0.tar.bz2#3226d9f73c63e14968e89a5422a1f4d7

--- a/bio/megahit/environment.yaml
+++ b/bio/megahit/environment.yaml
@@ -1,0 +1,7 @@
+channels:
+  - conda-forge
+  - bioconda
+  - nodefaults
+dependencies:
+  - megahit =1.2.9
+  - snakemake-wrapper-utils =0.7.2

--- a/bio/megahit/meta.yaml
+++ b/bio/megahit/meta.yaml
@@ -1,0 +1,23 @@
+name: "megahit"
+
+url: https://github.com/voutcn/megahit
+
+description: |
+  MEGAHIT is an ultra-fast and memory-efficient NGS assembler. It is optimized for metagenomes, but also works well on generic single genome assembly (small or mammalian size) and single-cell assembly.
+  Input options that can be specified for multiple times (supporting plain text and gz/bz2 extensions).
+
+input:
+  - reads: list of reads in FASTQ format
+  - r1: forward reads
+  - r2: reverse reads
+  - interleaved: interleaved reads
+  - unpaired: unpaired reads
+
+output:
+  - contigs: output file with contigs
+  - log: log file
+  - json: options json file
+
+authors:
+  - Jie Zhu
+  - Filipe G. Vieira

--- a/bio/megahit/test/Snakefile
+++ b/bio/megahit/test/Snakefile
@@ -5,7 +5,7 @@ rule run_megahit:
     input:
         reads=["test_reads/sample1_R1.fastq.gz", "test_reads/sample1_R2.fastq.gz"],
     output:
-        contigs="assembly/contigs.fasta",
+        contigs="assembly/final.contigs.fasta",
     benchmark:
         "logs/benchmarks/assembly/megahit.txt"
     params:

--- a/bio/megahit/test/Snakefile
+++ b/bio/megahit/test/Snakefile
@@ -1,0 +1,29 @@
+container: "docker://continuumio/miniconda3:4.4.10"
+
+
+rule run_megahit:
+    input:
+        reads=["test_reads/sample1_R1.fastq.gz", "test_reads/sample1_R2.fastq.gz"],
+    output:
+        contigs="assembly/contigs.fasta",
+    benchmark:
+        "logs/benchmarks/assembly/megahit.txt"
+    params:
+        # all parameters are optional
+        extra="--min-count 10 --k-list 21,29,39,59,79,99,119,141",
+    log:
+        "logs/megahit.log",
+    threads: 8
+    resources:
+        mem_mb=250000,
+    wrapper:
+        "master/bio/megahit"
+
+
+rule download_test_reads:
+    output:
+        ["test_reads/sample1_R1.fastq.gz", "test_reads/sample1_R2.fastq.gz"],
+    log:
+        "logs/download.log",
+    shell:
+        "(wget -O - https://zenodo.org/record/3992790/files/test_reads.tar.gz | tar -xzf -) > {log} 2>&1"

--- a/bio/megahit/wrapper.py
+++ b/bio/megahit/wrapper.py
@@ -1,0 +1,73 @@
+"""Snakemake wrapper for megahit."""
+
+__author__ = "Jie Zhu @alienzj"
+__copyright__ = "Copyright 2025, Jie Zhu"
+__email__ = "alienchuj@gmail.com"
+__license__ = "MIT"
+
+import os, tempfile, shutil
+from snakemake.shell import shell
+from snakemake_wrapper_utils.snakemake import get_mem
+
+# get output_dir and files from output
+output_dir = os.path.split(snakemake.output[0])[0]
+contigs_file = snakemake.output.get("contigs", os.path.join(output_dir, "contigs.fa"))
+contigs_file_original = os.path.join(output_dir, "final.contigs.fa")
+options_file = snakemake.output.get("options", os.path.join(output_dir, "options.json"))
+log_file = snakemake.output.get("log", os.path.join(output_dir, "log"))
+
+# parse params
+extra = snakemake.params.get("extra", "")
+log = snakemake.log_fmt_shell(stdout=True, stderr=True)
+memory_requirements = get_mem(snakemake, out_unit="KiB") * 1024
+
+# parse short reads
+if hasattr(snakemake.input, "reads"):
+    reads = snakemake.input.reads
+else:
+    reads = snakemake.input
+
+input_arg = ""
+
+# handle named inputs if available
+if hasattr(snakemake.input, "r1") and hasattr(snakemake.input, "r2"):
+    input_arg += " -1 {} -2 {} ".format(snakemake.input.r1, snakemake.input.r2)
+elif len(reads) >= 2:
+    input_arg += " -1 {} -2 {} ".format(reads[0], reads[1])
+
+# handle interleaved reads if specified
+if hasattr(snakemake.input, "interleaved"):
+    input_arg += " --12 {} ".format(snakemake.input.interleaved)
+elif len(reads) >= 3 and not hasattr(snakemake.input, "r1"):
+    input_arg += " --12 {} ".format(reads[2])
+
+# handle additional reads if specified
+if hasattr(snakemake.input, "unpaired"):
+    input_arg += " --read {} ".format(snakemake.input.unpaired)
+elif len(reads) >= 4 and not hasattr(snakemake.input, "r1"):
+    input_arg += " --read {} ".format(reads[3])
+
+
+with tempfile.TemporaryDirectory(dir=os.path.dirname(output_dir)) as temp_dir:
+    output_temp_dir = os.path.join(temp_dir, "temp")
+
+    shell(
+        "megahit "
+        " -t {snakemake.threads} "
+        " -m {memory_requirements} "
+        " -o {output_temp_dir} "
+        " {input_arg} "
+        " {extra} "
+        " > {snakemake.log[0]} 2>&1 "
+    )
+
+    if os.path.exists(os.path.join(output_temp_dir, "done")):
+        shell("rm -rf {output_dir}")
+        shutil.move(output_temp_dir, output_dir)
+
+        if (
+            os.path.exists(contigs_file_original)
+            and os.path.exists(options_file)
+            and os.path.exists(log_file)
+        ):
+            shutil.move(contigs_file_original, contigs_file)

--- a/bio/megahit/wrapper.py
+++ b/bio/megahit/wrapper.py
@@ -58,7 +58,7 @@ with tempfile.TemporaryDirectory(dir=os.path.dirname(output_dir)) as temp_dir:
         " -o {output_temp_dir} "
         " {input_arg} "
         " {extra} "
-        " > {snakemake.log[0]} 2>&1 "
+        " {log}"
     )
 
     if os.path.exists(os.path.join(output_temp_dir, "done")):

--- a/bio/megahit/wrapper.py
+++ b/bio/megahit/wrapper.py
@@ -41,8 +41,7 @@ elif len(reads) >= 4 and not hasattr(snakemake.input, "r1"):
     input_arg += " --read {} ".format(reads[3])
 
 # run megahit
-output_dir = os.path.dirname(snakemake.output.get("contigs"))
-with tempfile.TemporaryDirectory(dir=os.path.dirname(output_dir)) as temp_dir:
+with tempfile.TemporaryDirectory() as temp_dir:
     output_temp_dir = os.path.join(temp_dir, "temp")
 
     shell(

--- a/bio/megahit/wrapper.py
+++ b/bio/megahit/wrapper.py
@@ -1,24 +1,17 @@
 """Snakemake wrapper for megahit."""
 
-__author__ = "Jie Zhu @alienzj"
-__copyright__ = "Copyright 2025, Jie Zhu"
+__author__ = "Jie Zhu @alienzj, Filipe G. Vieira @fgvieira"
+__copyright__ = "Copyright 2025, Jie Zhu, Filipe G. Vieira"
 __email__ = "alienchuj@gmail.com"
 __license__ = "MIT"
 
-import os, tempfile, shutil
+import os, tempfile
 from snakemake.shell import shell
 from snakemake_wrapper_utils.snakemake import get_mem
 
-# get output_dir and files from output
-output_dir = os.path.split(snakemake.output[0])[0]
-contigs_file = snakemake.output.get("contigs", os.path.join(output_dir, "contigs.fa"))
-contigs_file_original = os.path.join(output_dir, "final.contigs.fa")
-options_file = snakemake.output.get("options", os.path.join(output_dir, "options.json"))
-log_file = snakemake.output.get("log", os.path.join(output_dir, "log"))
-
 # parse params
 extra = snakemake.params.get("extra", "")
-log = snakemake.log_fmt_shell(stdout=True, stderr=True)
+log = snakemake.log_fmt_shell(stdout=True, stderr=True, append=True)
 memory_requirements = get_mem(snakemake, out_unit="KiB") * 1024
 
 # parse short reads
@@ -47,8 +40,9 @@ if hasattr(snakemake.input, "unpaired"):
 elif len(reads) >= 4 and not hasattr(snakemake.input, "r1"):
     input_arg += " --read {} ".format(reads[3])
 
-
-with tempfile.TemporaryDirectory() as temp_dir:
+# run megahit
+output_dir = os.path.dirname(snakemake.output.get("contigs"))
+with tempfile.TemporaryDirectory(dir=os.path.dirname(output_dir)) as temp_dir:
     output_temp_dir = os.path.join(temp_dir, "temp")
 
     shell(
@@ -58,16 +52,16 @@ with tempfile.TemporaryDirectory() as temp_dir:
         " -o {output_temp_dir} "
         " {input_arg} "
         " {extra} "
-        " {log}"
+        " {log} "
     )
 
-    if os.path.exists(os.path.join(output_temp_dir, "done")):
-        shell("rm -rf {output_dir}")
-        shutil.move(output_temp_dir, output_dir)
-
-        if (
-            os.path.exists(contigs_file_original)
-            and os.path.exists(options_file)
-            and os.path.exists(log_file)
-        ):
-            shutil.move(contigs_file_original, contigs_file)
+    # Ensure user can name each file according to their need
+    output_mapping = {
+        "contigs": f"{output_temp_dir}/final.contigs.fa",
+        "json": f"{output_temp_dir}/options.json",
+        "log": f"{output_temp_dir}/log",
+    }
+    for output_key, temp_file in output_mapping.items():
+        output_path = snakemake.output.get(output_key)
+        if output_path:
+            shell("mv --verbose {temp_file:q} {output_path:q} {log}")

--- a/bio/megahit/wrapper.py
+++ b/bio/megahit/wrapper.py
@@ -16,10 +16,7 @@ log = snakemake.log_fmt_shell(stdout=True, stderr=True, append=True)
 memory_requirements = get_mem(snakemake, out_unit="KiB") * 1024
 
 # parse short reads
-if hasattr(snakemake.input, "reads"):
-    reads = snakemake.input.reads
-else:
-    reads = snakemake.input
+reads = snakemake.input.reads if hasattr(snakemake.input, "reads") else snakemake.input
 
 input_arg = ""
 

--- a/bio/megahit/wrapper.py
+++ b/bio/megahit/wrapper.py
@@ -5,7 +5,8 @@ __copyright__ = "Copyright 2025, Jie Zhu, Filipe G. Vieira"
 __email__ = "alienchuj@gmail.com"
 __license__ = "MIT"
 
-import os, tempfile
+import tempfile
+from pathlib import Path
 from snakemake.shell import shell
 from snakemake_wrapper_utils.snakemake import get_mem
 
@@ -24,43 +25,43 @@ input_arg = ""
 
 # handle named inputs if available
 if hasattr(snakemake.input, "r1") and hasattr(snakemake.input, "r2"):
-    input_arg += " -1 {} -2 {} ".format(snakemake.input.r1, snakemake.input.r2)
+    input_arg += f" -1 {snakemake.input.r1} -2 {snakemake.input.r2}"
 elif len(reads) >= 2:
-    input_arg += " -1 {} -2 {} ".format(reads[0], reads[1])
+    input_arg += f" -1 {reads[0]} -2 {reads[1]}"
 
 # handle interleaved reads if specified
 if hasattr(snakemake.input, "interleaved"):
-    input_arg += " --12 {} ".format(snakemake.input.interleaved)
+    input_arg += f" --12 {snakemake.input.interleaved}"
 elif len(reads) >= 3 and not hasattr(snakemake.input, "r1"):
-    input_arg += " --12 {} ".format(reads[2])
+    input_arg += f" --12 {reads[2]}"
 
 # handle additional reads if specified
 if hasattr(snakemake.input, "unpaired"):
-    input_arg += " --read {} ".format(snakemake.input.unpaired)
+    input_arg += f" --read {snakemake.input.unpaired}"
 elif len(reads) >= 4 and not hasattr(snakemake.input, "r1"):
-    input_arg += " --read {} ".format(reads[3])
+    input_arg += f" --read {reads[3]}"
 
 # run megahit
-with tempfile.TemporaryDirectory() as temp_dir:
-    output_temp_dir = os.path.join(temp_dir, "temp")
+with tempfile.TemporaryDirectory() as tmpdir:
+    output_tmpdir = Path(tmpdir) / "temp"
 
     shell(
-        "megahit "
-        " -t {snakemake.threads} "
-        " -m {memory_requirements} "
-        " -o {output_temp_dir} "
-        " {input_arg} "
-        " {extra} "
-        " {log} "
+        "megahit"
+        " -t {snakemake.threads}"
+        " -m {memory_requirements}"
+        " -o {output_tmpdir}"
+        " {input_arg}"
+        " {extra}"
+        " {log}"
     )
 
     # Ensure user can name each file according to their need
     output_mapping = {
-        "contigs": f"{output_temp_dir}/final.contigs.fa",
-        "json": f"{output_temp_dir}/options.json",
-        "log": f"{output_temp_dir}/log",
+        "contigs": f"{output_tmpdir}/final.contigs.fa",
+        "json": f"{output_tmpdir}/options.json",
+        "log": f"{output_tmpdir}/log",
     }
     for output_key, temp_file in output_mapping.items():
         output_path = snakemake.output.get(output_key)
         if output_path:
-            shell("mv --verbose {temp_file:q} {output_path:q} {log}")
+            shell("cp --verbose {temp_file:q} {output_path:q} {log}")

--- a/bio/megahit/wrapper.py
+++ b/bio/megahit/wrapper.py
@@ -48,7 +48,7 @@ elif len(reads) >= 4 and not hasattr(snakemake.input, "r1"):
     input_arg += " --read {} ".format(reads[3])
 
 
-with tempfile.TemporaryDirectory(dir=os.path.dirname(output_dir)) as temp_dir:
+with tempfile.TemporaryDirectory() as temp_dir:
     output_temp_dir = os.path.join(temp_dir, "temp")
 
     shell(

--- a/test_wrappers.py
+++ b/test_wrappers.py
@@ -6398,6 +6398,20 @@ def test_metaspades(run):
     )
 
 
+def test_megahit(run):
+    run(
+        "bio/megahit",
+        [
+            "snakemake",
+            "run_megahit",
+            "--cores",
+            "2",
+            "--use-conda",
+            "-F",
+        ],
+    )
+
+
 def test_verifybamid2(run):
     run(
         "bio/verifybamid/verifybamid2",

--- a/test_wrappers.py
+++ b/test_wrappers.py
@@ -6403,7 +6403,6 @@ def test_megahit(run):
         "bio/megahit",
         [
             "snakemake",
-            "run_megahit",
             "--cores",
             "2",
             "--use-conda",


### PR DESCRIPTION
<!-- Ensure that the PR title follows conventional commit style (<type>: <description>)-->
<!-- Possible types are here: https://github.com/commitizen/conventional-commit-types/blob/master/index.json -->

<!-- Add a description of your PR here-->

add wrapper for MEGAHIT, which is an ultra-fast and memory-efficient NGS assembler. It is optimized for metagenomes, but also works well on generic single genome assembly (small or mammalian size) and single-cell assembly.

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] I confirm that I have followed the [documentation for contributing to `snakemake-wrappers`](https://snakemake-wrappers.readthedocs.io/en/stable/contributing.html).

While the contributions guidelines are more extensive, please particularly ensure that:
* [x] `test.py` was updated to call any added or updated example rules in a `Snakefile`
* [x] `input:` and `output:` file paths in the rules can be chosen arbitrarily
* [x] wherever possible, command line arguments are inferred and set automatically (e.g. based on file extensions in `input:` or `output:`)
* [x] temporary files are either written to a unique hidden folder in the working directory, or (better) stored where the Python function `tempfile.gettempdir()` points to 
* [x] the `meta.yaml` contains a link to the documentation of the respective tool or command under `url:`
* [x] conda environments use a minimal amount of channels and packages, in recommended ordering


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for the MEGAHIT assembler, including environment setup and metadata.
  - Introduced a Snakemake workflow to automate downloading test data and running MEGAHIT assembly.
  - Provided a wrapper script for seamless integration of MEGAHIT within Snakemake workflows.

- **Tests**
  - Added automated tests to verify MEGAHIT wrapper functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->