### PR TITLE
fix: Sex.DetERRmine logging

### DIFF
--- a/bio/sexdeterrmine/wrapper.py
+++ b/bio/sexdeterrmine/wrapper.py
@@ -21,10 +21,10 @@ extra = snakemake.params.get("extra", "")
 
 with TemporaryDirectory() as tempdir:
     orig_path = os.path.realpath(os.getcwd())
-    depth_path = os.path.realpath(snakemake.input.depth)
+    input_path = os.path.realpath(snakemake.input.depth)
     os.chdir(tempdir)
     commands = [
-        f"sexdeterrmine --Input {depth_path} {extra} > out.tsv",
+        f"sexdeterrmine --Input {input_path} {extra} > out.tsv",
     ]
 
     tsv = snakemake.output.get("tsv")


### PR DESCRIPTION
<!-- Ensure that the PR title follows conventional commit style (<type>: <description>)-->
<!-- Possible types are here: https://github.com/commitizen/conventional-commit-types/blob/master/index.json -->

<!-- Add a description of your PR here-->
Currently, if the tool Sex.DetERRmine fails on line 27, the log is not given to end user. This PR fixes this behavior.

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] I confirm that I have followed the [documentation for contributing to `snakemake-wrappers`](https://snakemake-wrappers.readthedocs.io/en/stable/contributing.html).

While the contributions guidelines are more extensive, please particularly ensure that:
* [x] `test.py` was updated to call any added or updated example rules in a `Snakefile`
* [x] `input:` and `output:` file paths in the rules can be chosen arbitrarily
* [x] wherever possible, command line arguments are inferred and set automatically (e.g. based on file extensions in `input:` or `output:`)
* [x] temporary files are either written to a unique hidden folder in the working directory, or (better) stored where the Python function `tempfile.gettempdir()` points to 
* [x] the `meta.yaml` contains a link to the documentation of the respective tool or command under `url:`
* [x] conda environments use a minimal amount of channels and packages, in recommended ordering


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Enhanced the execution process of the analysis tool by streamlining output file handling into a single operation, improving reliability and efficiency for users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->