### PR TITLE
fix!: Switch token to an input file

### DIFF
--- a/bio/gdc-client/download/meta.yaml
+++ b/bio/gdc-client/download/meta.yaml
@@ -3,3 +3,10 @@ description: Download GDC data files with the gdc-client.
 url: https://gdc.cancer.gov/access-data/gdc-data-transfer-tool
 authors:
   - David Lähnemann
+input:
+  - File with GDC token (optional)
+output:
+  - Downloaded data
+params:
+  - uuid: GDC resource UUID
+  - extra: additional program arguments (see: https://docs.gdc.cancer.gov/Data_Transfer_Tool/Users_Guide/Data_Download_and_Upload/)

--- a/bio/gdc-client/download/meta.yaml
+++ b/bio/gdc-client/download/meta.yaml
@@ -8,5 +8,5 @@ input:
 output:
   - Downloaded data
 params:
-  - uuid: GDC resource UUID
-  - extra: additional program arguments (see: https://docs.gdc.cancer.gov/Data_Transfer_Tool/Users_Guide/Data_Download_and_Upload/)
+  - uuid: GDC resource UUID (mandatory)
+  - extra: additional program arguments (see `documentation <https://docs.gdc.cancer.gov/Data_Transfer_Tool/Users_Guide/Data_Download_and_Upload/>`_)

--- a/bio/gdc-client/download/test/Snakefile
+++ b/bio/gdc-client/download/test/Snakefile
@@ -11,11 +11,6 @@ rule gdc_download:
         # the column `id` in the GDC manifest files, which can be used to
         # systematically construct sample sheets)
         uuid="173e67fb-917c-43e1-b07c-f2b7d1ca6998",
-        # a gdc_token is only required for controlled access samples,
-        # leave blank otherwise (`gdc_token=""`) or skip this param entirely
-        gdc_token="gdc/gdc-user-token.2020-05-07T10_00_00.555Z.txt",
-        # for valid extra command line arguments, check command line help or:
-        # https://docs.gdc.cancer.gov/Data_Transfer_Tool/Users_Guide/Data_Download_and_Upload/
         extra="",
     threads: 4
     wrapper:
@@ -23,9 +18,12 @@ rule gdc_download:
 
 
 rule gdc_download_bam:
+    input:
+        # a gdc_token is only required for controlled access samples,
+        gdc_token="gdc/gdc-user-token.2020-05-07T10_00_00.555Z.txt",
     output:
         # specify all the downloaded files you want to keep, as all other
-        # downloaded files will be removed automatically e.g. for
+        # downloaded files will be removed automatically. For example, for
         # BAM data this could be
         "raw/{sample}.bam",
         "raw/{sample}.bam.bai",
@@ -39,11 +37,6 @@ rule gdc_download_bam:
         # the column `id` in the GDC manifest files, which can be used to
         # systematically construct sample sheets)
         uuid="72a72637-284e-4f1c-8c5e-0a657136c3c3",
-        # a gdc_token is only required for controlled access samples,
-        # leave blank otherwise (`gdc_token=""`) or skip this param entirely
-        gdc_token="gdc/gdc-user-token.2020-05-07T10_00_00.555Z.txt",
-        # for valid extra command line arguments, check command line help or:
-        # https://docs.gdc.cancer.gov/Data_Transfer_Tool/Users_Guide/Data_Download_and_Upload/
         extra="",
     threads: 4
     wrapper:

--- a/bio/gdc-client/download/test/Snakefile
+++ b/bio/gdc-client/download/test/Snakefile
@@ -5,6 +5,7 @@ rule gdc_download:
         "raw/{sample}.maf.gz",
     log:
         "logs/gdc-client/download/{sample}.log",
+    threads: 4
     params:
         # to use this rule flexibly, make uuid a function that maps your
         # sample names of choice to the UUIDs they correspond to (they are
@@ -12,7 +13,6 @@ rule gdc_download:
         # systematically construct sample sheets)
         uuid="173e67fb-917c-43e1-b07c-f2b7d1ca6998",
         extra="",
-    threads: 4
     wrapper:
         "master/bio/gdc-client/download"
 
@@ -31,6 +31,7 @@ rule gdc_download_bam:
         directory("raw/{sample}/logs"),
     log:
         "logs/gdc-client/download/{sample}.log",
+    threads: 4
     params:
         # to use this rule flexibly, make uuid a function that maps your
         # sample names of choice to the UUIDs they correspond to (they are
@@ -38,6 +39,5 @@ rule gdc_download_bam:
         # systematically construct sample sheets)
         uuid="72a72637-284e-4f1c-8c5e-0a657136c3c3",
         extra="",
-    threads: 4
     wrapper:
         "master/bio/gdc-client/download"

--- a/bio/gdc-client/download/wrapper.py
+++ b/bio/gdc-client/download/wrapper.py
@@ -32,22 +32,11 @@ with TemporaryDirectory() as tempdir:
         tmp_path = path.join(tempdir, uuid, path.basename(out_path))
         if not path.exists(tmp_path):
             root, ext1 = path.splitext(out_path)
-            paths = glob.glob(path.join(tempdir, uuid, "*" + ext1))
+            paths = glob.glob(path.join(tempdir, uuid, f"*{ext1}"))
             if len(paths) > 1:
                 root, ext2 = path.splitext(root)
-                paths = glob.glob(path.join(tempdir, uuid, "*" + ext2 + ext1))
-            if len(paths) == 0:
-                raise ValueError(
-                    f"{out_path} file extension {ext1} does not match any downloaded file. Are you sure that UUID {uuid} provides a file of such format?"
-                    )
-                )
-            if len(paths) > 1:
-                raise ValueError(
-                    "Found more than one downloaded file with extension '{}':\n"
-                    "{}\n"
-                    "Cannot match requested output file {} unambiguously.\n".format(
-                        ext2 + ext1, paths, out_path
-                    )
-                )
+                paths = glob.glob(path.join(tempdir, uuid, f"*{ext2}{ext1}"))
+            assert len(paths) > 0, f"File '{out_path}' extension ({ext1}) does not match any downloaded file. Are you sure that UUID {uuid} provides a file of such format?"
+            assert len(paths) == 1, f"Cannot match requested output file {out_path} unambiguously. Found more than one downloaded file with extension '{ext1}{ext2}': {paths}."
             tmp_path = paths[0]
         shell("mv {tmp_path} {out_path}")

--- a/bio/gdc-client/download/wrapper.py
+++ b/bio/gdc-client/download/wrapper.py
@@ -35,7 +35,11 @@ with TemporaryDirectory() as tempdir:
             if len(paths) > 1:
                 root, ext2 = path.splitext(root)
                 paths = glob.glob(path.join(tempdir, uuid, f"*{ext2}{ext1}"))
-            assert len(paths) > 0, f"File '{out_path}' extension ({ext1}) does not match any downloaded file. Are you sure that UUID {uuid} provides a file of such format?"
-            assert len(paths) == 1, f"Cannot match requested output file {out_path} unambiguously. Found more than one downloaded file with extension '{ext1}{ext2}': {paths}."
+            assert (
+                len(paths) > 0
+            ), f"File '{out_path}' extension ({ext1}) does not match any downloaded file. Are you sure that UUID {uuid} provides a file of such format?"
+            assert (
+                len(paths) == 1
+            ), f"Cannot match requested output file {out_path} unambiguously. Found more than one downloaded file with extension '{ext1}{ext2}': {paths}."
             tmp_path = paths[0]
         shell("mv {tmp_path} {out_path}")

--- a/bio/gdc-client/download/wrapper.py
+++ b/bio/gdc-client/download/wrapper.py
@@ -8,14 +8,15 @@ import os.path as path
 from tempfile import TemporaryDirectory
 import glob
 
+extra = snakemake.params.get("extra", "")
 uuid = snakemake.params.get("uuid", "")
 if uuid == "":
     raise ValueError("You need to provide a GDC UUID via the 'uuid' in 'params'.")
 
-extra = snakemake.params.get("extra", "")
-token = snakemake.params.get("gdc_token", "")
-if token != "":
-    token = "--token-file {}".format(token)
+# Input
+token = snakemake.input.get("gdc_token", "")
+if token:
+    token = f"--token-file {token}"
 
 with TemporaryDirectory() as tempdir:
     shell(

--- a/bio/gdc-client/download/wrapper.py
+++ b/bio/gdc-client/download/wrapper.py
@@ -9,9 +9,8 @@ from tempfile import TemporaryDirectory
 import glob
 
 extra = snakemake.params.get("extra", "")
-uuid = snakemake.params.get("uuid", "")
-if uuid == "":
-    raise ValueError("You need to provide a GDC UUID via the 'uuid' in 'params'.")
+uuid = snakemake.params.uuid
+assert str(uuid).strip(), "You need to provide a GDC UUID via the 'uuid' in 'params'."
 
 # Input
 token = snakemake.input.get("gdc_token", "")
@@ -26,7 +25,7 @@ with TemporaryDirectory() as tempdir:
         " -n {snakemake.threads} "
         " --log-file {snakemake.log} "
         " --dir {tempdir}"
-        " {uuid}"
+        " {snakemake.params.uuid}"
     )
 
     for out_path in snakemake.output:
@@ -39,9 +38,7 @@ with TemporaryDirectory() as tempdir:
                 paths = glob.glob(path.join(tempdir, uuid, "*" + ext2 + ext1))
             if len(paths) == 0:
                 raise ValueError(
-                    "{} file extension {} does not match any downloaded file.\n"
-                    "Are you sure that UUID {} provides a file of such format?\n".format(
-                        out_path, ext1, uuid
+                    f"{out_path} file extension {ext1} does not match any downloaded file. Are you sure that UUID {uuid} provides a file of such format?"
                     )
                 )
             if len(paths) > 1:

--- a/bio/gdc-client/download/wrapper.py
+++ b/bio/gdc-client/download/wrapper.py
@@ -9,8 +9,7 @@ from tempfile import TemporaryDirectory
 import glob
 
 extra = snakemake.params.get("extra", "")
-uuid = snakemake.params.uuid
-assert str(uuid).strip(), "You need to provide a GDC UUID via the 'uuid' in 'params'."
+uuid = snakemake.params.uuid.strip()
 
 # Input
 token = snakemake.input.get("gdc_token", "")


### PR DESCRIPTION
<!-- Ensure that the PR title follows conventional commit style (<type>: <description>)-->
<!-- Possible types are here: https://github.com/commitizen/conventional-commit-types/blob/master/index.json -->

<!-- Add a description of your PR here-->

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] I confirm that I have followed the [documentation for contributing to `snakemake-wrappers`](https://snakemake-wrappers.readthedocs.io/en/stable/contributing.html).

While the contributions guidelines are more extensive, please particularly ensure that:
* [x] `test.py` was updated to call any added or updated example rules in a `Snakefile`
* [x] `input:` and `output:` file paths in the rules can be chosen arbitrarily
* [x] wherever possible, command line arguments are inferred and set automatically (e.g. based on file extensions in `input:` or `output:`)
* [x] temporary files are either written to a unique hidden folder in the working directory, or (better) stored where the Python function `tempfile.gettempdir()` points to 
* [x] the `meta.yaml` contains a link to the documentation of the respective tool or command under `url:`
* [x] conda environments use a minimal amount of channels and packages, in recommended ordering


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Stricter validation for required download identifiers to prevent invalid runs.
  * Improved handling of token file usage so authentication credentials are reliably recognized.
  * Clearer file-extension error messaging.

* **Refactor**
  * Reworked how download parameters (identifier, extra options, token file) are surfaced and passed through the workflow for clearer, more consistent behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/snakemake/snakemake-wrappers/pull/5302?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->