### PR TITLE
fix: Fix doc builds caused by broken sphinxawesome_theme wheels

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,5 @@
 sphinx
-sphinxawesome-theme
+sphinxawesome-theme!=6.0.3  # 6.0.3 wheel is broken: ships no sphinxawesome_theme module
 sphinx_rtd_theme
 docutils
 pyyaml


### PR DESCRIPTION
At the moments the docs dont build. This PR updates requirements.txt to exclude broken theme version. See https://github.com/kai687/sphinxawesome-theme/issues/2421 and https://github.com/washu-tag/scout/pull/428.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed documentation theme compatibility issue by excluding a problematic version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->