### PR TITLE
fix: windows support for rasterio - clip

### DIFF
--- a/geo/rasterio/clip/wrapper.py
+++ b/geo/rasterio/clip/wrapper.py
@@ -128,7 +128,7 @@ def clip_wrapper(
         like_crs, dst_crs, l_minx, l_miny, l_maxx, l_maxy, densify_pts=21
     )
 
-    profile = PROFILE_DEFAULTS | profile_overrides
+    profile = PROFILE_DEFAULTS | (profile_overrides or {})
     co_commands = " ".join([f"--co {key}={value}" for key, value in profile.items()])
     bounds_arg = f"{r_minx} {r_miny} {r_maxx} {r_maxy}"
 
@@ -139,7 +139,7 @@ def clip_wrapper(
         {extra_options:q} \
         {log}
     """
-    environment = ENV_DEFAULTS | environment_overrides
+    environment = ENV_DEFAULTS | (environment_overrides or {})
     shell(
         cmd,
         input_raster=input_raster,

--- a/geo/rasterio/clip/wrapper.py
+++ b/geo/rasterio/clip/wrapper.py
@@ -70,17 +70,47 @@ def parse_bounds(raw) -> tuple[float, ...]:
 
 def clip_wrapper(
     output_path: str,
-    input_raster: str | None,
-    like_raster: str | None,
-    like_vector: str | None,
-    cog_url: str | None,
-    bounds: str | list | None,
-    bounds_crs: str | None,
-    buffer: float,
-    extra_options: list[str] | None,
-    profile_overrides: dict | None,
-    environment_overrides: dict | None,
+    input_raster: str | None = None,
+    cog_url: str | None = None,
+    like_raster: str | None = None,
+    like_vector: str | None = None,
+    bounds: str | list | None = None,
+    bounds_crs: str | None = None,
+    buffer: float = 0,
+    extra_options: list[str] | None = None,
+    profile_overrides: dict | None = None,
+    environment_overrides: dict | None = None,
 ):
+    """Wraps `rasterio`'s clipping functionality.
+
+    Can clip either local (`input_raster`) or remote (`cog_url`) rasters.
+    Clipping reference is either:
+     - a local file (`like_vector`, `like_raster`)
+     - parametrised bounds (needs `bounds` and `bounds_crs`).
+
+    Args:
+        output_path (str): location of the saved clipped raster.
+        input_raster (str | None):
+            local raster file to clip (optional, defaults to None).
+        cog_url (str | None):
+            URL of the raster file to clip (optional, defaults to None).
+        like_raster (str | None):
+            reference raster file for clipping (optional, defaults to None).
+        like_vector (str | None):
+            reference vector file for clipping (optional, defaults to None).
+        bounds (str | list | None):
+            reference bounds for clipping (optional, defaults to None).
+        bounds_crs (str | None):
+            CRS of the reference bounds (optional, defaults to None).
+        buffer (float):
+            Buffer to apply around the clipping area (optional, defaults to 0).
+        extra_options (list[str] | None): 
+            Additional options for the clip command (optional, defaults to None).
+        profile_overrides (dict | None):
+            Overrides for pre-defined file creation driver (optional, defaults to None).
+        environment_overrides (dict | None): _description_
+            Overrides for GDAL driver setup (optional, defaults to None).
+    """
     if sum(x is not None for x in (like_raster, like_vector, bounds)) != 1:
         raise ValueError(
             "Multiple clipping references given. Specify only one of "
@@ -155,9 +185,9 @@ def clip_wrapper(
 clip_wrapper(
     output_path=snakemake.output.path,
     input_raster=snakemake.input.get("raster", None),
+    cog_url=snakemake.params.get("cog_url", None),
     like_raster=snakemake.input.get("like_raster", None),
     like_vector=snakemake.input.get("like_vector", None),
-    cog_url=snakemake.params.get("cog_url", None),
     bounds=snakemake.params.get("bounds", None),
     bounds_crs=snakemake.params.get("bounds_crs", None),
     buffer=snakemake.params.get("buffer", 0),

--- a/geo/rasterio/clip/wrapper.py
+++ b/geo/rasterio/clip/wrapper.py
@@ -104,7 +104,7 @@ def clip_wrapper(
             CRS of the reference bounds (optional, defaults to None).
         buffer (float):
             Buffer to apply around the clipping area (optional, defaults to 0).
-        extra_options (list[str] | None): 
+        extra_options (list[str] | None):
             Additional options for the clip command (optional, defaults to None).
         profile_overrides (dict | None):
             Overrides for pre-defined file creation driver (optional, defaults to None).
@@ -161,6 +161,7 @@ def clip_wrapper(
     profile = PROFILE_DEFAULTS | (profile_overrides or {})
     co_commands = " ".join([f"--co {key}={value}" for key, value in profile.items()])
     bounds_arg = f"{r_minx} {r_miny} {r_maxx} {r_maxy}"
+    extra_options = extra_options or []
 
     cmd = """
     rio clip {input_raster:q} {output_path:q} \

--- a/geo/rasterio/clip/wrapper.py
+++ b/geo/rasterio/clip/wrapper.py
@@ -114,7 +114,7 @@ def clip_wrapper(
     if buffer:
         buffer = float(buffer)
         if buffer < 0:
-            raise ValueError(f"buffer_degrees must be non-negative, got {buffer}.")
+            raise ValueError(f"buffer must be non-negative, got {buffer}.")
         l_minx -= buffer
         l_miny -= buffer
         l_maxx += buffer
@@ -130,16 +130,26 @@ def clip_wrapper(
 
     profile = PROFILE_DEFAULTS | profile_overrides
     co_commands = " ".join([f"--co {key}={value}" for key, value in profile.items()])
+    bounds_arg = f"{r_minx} {r_miny} {r_maxx} {r_maxy}"
 
-    cmd = f"""
-    rio clip {input_raster} {output_path} \
-        --bounds '{r_minx} {r_miny} {r_maxx} {r_maxy}' \
+    cmd = """
+    rio clip {input_raster:q} {output_path:q} \
+        --bounds {bounds_arg:q} \
         {co_commands} \
-        {" ".join(extra_options)}
+        {extra_options:q} \
         {log}
     """
     environment = ENV_DEFAULTS | environment_overrides
-    shell(cmd, additional_envvars=environment)
+    shell(
+        cmd,
+        input_raster=input_raster,
+        output_path=output_path,
+        bounds_arg=bounds_arg,
+        co_commands=co_commands,
+        extra_options=extra_options,
+        log=log,
+        additional_envvars=environment,
+    )
 
 
 clip_wrapper(


### PR DESCRIPTION
<!-- Ensure that the PR title follows conventional commit style (<type>: <description>)-->
<!-- Possible types are here: https://github.com/commitizen/conventional-commit-types/blob/master/index.json -->

<!-- Add a description of your PR here-->

Fixes #5393 

This PR aims to fix a minor bug in the `clip` wrapper that only happens on Windows due to the awful cmd functionalities of that platform.

I've added `:q` use. The rest of the functionality of that wrapper stays the same.

Additional fixes to make the bot happy:
- Small comment issue (`buffer` is now referenced correctly).
- Better docstrings.

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] I confirm that I have followed the [documentation for contributing to `snakemake-wrappers`](https://snakemake-wrappers.readthedocs.io/en/stable/contributing.html).

While the contributions guidelines are more extensive, please particularly ensure that:
* [x] `test.py` was updated to call any added or updated example rules in a `Snakefile`
* [x] `input:` and `output:` file paths in the rules can be chosen arbitrarily
* [x] wherever possible, command line arguments are inferred and set automatically (e.g. based on file extensions in `input:` or `output:`)
* [x] temporary files are either written to a unique hidden folder in the working directory, or (better) stored where the Python function `tempfile.gettempdir()` points to 
* [x] the `meta.yaml` contains a link to the documentation of the respective tool or command under `url:`
* [x] conda environments use a minimal amount of channels and packages, in recommended ordering


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the validation message for `buffer` to clearly state it must be non-negative.
  * Enhanced `rio clip` command execution to be more reliable when using bounds and custom options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->