### PR TITLE
docs: document wrapper interface conventions

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -168,6 +168,19 @@ Please ensure that the wrapper:
 * writes any temporary files to a unique hidden folder in the working directory, or (better) stores them where the Python function `tempfile.gettempdir() <https://docs.python.org/3/library/tempfile.html#tempfile.gettempdir>`_ points (this also means that using any Python tempfile default behavior works)
 * is formatted according to the language's standards (for Python, format it with `black`_: ``black wrapper.py``)
 
+Wrapper interface design
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+Wrappers should expose a predictable Snakemake interface and infer command-line arguments where possible:
+
+* use ``input:`` for input files and ``output:`` for output files
+* automatically infer file formats and paths from ``input:`` and ``output:`` whenever possible
+* avoid allowing users to specify parameters that the wrapper can infer from ``input:`` or ``output:``; add error handling and document the behavior in ``meta.yaml`` when needed
+* keep parameters that are only needed for wrapper logic as explicit ``params:`` entries
+* prefer ``params.extra`` for tool-specific command-line options, including mandatory options that the wrapped tool can validate itself
+
+When checking whether a user has already supplied an argument in ``params.extra``, use helpers from ``snakemake-wrapper-utils`` such as `is_arg <https://github.com/snakemake/snakemake-wrapper-utils/blob/6912c9d9c9921a7f02a92940731014d87eb00080/snakemake_wrapper_utils/snakemake.py#L32-L34>`_.
+
 For repeatedly needed functionality you can use the `snakemake-wrapper-utils <https://github.com/snakemake/snakemake-wrapper-utils>`_.
 Use what is available or create new functionality there, whenever you start repeating functions across wrappers.
 Examples of this are:

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -167,13 +167,10 @@ Please ensure that the wrapper:
 * passes on the `threads` value, if the used tool(s) allow(s) it
 * writes any temporary files to a unique hidden folder in the working directory, or (better) stores them where the Python function `tempfile.gettempdir() <https://docs.python.org/3/library/tempfile.html#tempfile.gettempdir>`_ points (this also means that using any Python tempfile default behavior works)
 * is formatted according to the language's standards (for Python, format it with `black`_: ``black wrapper.py``)
-
 * automatically infer file formats and paths from ``input:`` and ``output:`` whenever possible
 * avoid allowing users to specify parameters that the wrapper can infer from ``input:`` or ``output:``; add error handling and document the behavior in ``meta.yaml`` when needed
 * keep parameters that are only needed for wrapper logic as explicit ``params:`` entries
 * prefer ``params.extra`` for tool-specific command-line options, including mandatory options that the wrapped tool can validate itself
-
-When checking whether a user has already supplied an argument in ``params.extra``, use helpers from ``snakemake-wrapper-utils`` such as `is_arg <https://github.com/snakemake/snakemake-wrapper-utils/blob/6912c9d9c9921a7f02a92940731014d87eb00080/snakemake_wrapper_utils/snakemake.py#L32-L34>`_.
 
 For repeatedly needed functionality you can use the `snakemake-wrapper-utils <https://github.com/snakemake/snakemake-wrapper-utils>`_.
 Use what is available or create new functionality there, whenever you start repeating functions across wrappers.

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -167,10 +167,7 @@ Please ensure that the wrapper:
 * passes on the `threads` value, if the used tool(s) allow(s) it
 * writes any temporary files to a unique hidden folder in the working directory, or (better) stores them where the Python function `tempfile.gettempdir() <https://docs.python.org/3/library/tempfile.html#tempfile.gettempdir>`_ points (this also means that using any Python tempfile default behavior works)
 * is formatted according to the language's standards (for Python, format it with `black`_: ``black wrapper.py``)
-* automatically infer file formats and paths from ``input:`` and ``output:`` whenever possible
-* avoid allowing users to specify parameters that the wrapper can infer from ``input:`` or ``output:``; add error handling and document the behavior in ``meta.yaml`` when needed
-* keep parameters that are only needed for wrapper logic as explicit ``params:`` entries
-* prefer ``params.extra`` for tool-specific command-line options, including mandatory options that the wrapped tool can validate itself
+* use explicit parameters only for those needed for wrapper logic, and prefer ``params.extra`` for all other parameters
 
 For repeatedly needed functionality you can use the `snakemake-wrapper-utils <https://github.com/snakemake/snakemake-wrapper-utils>`_.
 Use what is available or create new functionality there, whenever you start repeating functions across wrappers.

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -168,12 +168,6 @@ Please ensure that the wrapper:
 * writes any temporary files to a unique hidden folder in the working directory, or (better) stores them where the Python function `tempfile.gettempdir() <https://docs.python.org/3/library/tempfile.html#tempfile.gettempdir>`_ points (this also means that using any Python tempfile default behavior works)
 * is formatted according to the language's standards (for Python, format it with `black`_: ``black wrapper.py``)
 
-Wrapper interface design
-^^^^^^^^^^^^^^^^^^^^^^^^
-
-Wrappers should expose a predictable Snakemake interface and infer command-line arguments where possible:
-
-* use ``input:`` for input files and ``output:`` for output files
 * automatically infer file formats and paths from ``input:`` and ``output:`` whenever possible
 * avoid allowing users to specify parameters that the wrapper can infer from ``input:`` or ``output:``; add error handling and document the behavior in ``meta.yaml`` when needed
 * keep parameters that are only needed for wrapper logic as explicit ``params:`` entries


### PR DESCRIPTION
## Summary
- Add a short wrapper interface design subsection to the contributing guide.
- Document the preferred split between `input:`, `output:`, explicit wrapper-logic params, and `params.extra`.
- Link to `snakemake-wrapper-utils` `is_arg` for checking user-supplied command-line flags.

## Related issue
Closes #4915

## Testing
- `mamba run -p /tmp/snakemake-wrappers-docs-env-20260526 make html` (succeeded; existing generated docs/logo warnings remain, none from `docs/contributing.rst`)
- `git diff --check HEAD~1 HEAD`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Streamlined contributor guidance by removing a standalone note about checking user-supplied arguments.
  * Improved the formatting and flow of wrapper development requirements by consolidating related interface guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->