### PR TITLE
feat: add optional background_genes support to gseapy enrichr

### DIFF
--- a/bio/gseapy/gsea/meta.yaml
+++ b/bio/gseapy/gsea/meta.yaml
@@ -9,7 +9,7 @@ input:
   - cls: Path to categorical class file, required for `gsea`. (CLS formatted)
   - rank: Path to pre-ranked genes, required for `prerank`. (TSV/CSV formatted)
   - gene_list: Path to gene list file, required for `enrichr`. (TXT/TSV/CSV formatted)
-  - background: Optional path to a background file for `enrichr`. (TXT/TSV/CSV formatted)
+  - background_genes: Optional path to a background genes file for `enrichr`. (TXT/TSV/CSV formatted)
 output:
   - outdir: Path to output directory
   - pkl: Path to serialized results (Pickle)

--- a/bio/gseapy/gsea/test/Snakefile
+++ b/bio/gseapy/gsea/test/Snakefile
@@ -76,6 +76,7 @@ rule test_gseapy_prerank:
     wrapper:
         "master/bio/gseapy/gsea"
 
+
 rule test_gseapy_enrichr_with_background:
     input:
         gene_list="genes_list.txt",

--- a/bio/gseapy/gsea/test/Snakefile
+++ b/bio/gseapy/gsea/test/Snakefile
@@ -75,3 +75,19 @@ rule test_gseapy_prerank:
         # gene_sets = [""] # Optional list of gene sets available on biomart
     wrapper:
         "master/bio/gseapy/gsea"
+
+rule test_gseapy_enrichr_with_background:
+    input:
+        gene_list="genes_list.txt",
+        background_genes="genes_list.txt",  # Using same file as background for testing
+    output:
+        enrichr_dir=directory("out/enrichr_background/KEGG_2016"),
+    log:
+        wrapper="logs/enrichr_background.wrapper.log",
+        gseapy="logs/enrichr_background.log",
+    threads: 1
+    params:
+        extra={"cutoff": 1},
+        gene_sets=["KEGG_2016"],
+    wrapper:
+        "master/bio/gseapy/gsea"

--- a/bio/gseapy/gsea/wrapper.py
+++ b/bio/gseapy/gsea/wrapper.py
@@ -119,11 +119,12 @@ with TemporaryDirectory() as tempdir:
     elif snakemake.input.get("gene_list"):
         if snakemake.threads > 1:
             raise TooManyThreadsRequested()
-
         print("Using Biomart EnrichR method")
+        background = snakemake.input.get("background_genes")
         result = gseapy.enrichr(
             gene_list=snakemake.input.gene_list,
             gene_sets=gene_sets,
+            background=background,
             outdir=tempdir,
             **extra,
         )

--- a/bio/gseapy/gsea/wrapper.py
+++ b/bio/gseapy/gsea/wrapper.py
@@ -120,11 +120,10 @@ with TemporaryDirectory() as tempdir:
         if snakemake.threads > 1:
             raise TooManyThreadsRequested()
         print("Using Biomart EnrichR method")
-        background = snakemake.input.get("background_genes")
         result = gseapy.enrichr(
             gene_list=snakemake.input.gene_list,
             gene_sets=gene_sets,
-            background=background,
+            background=snakemake.input.get("background_genes"),
             outdir=tempdir,
             **extra,
         )


### PR DESCRIPTION
Added optional `background_genes` input to the gseapy enrichr method, passed to `gseapy.enrichr(background=)`.

### QC
* [x] I confirm that I have followed the [documentation for contributing to `snakemake-wrappers`](https://snakemake-wrappers.readthedocs.io/en/stable/contributing.html).
* [x] `test.py` was updated to call any added or updated example rules in a `Snakefile`
* [x] `input:` and `output:` file paths in the rules can be chosen arbitrarily
* [x] wherever possible, command line arguments are inferred and set automatically
* [x] temporary files are either written to a unique hidden folder in the working directory, or stored where the Python function `tempfile.gettempdir()` points to
* [x] the `meta.yaml` contains a link to the documentation of the respective tool or command under `url:`
* [x] conda environments use a minimal amount of channels and packages, in recommended ordering.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enrichment analysis now accepts an optional background genes input for Enrichr-based workflows, allowing more precise background specification.

* **Tests**
  * Added test coverage validating enrichment runs using an explicit background genes input to ensure correct behavior and outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->