### PR TITLE
feat: allow setting launchDir in params

### DIFF
--- a/utils/nextflow/meta.yaml
+++ b/utils/nextflow/meta.yaml
@@ -6,3 +6,7 @@ notes: |
   This wrapper can e.g. be used to run `nf-core <https://nf-co.re>`_ pipelines. 
   In each of the nf-core pipeline descriptions, you will find available parameters and the output file structure (under "aws results"). 
   The latter can be used to set the desired output files for this wrapper.
+params:
+  launch_dir: |
+    Allows adjusting the directory from which nextflow is launched.
+    Nextflow itself does not allow doing so; it always sets launchDir (read-only) from where it was invoked.

--- a/utils/nextflow/test/Snakefile
+++ b/utils/nextflow/test/Snakefile
@@ -44,15 +44,18 @@ rule chipseq_pipeline:
         gtf="data/genome.gtf",
         # any --<argname> pipeline file arguments can be given here as <argname>=<path>
     output:
-        "results/multiqc/broadPeak/multiqc_report.html",
+        multiqc_report="results/multiqc/broadPeak/multiqc_report.html",
+        # directory from which nextflow is launched, will contain the `.nextflow` directory
+        launch_dir=directory("some_directory"),
     params:
         pipeline="nf-core/chipseq",
         revision="2.0.0",
         profile=["test", "docker"],
+        launch_dir=lambda wildcards, output: output.launch_dir,
         # The chosen pipeline expects an --outdir to be given.
         # We infer this from the output file path. Since that file path can be changed
         # e.g. in case of cloud storage, we use a lambda function to infer the outdir.
-        outdir=lambda wildcards, output: str(Path(output[0]).parents[-2]),
+        outdir=lambda wildcards, output: str(Path(output.multiqc_report).parents[-2]),
         # any --<argname> pipeline arguments can be given here as <argname>=<value>
     handover: True
     wrapper:

--- a/utils/nextflow/wrapper.py
+++ b/utils/nextflow/wrapper.py
@@ -38,6 +38,12 @@ for name, value in snakemake.params.items():
 log = snakemake.log_fmt_shell(stdout=False, stderr=True)
 args = " ".join(args)
 pipeline = snakemake.params.pipeline
-launch_dir = snakemake.params.get("launch_dir", ".")
 
-shell("cd {launch_dir}; nextflow run {pipeline} {args} {extra} {log}")
+launch_dir = snakemake.params.get("launch_dir")
+if launch_dir:
+    if not os.path.isdir(launch_dir):
+        raise ValueError(f"launch_dir does not exist: {launch_dir}")
+    else:
+        os.chdir(launch_dir)
+
+shell("nextflow run {pipeline} {args} {extra} {log}")

--- a/utils/nextflow/wrapper.py
+++ b/utils/nextflow/wrapper.py
@@ -32,16 +32,12 @@ for name, files in snakemake.input.items():
         files = ",".join(files)
     add_parameter(name, files)
 for name, value in snakemake.params.items():
-    if (
-        name != "pipeline"
-        and name != "revision"
-        and name != "profile"
-        and name != "extra"
-    ):
+    if name not in {"pipeline", "revision", "profile", "extra", "launch_dir"}:
         add_parameter(name, value)
 
 log = snakemake.log_fmt_shell(stdout=False, stderr=True)
 args = " ".join(args)
 pipeline = snakemake.params.pipeline
+launch_dir = snakemake.params.get("launch_dir", ".")
 
-shell("nextflow run {pipeline} {args} {extra} {log}")
+shell("cd {launch_dir}; nextflow run {pipeline} {args} {extra} {log}")


### PR DESCRIPTION
Because nextflow does not allow specifying the `launchDir`, but stores its `.nextflow` folder in that directory, the wrapper now allows changing into the directory specified in the param `launch_dir` before invoking nextflow.
Not sure if this is the way to go / a robust way of doing so, though. Comments welcome.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional launch_dir support: runs can validate and switch to a specified working directory before execution to improve reproducibility.

* **Refactor**
  * Parameter forwarding adjusted to exclude internal keys (including launch_dir) from downstream command inputs for cleaner behavior.

* **Documentation**
  * Added configuration documentation describing the launch_dir option and its intended behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->