### PR TITLE
docs: fix arriba documentation links (from non-existing readthedocs page to the existing GitHub Wiki)

### DIFF
--- a/bio/arriba/meta.yaml
+++ b/bio/arriba/meta.yaml
@@ -9,16 +9,16 @@ input:
   - bam: Path to SAM, BAM or CRAM formatted alignment file from STAR. See `the documentation on alignment file inputs <https://github.com/suhrig/arriba/wiki/04-Input-files#alignments>`_.
   - genome: Path to FASTA formatted genome sequence file (may be gzipped). See `the documentation on assembly file inputs <https://github.com/suhrig/arriba/wiki/04-Input-files#assembly>`_.
   - annotation: Path to GTF formatted genome annotation file (may be gzipped). See `the documentation on annotation file inputs <https://github.com/suhrig/arriba/wiki/04-Input-files#annotation>`_.
-  - custom_blacklist: (optional) Path to custom arriba blacklist file. See `the documentation on blacklist <https://arriba.readthedocs.io/en/latest/input-files/#blacklist>`_.
-  - custom_known_fusions: (optional) Path to known fusions file. See `the documentation on known fusions <https://arriba.readthedocs.io/en/latest/input-files/#known-fusions>`_.
-  - sv_file: (optional) Path to structural variations calls from WGS. See `the documentation on SV <https://arriba.readthedocs.io/en/latest/input-files/#structural-variant-calls-from-wgs>`_.
+  - custom_blacklist: (optional) Path to custom arriba blacklist file. See `the documentation on blacklist <https://github.com/suhrig/arriba/wiki/04-Input-files#blacklist>`_.
+  - custom_known_fusions: (optional) Path to known fusions file. See `the documentation on known fusions <https://github.com/suhrig/arriba/wiki/04-Input-files#known-fusions>`_.
+  - sv_file: (optional) Path to structural variations calls from WGS. See `the documentation on SV <https://github.com/suhrig/arriba/wiki/04-Input-files#structural-variant-calls-from-wgs>`_.
 output:
   - fusions: Path to output file for fusions after filtering.
   - discarded: (optional) Path to output file for fusions that were filtered out by arriba.
 params:
   - genome_build: Required if any of ``default_blacklist`` or ``default_known_fusions`` is set to ``True``
-  - default_blacklist: Set to ``True`` to use default blacklist. Must be ``False`` (or omitted) if a ``custom_blacklist`` file is specified under ``input:``. See `the documentation on blacklist <https://arriba.readthedocs.io/en/latest/input-files/#blacklist>`_.
-  - default_known_fusions: Set to ``True`` to use default known fusions. Must be ``False`` (or omitted) if a ``custom_known_fusions`` file is specified under ``input:``. See `the documentation on known fusions <https://arriba.readthedocs.io/en/latest/input-files/#known-fusions>`_.
-  - extra: Other `optional parameters <https://arriba.readthedocs.io/en/latest/command-line-options/>`_.
+  - default_blacklist: Set to ``True`` to use default blacklist. Must be ``False`` (or omitted) if a ``custom_blacklist`` file is specified under ``input:``. See `the documentation on blacklist <https://github.com/suhrig/arriba/wiki/04-Input-files#blacklist>`_.
+  - default_known_fusions: Set to ``True`` to use default known fusions. Must be ``False`` (or omitted) if a ``custom_known_fusions`` file is specified under ``input:``. See `the documentation on known fusions <https://github.com/suhrig/arriba/wiki/04-Input-files#known-fusions>`_.
+  - extra: Other `optional parameters <https://github.com/suhrig/arriba/wiki/07-Command-line-options>`_.
 notes: |
   This tool/wrapper does not handle multi threading, as arriba indicates that no significant speedup is expected from it. Also see the ``-@ THREADS`` option description description in the `the command line arguments documentation <https://github.com/suhrig/arriba/wiki/07-Command-line-options>`_.

--- a/bio/arriba/test/Snakefile
+++ b/bio/arriba/test/Snakefile
@@ -18,7 +18,7 @@ rule arriba:
     log:
         "logs/arriba/{sample}.log",
     params:
-        # strongly recommended, see https://arriba.readthedocs.io/en/latest/input-files/#blacklist
+        # strongly recommended, see https://github.com/suhrig/arriba/wiki/04-Input-files#blacklist
         # only set blacklist input-file or blacklist-param
         default_blacklist=False,  # optional
         default_known_fusions=False,  # optional
@@ -51,7 +51,7 @@ rule arriba_with_sv:
     params:
         # required when any of blacklist or known_fusions is set to True
         genome_build="GRCh38",
-        # strongly recommended, see https://arriba.readthedocs.io/en/latest/input-files/#blacklist
+        # strongly recommended, see https://github.com/suhrig/arriba/wiki/04-Input-files#blacklist
         # only set blacklist input-file or blacklist-param
         default_blacklist=False,  # optional
         default_known_fusions=True,  # optional

--- a/meta/bio/star_arriba/meta.yaml
+++ b/meta/bio/star_arriba/meta.yaml
@@ -1,7 +1,7 @@
 name: star-arriba
 description: >
   A subworkflow for fusion detection from RNA-seq data with ``arriba``. The fusion calling is based on splice-aware, chimeric alignments done with ``STAR``.
-  ``STAR`` is used with specific parameters to ensure optimal functionality of the ``arriba`` fusion detection, for details, see the `documentation <https://arriba.readthedocs.io/en/latest/workflow/>`_.
+  ``STAR`` is used with specific parameters to ensure optimal functionality of the ``arriba`` fusion detection, for details, see the `documentation <https://github.com/suhrig/arriba/wiki/01-Home>`_.
 authors:
   - Jan Forster
 pathvars:

--- a/meta/bio/star_arriba/meta_wrapper.smk
+++ b/meta/bio/star_arriba/meta_wrapper.smk
@@ -49,7 +49,7 @@ rule arriba:
         annotation="<genome_annotation>",
         # optional: # A custom tsv containing identified artifacts, such as read-through fusions of neighbouring genes.
         # default blacklists are selected via blacklist parameter
-        # see https://arriba.readthedocs.io/en/latest/input-files/#blacklist
+        # see https://github.com/suhrig/arriba/wiki/04-Input-files#blacklist
         custom_blacklist=[],
     output:
         fusions="<results>/arriba/<per>.fusions.tsv",


### PR DESCRIPTION
<!-- Ensure that the PR title follows conventional commit style (<type>: <description>)-->
<!-- Possible types are here: https://github.com/commitizen/conventional-commit-types/blob/master/index.json -->

<!-- Add a description of your PR here-->

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] I confirm that I have followed the [documentation for contributing to `snakemake-wrappers`](https://snakemake-wrappers.readthedocs.io/en/stable/contributing.html).

While the contributions guidelines are more extensive, please particularly ensure that:
* [x] `test.py` was updated to call any added or updated example rules in a `Snakefile`
* [x] `input:` and `output:` file paths in the rules can be chosen arbitrarily
* [x] wherever possible, command line arguments are inferred and set automatically (e.g. based on file extensions in `input:` or `output:`)
* [x] temporary files are either written to a unique hidden folder in the working directory, or (better) stored where the Python function `tempfile.gettempdir()` points to 
* [x] the `meta.yaml` contains a link to the documentation of the respective tool or command under `url:`
* [x] conda environments use a minimal amount of channels and packages, in recommended ordering


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated external documentation links to reference the GitHub wiki for Arriba configuration and input file guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->