### PR TITLE
fix: Switch ensembl annotation download to HTTPS with FTP fallback

### DIFF
--- a/bio/reference/ensembl-annotation/meta.yaml
+++ b/bio/reference/ensembl-annotation/meta.yaml
@@ -5,4 +5,4 @@ authors:
 output:
   - Ensemble GTF or GFF3 anotation file
 params:
-  - url: URL from where to download cache data (optional; by default is ``ftp://ftp.ensembl.org/pub``)
+  - url: URL from where to download cache data (optional; by default is ``https://ftp.ensembl.org/pub``)


### PR DESCRIPTION
This pull request updates the Ensembl annotation download process to prefer secure HTTPS connections and adds a fallback to FTP if HTTPS fails.