### PR TITLE
fix: star_arriba meta-wrapper, remove star_index extra parameter

### DIFF
--- a/meta/bio/star_arriba/meta_wrapper.smk
+++ b/meta/bio/star_arriba/meta_wrapper.smk
@@ -7,7 +7,7 @@ rule star_index:
     threads: 4
     params:
         sjdbOverhang=100,
-        extra="--genomeSAindexNbases 2",
+        extra="",
     log:
         "<logs>/star_index_genome.log",
     cache: True  # mark as eligible for between workflow caching


### PR DESCRIPTION
This parameter setting will very likely be copy-pasted (we have done this in one of our workflows;), and might mess up the index creation. So it's best to remove this.

The discussion about this is documented here:
https://github.com/snakemake/snakemake-wrappers/pull/1173/files#r2686497381

<!-- Ensure that the PR title follows conventional commit style (<type>: <description>)-->
<!-- Possible types are here: https://github.com/commitizen/conventional-commit-types/blob/master/index.json -->

<!-- Add a description of your PR here-->

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] I confirm that I have followed the [documentation for contributing to `snakemake-wrappers`](https://snakemake-wrappers.readthedocs.io/en/stable/contributing.html).

While the contributions guidelines are more extensive, please particularly ensure that:
* [x] `test.py` was updated to call any added or updated example rules in a `Snakefile`
* [x] `input:` and `output:` file paths in the rules can be chosen arbitrarily
* [x] wherever possible, command line arguments are inferred and set automatically (e.g. based on file extensions in `input:` or `output:`)
* [x] temporary files are either written to a unique hidden folder in the working directory, or (better) stored where the Python function `tempfile.gettempdir()` points to 
* [x] the `meta.yaml` contains a link to the documentation of the respective tool or command under `url:`
* [x] conda environments use a minimal amount of channels and packages, in recommended ordering


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Modified STAR genome indexing configuration parameters to allow more flexible specification during genome index generation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->