### PR TITLE
fix: Use HTTPS for Ensembl downloads and add FTP fallback

### DIFF
--- a/bio/reference/ensembl-variation/wrapper.py
+++ b/bio/reference/ensembl-variation/wrapper.py
@@ -73,7 +73,9 @@ names = [os.path.basename(url) for url in urls]
 
 try:
     gather = "curl -fsSL {urls}".format(urls=" ".join(map("-O {}".format, urls)))
-    ftp_gather = "curl -fsSL {urls}".format(urls=" ".join(map("-O {}".format, ftp_urls)))
+    ftp_gather = "curl -fsSL {urls}".format(
+        urls=" ".join(map("-O {}".format, ftp_urls))
+    )
     workdir = os.getcwd()
     out = os.path.abspath(snakemake.output[0])
     with tempfile.TemporaryDirectory() as tmpdir:

--- a/bio/reference/ensembl-variation/wrapper.py
+++ b/bio/reference/ensembl-variation/wrapper.py
@@ -62,30 +62,32 @@ else:
 
 species_filename = species if release >= 91 else species.capitalize()
 
-url = snakemake.params.get("url", "ftp://ftp.ensembl.org/pub")
+url = snakemake.params.get("url", "https://ftp.ensembl.org/pub")
 urls = [
     f"{url}/{branch}release-{release}/variation/vcf/{species}/{species_filename}{suffix}.vcf.gz"
     for suffix in suffixes
 ]
+ftp_urls = [ftp_url.replace("https://", "ftp://") for ftp_url in urls]
 
 names = [os.path.basename(url) for url in urls]
 
 try:
-    gather = "curl {urls}".format(urls=" ".join(map("-O {}".format, urls)))
+    gather = "curl -fsSL {urls}".format(urls=" ".join(map("-O {}".format, urls)))
+    ftp_gather = "curl -fsSL {urls}".format(urls=" ".join(map("-O {}".format, ftp_urls)))
     workdir = os.getcwd()
     out = os.path.abspath(snakemake.output[0])
     with tempfile.TemporaryDirectory() as tmpdir:
         if snakemake.input.get("fai"):
             fai = os.path.abspath(snakemake.input.fai)
             shell(
-                "(cd {tmpdir}; {gather} && "
+                "(cd {tmpdir}; ({gather} || {ftp_gather}) && "
                 "bcftools concat -Oz --naive {names} > concat.vcf.gz && "
                 "bcftools reheader --fai {fai} concat.vcf.gz "
                 "> {out}) {log}"
             )
         else:
             shell(
-                "(cd {tmpdir}; {gather} && "
+                "(cd {tmpdir}; ({gather} || {ftp_gather}) && "
                 "bcftools concat -Oz --naive {names} "
                 "> {out}) {log}"
             )


### PR DESCRIPTION
The main change is to default to HTTPS for downloads, but to fall back to FTP if HTTPS fails. Additionally, curl is now used with safer flags for better error handling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Downloads Ensembl variation data over HTTPS by default with automatic FTP fallback for improved resilience.
  * Supports fetching multiple chromosome-specific VCF files and seamlessly concatenates them after retrieval.
* **Improvements**
  * More secure and robust download process using modern transfer options.
* **Bug Fixes**
  * Reduces failures when the primary download source is unavailable by transparently retrying via an alternate source.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->