### PR TITLE
fix: add a space after 'haplotag'

### DIFF
--- a/bio/whatshap/haplotag/wrapper.py
+++ b/bio/whatshap/haplotag/wrapper.py
@@ -11,7 +11,7 @@ extra = snakemake.params.get("extra", "")
 log = snakemake.log_fmt_shell(stdout=False, stderr=True)
 
 shell(
-    "whatshap haplotag"
+    "whatshap haplotag "
     "{extra} "
     "--output-threads={snakemake.threads} "
     "-o {snakemake.output} "


### PR DESCRIPTION
Fixes issue #4300

<!-- Ensure that the PR title follows conventional commit style (<type>: <description>)-->
<!-- Possible types are here: https://github.com/commitizen/conventional-commit-types/blob/master/index.json -->

<!-- Add a description of your PR here-->

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] I confirm that I have followed the [documentation for contributing to `snakemake-wrappers`](https://snakemake-wrappers.readthedocs.io/en/stable/contributing.html).

While the contributions guidelines are more extensive, please particularly ensure that:
* [ ] `test.py` was updated to call any added or updated example rules in a `Snakefile`
* [x] `input:` and `output:` file paths in the rules can be chosen arbitrarily
* [x] wherever possible, command line arguments are inferred and set automatically (e.g. based on file extensions in `input:` or `output:`)
* [x] temporary files are either written to a unique hidden folder in the working directory, or (better) stored where the Python function `tempfile.gettempdir()` points to 
* [x] the `meta.yaml` contains a link to the documentation of the respective tool or command under `url:`
* [x] conda environments use a minimal amount of channels and packages, in recommended ordering


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where command-line arguments could be incorrectly concatenated with the command name during execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->