### PR TITLE
fix: Add fallback to FTP if HTTPS cache download fails for vep-cache

### DIFF
--- a/bio/vep/cache/wrapper.py
+++ b/bio/vep/cache/wrapper.py
@@ -3,6 +3,7 @@ __copyright__ = "Copyright 2023, Johannes Köster"
 __email__ = "johannes.koester@uni-due.de"
 __license__ = "MIT"
 
+import subprocess as sp
 import tempfile
 from pathlib import Path
 from snakemake.shell import shell

--- a/bio/vep/cache/wrapper.py
+++ b/bio/vep/cache/wrapper.py
@@ -21,8 +21,16 @@ except ValueError:
 with tempfile.TemporaryDirectory() as tmpdir:
     # We download the cache tarball manually because vep_install does not consider proxy settings (in contrast to curl).
     # See https://github.com/bcbio/bcbio-nextgen/issues/1080
-    url_https = f"https://{snakemake.params.get('url', 'ftp.ensembl.org/pub')}/release-{release}/variation/{vep_dir}/{cache_tarball}"
-    url_ftp = url_https.replace("https://", "ftp://")
+    user_url = snakemake.params.get("url", "ftp.ensembl.org/pub")
+    if user_url.startswith("https://"):
+        url_https = f"{user_url}/release-{release}/variation/{vep_dir}/{cache_tarball}"
+        url_ftp = url_https.replace("https://", "ftp://")
+    elif user_url.startswith("ftp://"):
+        url_ftp = user_url
+        url_https = url_ftp.replace("ftp://", "https://")
+    else:
+        url_https = f"https://{user_url}/release-{release}/variation/{vep_dir}/{cache_tarball}"
+        url_ftp = url_https.replace("https://", "ftp://")
     cache_tarball = (
         f"{snakemake.params.species}_vep_{release}_{snakemake.params.build}.tar.gz"
     )

--- a/bio/vep/cache/wrapper.py
+++ b/bio/vep/cache/wrapper.py
@@ -37,7 +37,7 @@ with tempfile.TemporaryDirectory() as tmpdir:
         url_https = f"{user_url}/release-{release}/variation/{vep_dir}/{cache_tarball}"
         url_ftp = url_https.replace("https://", "ftp://")
     elif user_url.startswith("ftp://"):
-        url_ftp = user_url
+        url_ftp = f"{user_url}/release-{release}/variation/{vep_dir}/{cache_tarball}"
         url_https = url_ftp.replace("ftp://", "https://")
     else:
         url_https = (

--- a/bio/vep/cache/wrapper.py
+++ b/bio/vep/cache/wrapper.py
@@ -47,6 +47,7 @@ with tempfile.TemporaryDirectory() as tmpdir:
 
     try:
         shell(f"curl --fail -L {url_https} -o {tmpdir}/{cache_tarball} {log}")
+        shell(f"gzip -t {tmpdir}/{cache_tarball}")
     except sp.CalledProcessError:
         shell(f"curl -L {url_ftp} -o {tmpdir}/{cache_tarball} {log}")
 

--- a/bio/vep/cache/wrapper.py
+++ b/bio/vep/cache/wrapper.py
@@ -46,7 +46,7 @@ with tempfile.TemporaryDirectory() as tmpdir:
         url_ftp = url_https.replace("https://", "ftp://")
 
     try:
-        shell(f"curl -L {url_https} -o {tmpdir}/{cache_tarball} {log}")
+        shell(f"curl --fail -L {url_https} -o {tmpdir}/{cache_tarball} {log}")
     except sp.CalledProcessError:
         shell(f"curl -L {url_ftp} -o {tmpdir}/{cache_tarball} {log}")
 

--- a/bio/vep/cache/wrapper.py
+++ b/bio/vep/cache/wrapper.py
@@ -29,7 +29,9 @@ with tempfile.TemporaryDirectory() as tmpdir:
         url_ftp = user_url
         url_https = url_ftp.replace("ftp://", "https://")
     else:
-        url_https = f"https://{user_url}/release-{release}/variation/{vep_dir}/{cache_tarball}"
+        url_https = (
+            f"https://{user_url}/release-{release}/variation/{vep_dir}/{cache_tarball}"
+        )
         url_ftp = url_https.replace("https://", "ftp://")
     cache_tarball = (
         f"{snakemake.params.species}_vep_{release}_{snakemake.params.build}.tar.gz"


### PR DESCRIPTION
This pull request updates the cache download logic in the `bio/vep/cache/wrapper.py` script to improve reliability and compatibility with different network environments. The main change is to attempt downloading the cache tarball via HTTPS first, and if that fails, fall back to FTP.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Allow specifying download source as a host or full URL; defaults choose HTTPS for host input and FTP as fallback.
  * Add an "indexed" cache option that selects the indexed cache path and adjusts conversion behavior.

* **Bug Fixes**
  * More robust download: try HTTPS first, verify archive integrity, then fall back to FTP on failure.

* **Compatibility**
  * Tarball naming and downstream installation behavior remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->