### PR TITLE
fix: Add OOM check to bbtools

### DIFF
--- a/bio/bbtools/wrapper.py
+++ b/bio/bbtools/wrapper.py
@@ -439,7 +439,7 @@ def parse_bbtool(snakemake):
     # log
     log = multiple_log_fmt_shell(snakemake, append_stderr=True)
 
-    command_with_parameters += f" {java_opts} {log}"
+    command_with_parameters += f" {java_opts} -eoom {log}"
 
     return command_with_parameters
 


### PR DESCRIPTION
<!-- Ensure that the PR title follows conventional commit style (<type>: <description>)-->
<!-- Possible types are here: https://github.com/commitizen/conventional-commit-types/blob/master/index.json -->

<!-- Add a description of your PR here-->

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] I confirm that I have followed the [documentation for contributing to `snakemake-wrappers`](https://snakemake-wrappers.readthedocs.io/en/stable/contributing.html).

While the contributions guidelines are more extensive, please particularly ensure that:
* [x] `test.py` was updated to call any added or updated example rules in a `Snakefile`
* [x] `input:` and `output:` file paths in the rules can be chosen arbitrarily
* [x] wherever possible, command line arguments are inferred and set automatically (e.g. based on file extensions in `input:` or `output:`)
* [x] temporary files are either written to a unique hidden folder in the working directory, or (better) stored where the Python function `tempfile.gettempdir()` points to 
* [x] the `meta.yaml` contains a link to the documentation of the respective tool or command under `url:`
* [x] conda environments use a minimal amount of channels and packages, in recommended ordering
