### PR TITLE
ci: add autobump to meta-wrappers

### DIFF
--- a/.github/workflows/autobump.yml
+++ b/.github/workflows/autobump.yml
@@ -34,4 +34,10 @@ jobs:
           subcommand: update-conda-envs
           args: "*/${{ matrix.prefix }}*/environment.yaml */${{ matrix.prefix }}*/*/environment.yaml --create-prs --warn-on-error --entity-regex '(?P<entity>.+)/environment.yaml' --pr-add-label --pin-envs"
 
-      # TODO add snakedeploy update-wrappers command applied to all meta-wrappers once it has the --create-prs option
+      - name: Update meta-wrappers
+        uses: snakemake/snakedeploy-github-action@v1
+        env:
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
+        with:
+          subcommand: update-snakemake-wrappers
+          args: "meta/*/${{ matrix.prefix }}*/meta_wrapper.smk --create-prs --entity-regex '(?P<entity>.+)/meta_wrapper.smk' --pr-add-label --per-snakefile-prs"


### PR DESCRIPTION
<!-- Ensure that the PR title follows conventional commit style (<type>: <description>)-->
<!-- Possible types are here: https://github.com/commitizen/conventional-commit-types/blob/master/index.json -->

<!-- Add a description of your PR here-->

### QC
<!-- Make sure that you can tick the boxes below. -->

* [ ] I confirm that I have followed the [documentation for contributing to `snakemake-wrappers`](https://snakemake-wrappers.readthedocs.io/en/stable/contributing.html).

While the contributions guidelines are more extensive, please particularly ensure that:
* [ ] `test.py` was updated to call any added or updated example rules in a `Snakefile`
* [ ] `input:` and `output:` file paths in the rules can be chosen arbitrarily
* [ ] wherever possible, command line arguments are inferred and set automatically (e.g. based on file extensions in `input:` or `output:`)
* [ ] temporary files are either written to a unique hidden folder in the working directory, or (better) stored where the Python function `tempfile.gettempdir()` points to 
* [ ] the `meta.yaml` contains a link to the documentation of the respective tool or command under `url:`
* [ ] conda environments use a minimal amount of channels and packages, in recommended ordering


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced automated PR creation for Snakemake meta-wrapper updates in the continuous integration pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->