### PR TITLE
fix: Redirect ensembl-sequence wrapper output to log

### DIFF
--- a/bio/reference/ensembl-sequence/wrapper.py
+++ b/bio/reference/ensembl-sequence/wrapper.py
@@ -21,7 +21,7 @@ if release >= 81 and build == "GRCh37":
 elif snakemake.params.get("branch"):
     branch = snakemake.params.branch + "/"
 
-log = snakemake.log_fmt_shell(stdout=False, stderr=True)
+log = snakemake.log_fmt_shell(stdout=True, stderr=True, append=True)
 
 spec = ("{build}" if int(release) > 75 else "{build}.{release}").format(
     build=build, release=release
@@ -71,10 +71,10 @@ for suffix in suffixes:
     try:
         # --location follows redirects, --head only gets the header without any download,
         # Content-Length is only there if the file exists, for both https:// and ftp://
-        shell("curl --location --head {url} | grep 'Content-Length'")
+        shell("(curl --location --head {url} | grep 'Content-Length') {log}")
     except sp.CalledProcessError:
         try:
-            shell("curl --location --head {url_ftp} | grep 'Content-Length'")
+            shell("(curl --location --head {url_ftp} | grep 'Content-Length') {log}")
         except sp.CalledProcessError:
             if chromosome:
                 logger.error(


### PR DESCRIPTION
At the moment the wrapper outputs this into the console despite having its own log file:

```bash
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0 66.0M    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
Content-Length: 69273468
  0 65.2M    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
Content-Length: 68379704
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved logging for sequence download checks so output is captured in the job log more reliably.
  * Ensured both the initial request and retry path record log output when probing HTTP/FTP headers, making failures easier to diagnose.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->