### PR TITLE
feat: add param for mem_overhead

### DIFF
--- a/bio/fastqc/meta.yaml
+++ b/bio/fastqc/meta.yaml
@@ -7,5 +7,8 @@ authors:
 input:
   - fastq file
 output:
-  - html file containing statistics
-  - zip file containing statistics
+  - html: statistics file in HTML format
+  - zip: statistics in text format (zip'ed)
+params:
+  - extra: additional program arguments
+  - mem_overhead_factor: factor of total memory saved for overhead

--- a/bio/fastqc/test/Snakefile
+++ b/bio/fastqc/test/Snakefile
@@ -1,15 +1,16 @@
 rule fastqc:
     input:
-        "reads/{sample}.fastq"
+        "reads/{sample}.fastq",
     output:
         html="qc/fastqc/{sample}.html",
-        zip="qc/fastqc/{sample}_fastqc.zip" # the suffix _fastqc.zip is necessary for multiqc to find the file. If not using multiqc, you are free to choose an arbitrary filename
+        zip="qc/fastqc/{sample}_fastqc.zip", # the suffix _fastqc.zip is necessary for multiqc to find the file. If not using multiqc, you are free to choose an arbitrary filename
     params:
-        extra = "--quiet"
+        extra="--quiet",
+        mem_overhead_factor=0.1,
     log:
-        "logs/fastqc/{sample}.log"
+        "logs/fastqc/{sample}.log",
     threads: 1
     resources:
-        mem_mb = 1024
+        mem_mb = 1024,
     wrapper:
         "master/bio/fastqc"

--- a/bio/fastqc/wrapper.py
+++ b/bio/fastqc/wrapper.py
@@ -16,7 +16,9 @@ extra = snakemake.params.get("extra", "")
 log = snakemake.log_fmt_shell(stdout=True, stderr=True)
 # Define memory per thread (https://github.com/s-andrews/FastQC/blob/master/fastqc#L201-L222)
 mem_overhead_factor = snakemake.params.get("mem_overhead_factor", 0.1)
-assert 0 <= mem_overhead_factor < 1, f"mem_overhead_factor must be between 0 and 1, got {mem_overhead_factor}"
+assert (
+    0 <= mem_overhead_factor < 1
+), f"mem_overhead_factor must be between 0 and 1, got {mem_overhead_factor}"
 mem_per_thread_mb = int(
     get_mem(snakemake, "MiB") / snakemake.threads * (1.0 - mem_overhead_factor)
 )

--- a/bio/fastqc/wrapper.py
+++ b/bio/fastqc/wrapper.py
@@ -16,6 +16,7 @@ extra = snakemake.params.get("extra", "")
 log = snakemake.log_fmt_shell(stdout=True, stderr=True)
 # Define memory per thread (https://github.com/s-andrews/FastQC/blob/master/fastqc#L201-L222)
 mem_overhead_factor = snakemake.params.get("mem_overhead_factor", 0.1)
+assert 0 <= mem_overhead_factor < 1, f"mem_overhead_factor must be between 0 and 1, got {mem_overhead_factor}"
 mem_per_thread_mb = int(
     get_mem(snakemake, "MiB") / snakemake.threads * (1.0 - mem_overhead_factor)
 )

--- a/bio/fastqc/wrapper.py
+++ b/bio/fastqc/wrapper.py
@@ -15,8 +15,10 @@ from snakemake_wrapper_utils.snakemake import get_mem
 extra = snakemake.params.get("extra", "")
 log = snakemake.log_fmt_shell(stdout=True, stderr=True)
 # Define memory per thread (https://github.com/s-andrews/FastQC/blob/master/fastqc#L201-L222)
-mem_mb = int(get_mem(snakemake, "MiB") / snakemake.threads)
-
+mem_overhead_factor = snakemake.params.get("mem_overhead_factor", 0.1)
+mem_per_thread_mb = int(
+    get_mem(snakemake, "MiB") / snakemake.threads * (1.0 - mem_overhead_factor)
+)
 
 def basename_without_ext(file_path):
     """Returns basename of file path, without the file extension."""
@@ -45,7 +47,7 @@ with TemporaryDirectory() as tempdir:
     shell(
         "fastqc"
         " --threads {snakemake.threads}"
-        " --memory {mem_mb}"
+        " --memory {mem_per_thread_mb}"
         " {extra}"
         " --outdir {tempdir:q}"
         " {snakemake.input[0]:q}"

--- a/bio/fastqc/wrapper.py
+++ b/bio/fastqc/wrapper.py
@@ -20,6 +20,7 @@ mem_per_thread_mb = int(
     get_mem(snakemake, "MiB") / snakemake.threads * (1.0 - mem_overhead_factor)
 )
 
+
 def basename_without_ext(file_path):
     """Returns basename of file path, without the file extension."""
 


### PR DESCRIPTION
<!-- Ensure that the PR title follows conventional commit style (<type>: <description>)-->
<!-- Possible types are here: https://github.com/commitizen/conventional-commit-types/blob/master/index.json -->

<!-- Add a description of your PR here-->

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] I confirm that I have followed the [documentation for contributing to `snakemake-wrappers`](https://snakemake-wrappers.readthedocs.io/en/stable/contributing.html).

While the contributions guidelines are more extensive, please particularly ensure that:
* [x] `test.py` was updated to call any added or updated example rules in a `Snakefile`
* [x] `input:` and `output:` file paths in the rules can be chosen arbitrarily
* [x] wherever possible, command line arguments are inferred and set automatically (e.g. based on file extensions in `input:` or `output:`)
* [x] temporary files are either written to a unique hidden folder in the working directory, or (better) stored where the Python function `tempfile.gettempdir()` points to 
* [x] the `meta.yaml` contains a link to the documentation of the respective tool or command under `url:`
* [x] conda environments use a minimal amount of channels and packages, in recommended ordering


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a configurable memory overhead setting to optimize memory allocation during FastQC runs.
  - Enhanced output descriptions for FastQC results, clarifying file formats and contents.
- **Refactor**
  - Improved memory management during FastQC execution to optimize resource allocation per thread, enhancing performance stability without changing user workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->