### PR TITLE
fix: Change bbtools logging level

### DIFF
--- a/bio/bbtools/meta.yaml
+++ b/bio/bbtools/meta.yaml
@@ -1,7 +1,7 @@
-name: BBmap-suite
+name: BBtools
 url: https://bbmap.org/#documentation
 description: |
-  Wrapper for all tools in the BBmap suite. One pattern to run them all.
+  Wrapper for all tools in the BBtools. One pattern to run them all.
 authors:
   - Silas Kieser
 input:
@@ -16,7 +16,7 @@ params:
   - command: Required parameter defining the command to be used e.g. 'bbmap.sh'
   - extra: additional program arguments. All other parameters are passed to the bbtool as key=value pairs
 notes: |
-  This wrapper allows to run any of the bbtools. The command is defined by the 'command' parameter, which is required.
+  This wrapper allows to run any of the BBtools. The command is defined by the 'command' parameter, which is required.
   **All keywords in input, output, params are passed as key value pairs to the command!**
   Take care that they are valid for the bbtool.
   In theory all of the tools in the bbmap-suite v39.01 are supported by this wrapper, but we didn't test them all.

--- a/bio/bbtools/wrapper.py
+++ b/bio/bbtools/wrapper.py
@@ -73,32 +73,12 @@ single_threaded_scripts = [
 ]
 
 logging.basicConfig(
-    level=logging.DEBUG,
+    level=logging.WARN,
     format="%(asctime)s %(message)s",
     datefmt="%Y-%m-%d %H:%M:%S",
 )
 
 logger = logging.getLogger(__file__)
-
-
-def handle_exception(exc_type, exc_value, exc_traceback):
-    if issubclass(exc_type, KeyboardInterrupt):
-        sys.__excepthook__(exc_type, exc_value, exc_traceback)
-        return
-
-    logger.error(
-        "".join(
-            [
-                "Uncaught exception: ",
-                *traceback.format_exception(exc_type, exc_value, exc_traceback),
-            ]
-        )
-    )
-
-
-# Install exception handler
-sys.excepthook = handle_exception
-
 
 ###################################### Beginning of wrapper ######################################
 # global flags to check if input and output are parsed multiple times
@@ -121,7 +101,7 @@ def get_java_opts(snakemake, java_mem_overhead_factor=0.15) -> str:
     regex = re.compile(r"-Xmx\d+[gGmM]")
     memory_options = regex.findall(all_java_opts)[0]
 
-    logger.info("Memory specification: " + memory_options)
+    logger.debug(f"Memory specification: {memory_options}")
 
     return memory_options
 
@@ -222,7 +202,7 @@ def _parse_paired_keys(key, values):
 
         parsed_arg = f" {key}=" + ",".join(values)
 
-    logger.info(f"parsed {key} argument: {parsed_arg}")
+    logger.debug(f"parsed {key} argument: {parsed_arg}")
     return parsed_arg
 
 
@@ -237,7 +217,7 @@ def _parse_keywords_for_bbtool(parameter_list, section):
 
     """
 
-    logger.info(f"Parse {section} section of snamemake rule into bbmap command")
+    logger.debug(f"Parse {section} section of snamemake rule into bbmap command")
 
     if section == "params":
         ignore_keys = ["command", "extra"]
@@ -254,7 +234,7 @@ def _parse_keywords_for_bbtool(parameter_list, section):
 
     if len(unnamed_arguments) > 0:
         assert section in ["input", "output"]
-        logger.info(f"Found unnamed arguments. parse them as {section}")
+        logger.debug(f"Found unnamed arguments. parse them as {section}")
 
         command += _parse_in_out(section, unnamed_arguments)
 
@@ -263,9 +243,9 @@ def _parse_keywords_for_bbtool(parameter_list, section):
     parameter_list = dict(parameter_list)
 
     for k in parameter_list.keys():
-        logger.info(f"Parse keyword: {k}")
+        logger.debug(f"Parse keyword: {k}")
         if k in ignore_keys:
-            logger.info(f"{k} argument detected, This is not passed to the bbtool.")
+            logger.debug(f"{k} argument detected, This is not passed to the bbtool.")
             pass
 
         # INPUT keys
@@ -292,7 +272,7 @@ def _parse_keywords_for_bbtool(parameter_list, section):
 
             parsed = f" {k}={parameter_list[k]} "
 
-            logger.info(f"parsed argument: {parsed}")
+            logger.debug(f"parsed argument: {parsed}")
             command += parsed
 
     return command
@@ -348,7 +328,7 @@ def parse_bbtool(snakemake):
 
 
 command = parse_bbtool(snakemake)
-logger.info(f"run command:\n\n\t{command}\n")
+logger.debug(f"run command:\n\n\t{command}\n")
 
 log = snakemake.log_fmt_shell(stdout=True, stderr=True)
 


### PR DESCRIPTION
<!-- Ensure that the PR title follows conventional commit style (<type>: <description>)-->
<!-- Possible types are here: https://github.com/commitizen/conventional-commit-types/blob/master/index.json -->

<!-- Add a description of your PR here-->

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] I confirm that I have followed the [documentation for contributing to `snakemake-wrappers`](https://snakemake-wrappers.readthedocs.io/en/stable/contributing.html).

While the contributions guidelines are more extensive, please particularly ensure that:
* [x] `test.py` was updated to call any added or updated example rules in a `Snakefile`
* [x] `input:` and `output:` file paths in the rules can be chosen arbitrarily
* [x] wherever possible, command line arguments are inferred and set automatically (e.g. based on file extensions in `input:` or `output:`)
* [x] temporary files are either written to a unique hidden folder in the working directory, or (better) stored where the Python function `tempfile.gettempdir()` points to 
* [x] the `meta.yaml` contains a link to the documentation of the respective tool or command under `url:`
* [x] conda environments use a minimal amount of channels and packages, in recommended ordering
