### PR TITLE
fix: Redirect yte warnings to log file in datavzrd wrapper

### DIFF
--- a/utils/datavzrd/wrapper.py
+++ b/utils/datavzrd/wrapper.py
@@ -9,6 +9,8 @@ from snakemake.shell import shell
 import shutil
 
 log = snakemake.log_fmt_shell(stdout=True, stderr=True)
+sys.stderr = open(snakemake.log[0], "w", buffering=1)
+sys.stdout = open(snakemake.log[0], "w", buffering=1)
 
 extra = snakemake.params.get("extra", "")
 

--- a/utils/datavzrd/wrapper.py
+++ b/utils/datavzrd/wrapper.py
@@ -17,24 +17,20 @@ with tempfile.NamedTemporaryFile(mode="w") as processed, open(
     snakemake.input.config
 ) as f:
     with open(snakemake.log[0], "a") as log_file:
-        old_stdout, old_stderr = sys.stdout, sys.stderr
         sys.stdout = sys.stderr = log_file
-        try:
-            # support templating in the config file
-            process_yaml(
-                f,
-                outfile=processed,
-                variables={
-                    "snakemake": snakemake,
-                    # keep the ones below for backwards compatibility
-                    "params": snakemake.params,
-                    "wildcards": snakemake.wildcards,
-                    "input": snakemake.input,
-                },
-                require_use_yte=True,
-            )
-        finally:
-            sys.stdout, sys.stderr = old_stdout, old_stderr
+        # support templating in the config file
+        process_yaml(
+            f,
+            outfile=processed,
+            variables={
+                "snakemake": snakemake,
+                # keep the ones below for backwards compatibility
+                "params": snakemake.params,
+                "wildcards": snakemake.wildcards,
+                "input": snakemake.input,
+            },
+            require_use_yte=True,
+        )
     processed.flush()
 
     if config_out := snakemake.output.get("config"):

--- a/utils/datavzrd/wrapper.py
+++ b/utils/datavzrd/wrapper.py
@@ -17,20 +17,24 @@ with tempfile.NamedTemporaryFile(mode="w") as processed, open(
     snakemake.input.config
 ) as f:
     with open(snakemake.log[0], "a") as log_file:
+        old_stdout, old_stderr = sys.stdout, sys.stderr
         sys.stdout = sys.stderr = log_file
-        # support templating in the config file
-        process_yaml(
-            f,
-            outfile=processed,
-            variables={
-                "snakemake": snakemake,
-                # keep the ones below for backwards compatibility
-                "params": snakemake.params,
-                "wildcards": snakemake.wildcards,
-                "input": snakemake.input,
-            },
-            require_use_yte=True,
-        )
+        try:
+            # support templating in the config file
+            process_yaml(
+                f,
+                outfile=processed,
+                variables={
+                    "snakemake": snakemake,
+                    # keep the ones below for backwards compatibility
+                    "params": snakemake.params,
+                    "wildcards": snakemake.wildcards,
+                    "input": snakemake.input,
+                },
+                require_use_yte=True,
+            )
+        finally:
+            sys.stdout, sys.stderr = old_stdout, old_stderr
     processed.flush()
 
     if config_out := snakemake.output.get("config"):

--- a/utils/datavzrd/wrapper.py
+++ b/utils/datavzrd/wrapper.py
@@ -9,7 +9,7 @@ from snakemake.shell import shell
 import shutil
 import sys
 
-log = snakemake.log_fmt_shell(stdout=True, stderr=True)
+log = snakemake.log_fmt_shell(stdout=True, stderr=True, append=True)
 
 extra = snakemake.params.get("extra", "")
 

--- a/utils/datavzrd/wrapper.py
+++ b/utils/datavzrd/wrapper.py
@@ -7,30 +7,31 @@ import tempfile
 from yte import process_yaml
 from snakemake.shell import shell
 import shutil
+import contextlib
 
 log = snakemake.log_fmt_shell(stdout=True, stderr=True)
-sys.stderr = open(snakemake.log[0], "w", buffering=1)
-sys.stdout = open(snakemake.log[0], "w", buffering=1)
 
 extra = snakemake.params.get("extra", "")
 
 with tempfile.NamedTemporaryFile(mode="w") as processed, open(
     snakemake.input.config
 ) as f:
-    # support templating in the config file
-    process_yaml(
-        f,
-        outfile=processed,
-        variables={
-            "snakemake": snakemake,
-            # keep the ones below for backwards compatibility
-            "params": snakemake.params,
-            "wildcards": snakemake.wildcards,
-            "input": snakemake.input,
-        },
-        require_use_yte=True,
-    )
-    processed.flush()
+    with open(snakemake.log[0], "w") as log_yte:
+        with contextlib.redirect_stdout(log_yte), contextlib.redirect_stderr(log_yte):
+            # support templating in the config file
+            process_yaml(
+                f,
+                outfile=processed,
+                variables={
+                    "snakemake": snakemake,
+                    # keep the ones below for backwards compatibility
+                    "params": snakemake.params,
+                    "wildcards": snakemake.wildcards,
+                    "input": snakemake.input,
+                },
+                require_use_yte=True,
+            )
+            processed.flush()
 
     if config_out := snakemake.output.get("config"):
         shutil.copy(processed.name, config_out)

--- a/utils/datavzrd/wrapper.py
+++ b/utils/datavzrd/wrapper.py
@@ -7,7 +7,7 @@ import tempfile
 from yte import process_yaml
 from snakemake.shell import shell
 import shutil
-import contextlib
+import sys
 
 log = snakemake.log_fmt_shell(stdout=True, stderr=True)
 
@@ -16,8 +16,10 @@ extra = snakemake.params.get("extra", "")
 with tempfile.NamedTemporaryFile(mode="w") as processed, open(
     snakemake.input.config
 ) as f:
-    with open(snakemake.log[0], "w") as log_yte:
-        with contextlib.redirect_stdout(log_yte), contextlib.redirect_stderr(log_yte):
+    with open(snakemake.log[0], "a") as log_file:
+        old_stdout, old_stderr = sys.stdout, sys.stderr
+        sys.stdout = sys.stderr = log_file
+        try:
             # support templating in the config file
             process_yaml(
                 f,
@@ -31,7 +33,9 @@ with tempfile.NamedTemporaryFile(mode="w") as processed, open(
                 },
                 require_use_yte=True,
             )
-            processed.flush()
+        finally:
+            sys.stdout, sys.stderr = old_stdout, old_stderr
+    processed.flush()
 
     if config_out := snakemake.output.get("config"):
         shutil.copy(processed.name, config_out)


### PR DESCRIPTION
Previously anything coming from `process_yaml` within the wrapper was logged in the console. This redirects the output into the log file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced logging and output redirection during configuration processing: standard output/error are routed to the workflow log (append enabled), temporary outputs are flushed and optionally preserved to the final config, improving visibility and reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/snakemake/snakemake-wrappers/pull/5312?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->