### PR TITLE
feat: sd text replacement

### DIFF
--- a/test_wrappers.py
+++ b/test_wrappers.py
@@ -523,6 +523,15 @@ def test_swarm(run):
     )
 
 
+def test_sd(run):
+    run(
+        "utils/sd",
+        ["snakemake"],
+        compare_results_with_expected={"replaced.txt": "expected_replacement.txt"},
+    )
+    
+
+
 def test_sed(run):
     run(
         "utils/sed",

--- a/test_wrappers.py
+++ b/test_wrappers.py
@@ -526,8 +526,11 @@ def test_swarm(run):
 def test_sd(run):
     run(
         "utils/sd",
-        ["snakemake"],
-        compare_results_with_expected={"replaced.txt": "expected_replacement.txt"},
+        ["snakemake", "replaced.txt", "trailing_whitespace_trimmed.txt"],
+        compare_results_with_expected={
+            "replaced.txt": "expected_replacement.txt",
+            "trailing_whitespace_trimmed.txt": "expected_whitespace_trimming.txt",
+        },
     )
     
 

--- a/utils/sd/environment.linux-64.pin.txt
+++ b/utils/sd/environment.linux-64.pin.txt
@@ -1,0 +1,10 @@
+# This file may be used to create an environment using:
+# $ conda create --name <env> --file <this file>
+# platform: linux-64
+# created-by: conda 26.3.2
+@EXPLICIT
+https://prefix.dev/conda-forge/linux-64/libgomp-15.2.0-he0feb66_19.conda#faac990cb7aedc7f3a2224f2c9b0c26c
+https://prefix.dev/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda#a9f577daf3de00bca7c3c76c0ecbd1de
+https://prefix.dev/conda-forge/linux-64/libgcc-15.2.0-he0feb66_19.conda#57736f29cc2b0ec0b6c2952d3f101b6a
+https://prefix.dev/conda-forge/linux-64/libgcc-ng-15.2.0-h69a702a_19.conda#331ee9b72b9dff570d56b1302c5ab37d
+https://prefix.dev/conda-forge/linux-64/sd-1.0.0-he8a937b_0.conda#d6e64514b3e203f697d0fefe39a7aed7

--- a/utils/sd/environment.yaml
+++ b/utils/sd/environment.yaml
@@ -1,0 +1,5 @@
+channel:
+  - conda-forge
+  - nodefaults
+dependencies:
+  - sd =1.0.0

--- a/utils/sd/environment.yaml
+++ b/utils/sd/environment.yaml
@@ -1,4 +1,4 @@
-channel:
+channels:
   - conda-forge
   - nodefaults
 dependencies:

--- a/utils/sd/meta.yaml
+++ b/utils/sd/meta.yaml
@@ -1,7 +1,8 @@
 name: sd
 url: https://github.com/chmln/sd
 description: |
-  `sd` is an intuitive find & replace CLI.
+  `sd` is an intuitive find & replace CLI. Faster than gnu `sed` for plain text
+  replacement.
 authors:
   - Thibault Dayris
 input:

--- a/utils/sd/meta.yaml
+++ b/utils/sd/meta.yaml
@@ -1,0 +1,16 @@
+name: sd
+url: https://github.com/chmln/sd
+description: |
+  `sd` is an intuitive find & replace CLI.
+authors:
+  - Thibault Dayris
+input:
+  - Path to file to search and replace patterns into
+output:
+  - Path to processed file
+params:
+  - before: Regular expression to search
+  - after: Replacement expression
+  - extra: Optional parameters for `sd`, any non-positional parameter
+notes: |
+  See patterns examples at https://github.com/chmln/sd#quick-guide

--- a/utils/sd/test/Snakefile
+++ b/utils/sd/test/Snakefile
@@ -3,9 +3,9 @@ rule test_sd:
         "file.txt",
     output:
         "replaced.txt",
-    threads: 1
     log:
         "test_sd.log",
+    threads: 1
     params:
         # Pattern to search in original text
         before="change /this/path",

--- a/utils/sd/test/Snakefile
+++ b/utils/sd/test/Snakefile
@@ -1,0 +1,17 @@
+rule test_sd:
+    input:
+        "file.txt",
+    output:
+        "replaced.txt",
+    threads: 1
+    log:
+        "test_sd.log",
+    params:
+        # Pattern to search in original text
+        before="change /this/path",
+        # Replacement pattern in the output text
+        after="keep /that/one",
+        # Any non-positional argument
+        extra="",
+    wrapper:
+        "master/utils/sd"

--- a/utils/sd/test/Snakefile
+++ b/utils/sd/test/Snakefile
@@ -15,3 +15,19 @@ rule test_sd:
         extra="",
     wrapper:
         "master/utils/sd"
+
+
+rule test_sd_regex:
+    input:
+        "file.txt",
+    output:
+        "trailing_whitespace_trimmed.txt",
+    log:
+        "test_sd_regex.log",
+    threads: 1
+    params:
+        before=r"\s+$",
+        after=r"",
+        extra="",
+    wrapper:
+        "master/utils/sd"

--- a/utils/sd/test/expected_replacement.txt
+++ b/utils/sd/test/expected_replacement.txt
@@ -1,1 +1,1 @@
-In this file, keep /that/one
+In this file, keep /that/one    

--- a/utils/sd/test/expected_replacement.txt
+++ b/utils/sd/test/expected_replacement.txt
@@ -1,0 +1,1 @@
+In this file, keep /that/one

--- a/utils/sd/test/expected_whitespace_trimming.txt
+++ b/utils/sd/test/expected_whitespace_trimming.txt
@@ -1,0 +1,1 @@
+In this file, change /this/path

--- a/utils/sd/test/file.txt
+++ b/utils/sd/test/file.txt
@@ -1,1 +1,1 @@
-In this file, change /this/path
+In this file, change /this/path    

--- a/utils/sd/test/file.txt
+++ b/utils/sd/test/file.txt
@@ -1,0 +1,1 @@
+In this file, change /this/path

--- a/utils/sd/wrapper.py
+++ b/utils/sd/wrapper.py
@@ -7,14 +7,20 @@ __copyright__ = "Copyright 2025, Thibault Dayris"
 __license__ = "MIT"
 
 from snakemake.shell import shell
+from shlex import quote
 
 extra = snakemake.params.get("extra", "")
 log = snakemake.log_fmt_shell(stdout=False, stderr=True)
 
-# Since `sd` changes files inplace,
+# Snakemake does not treat empty strings as quotable arguments
+# We use shlex.quote instead of `:q` syntax to force quotes around empty strings
+before = quote(snakemake.params.get("before", ""))
+after = quote(snakemake.params.get("after", ""))
+
+# Since `sd` changes files in place,
 # we use `cat` to disable this behavior
 shell(
     "cat {snakemake.input:q} | "
-    "sd {extra} {snakemake.params.before:q} {snakemake.params.after:q} "
+    "sd {extra} {before} {after} "
     "> {snakemake.output:q} {log}"
 )

--- a/utils/sd/wrapper.py
+++ b/utils/sd/wrapper.py
@@ -14,7 +14,7 @@ log = snakemake.log_fmt_shell(stdout=False, stderr=True)
 # Since `sd` changes files inplace,
 # we use `cat` to disable this behavior
 shell(
-    "cat {snakemake.input} | "
+    "cat {snakemake.input:q} | "
     "sd {extra} {snakemake.params.before:q} {snakemake.params.after:q} "
-    "> {snakemake.output} {log}"
+    "> {snakemake.output:q} {log}"
 )

--- a/utils/sd/wrapper.py
+++ b/utils/sd/wrapper.py
@@ -1,0 +1,20 @@
+# coding: utf-8
+
+"""Snakemake wrappers for sd"""
+
+__author__ = "Thibault Dayris"
+__copyright__ = "Copyright 2025, Thibault Dayris"
+__license__ = "MIT"
+
+from snakemake.shell import shell
+
+extra = snakemake.params.get("extra", "")
+log = snakemake.log_fmt_shell(stdout=False, stderr=True)
+
+# Since `sd` changes files inplace,
+# we use `cat` to disable this behavior
+shell(
+    "cat {snakemake.input} | "
+    "sd {extra} {snakemake.params.before:q} {snakemake.params.after:q} "
+    "> {snakemake.output} {log}"
+)


### PR DESCRIPTION
<!-- Ensure that the PR title follows conventional commit style (<type>: <description>)-->
<!-- Possible types are here: https://github.com/commitizen/conventional-commit-types/blob/master/index.json -->

<!-- Add a description of your PR here-->
This PR adds [`sd`](https://github.com/chmln/sd#quick-guide) for text find/replace faster than sed.

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] I confirm that I have followed the [documentation for contributing to `snakemake-wrappers`](https://snakemake-wrappers.readthedocs.io/en/stable/contributing.html).

While the contributions guidelines are more extensive, please particularly ensure that:
* [x] `test.py` was updated to call any added or updated example rules in a `Snakefile`
* [x] `input:` and `output:` file paths in the rules can be chosen arbitrarily
* [x] wherever possible, command line arguments are inferred and set automatically (e.g. based on file extensions in `input:` or `output:`)
* [x] temporary files are either written to a unique hidden folder in the working directory, or (better) stored where the Python function `tempfile.gettempdir()` points to 
* [x] the `meta.yaml` contains a link to the documentation of the respective tool or command under `url:`
* [x] conda environments use a minimal amount of channels and packages, in recommended ordering


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an `sd` text-replacement utility to the workflow wrapper system.
  * Added Conda environment specs and package metadata for consistent installation and execution.
* **Tests**
  * Added an end-to-end automated test that runs the wrapper and verifies output content.
  * Added additional coverage for regex-based replacement, including trailing whitespace trimming, with updated input and expected output files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->