### PR TITLE
fix: more verbose docs for VEP usage

### DIFF
--- a/bio/vep/annotate/meta.yaml
+++ b/bio/vep/annotate/meta.yaml
@@ -14,7 +14,6 @@ input:
   - fasta: Genome sequence in fasta format (optional).
   - fai: Fasta file index (optional).
   - <plugin>: Aux-files required by some plugins (optional).
-  - revel: Path to revel scores file (optional), see VEP documentation.
 output:
   - calls: Annotated variant calls in .vcf, .vcf.gz or .bcf format.
   - stats: HTML file with stats that can be interpreted by e.g. MultiQC.

--- a/bio/vep/annotate/meta.yaml
+++ b/bio/vep/annotate/meta.yaml
@@ -1,5 +1,45 @@
 name: vep annotate
-description: Annotate variant calls with VEP.
+url: https://www.ensembl.org/info/docs/tools/vep/index.html
+description: Annotate variant calls with Ensemble's Variant Effect Predictor (VEP).
 authors:
   - Johannes Köster
   - Felix Mölder
+  - Michael Jahn
+input:
+  - calls: Variant calls in .vcf, .vcf.gz or .bcf format.
+  - cache: Path to cache dir. Can be output from the wrapper VEP / cache.
+  - plugins: Path to plugins dir. Can be output from the wrapper VEP / plugins.
+  - gff: Genome features in GFF format (optional). See notes for details on how to prepare.
+  - csi: Tabix index file for the GFF (optional). See notes for details on how to prepare.
+  - fasta: Genome sequence in fasta format (optional).
+  - fai: Fasta file index (optional).
+  - <plugin>: Aux-files required by some plugins (optional).
+  - revel: Path to revel scores file (optional), see VEP documentation.
+output:
+  - calls: Annotated variant calls in .vcf, .vcf.gz or .bcf format.
+  - stats: HTML file with stats that can be interpreted by e.g. MultiQC.
+params:
+  - plugins: Optional list of plugins to use, see https://www.ensembl.org/info/docs/tools/vep/script/vep_plugins.html
+  - extra: additional program arguments.
+notes: |
+  * In order ro predict variant effects, VEP makes use of variant data bases supplied with the `cache` argument.
+  * Alternatively, genome annotation can be supplied as GFF and Fasta files.
+  * In that case, VEP *does not accept* plain GFF files as e.g. obtained from NCBI.
+    GFF files need to be sorted, gzipped, and indexed as documented on the [VEP homepage](https://www.ensembl.org/info/docs/tools/vep/script/vep_cache.html#gff).
+    It is recommended to add a rule preparing the GFF similar to this:
+    ```
+    rule vep_prepare:
+        input:
+            gff="genome.gff",
+        output:
+            gff="genome.gff.gz",
+            index="genome.gff.gz.tbi",
+        conda:
+            "../envs/vep.yml" # env with htslib
+        log:
+            "tabix.log",
+        threads: 1
+        shell:
+            "grep -v '#' {input.gff} | sort -k1,1 -k4,4n -k5,5n -t$'\t' | bgzip -c > {output.gff};"
+            "tabix -p gff {output.gff}"
+    ```

--- a/bio/vep/annotate/test/Snakefile
+++ b/bio/vep/annotate/test/Snakefile
@@ -6,7 +6,7 @@ rule annotate_variants:
         # optionally add reference genome fasta
         # fasta="genome.fasta",
         # fai="genome.fasta.fai", # fasta index
-        # gff="annotation.gff",
+        # gff="annotation.gff", # note: GFF files must be sorted, gzipped and indexed
         # csi="annotation.gff.csi", # tabix index
         # add mandatory aux-files required by some plugins if not present in the VEP plugin directory specified above.
         # aux files must be defined as following: "<plugin> = /path/to/file" where plugin must be in lowercase


### PR DESCRIPTION
- fixes the problem that VEP does not actually accepts plain GFF files as custom input.
- closes #4404 

### QC

* [x] I confirm that I have followed the [documentation for contributing to `snakemake-wrappers`](https://snakemake-wrappers.readthedocs.io/en/stable/contributing.html).

While the contributions guidelines are more extensive, please particularly ensure that:
* [x] `test.py` was updated to call any added or updated example rules in a `Snakefile`
* [x] `input:` and `output:` file paths in the rules can be chosen arbitrarily
* [x] wherever possible, command line arguments are inferred and set automatically (e.g. based on file extensions in `input:` or `output:`)
* [x] temporary files are either written to a unique hidden folder in the working directory, or (better) stored where the Python function `tempfile.gettempdir()` points to 
* [x] the `meta.yaml` contains a link to the documentation of the respective tool or command under `url:`
* [x] conda environments use a minimal amount of channels and packages, in recommended ordering


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * VEP annotation expanded: support for cache, plugins, GFF, FASTA/FAI, CSI, plugin-specific auxiliary files, annotated calls output, and VEP stats HTML.
  * New parameters for plugin lists and extra program arguments.

* **Documentation**
  * Added official URL and updated description to reference Ensembl VEP.
  * Expanded usage guidance on cache vs. GFF/FASTA with a GFF preparation/indexing example and note that GFFs must be sorted, gzipped, and indexed.
  * Updated authors list.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->