### PR TITLE
feat: Agat prepare genome resources meta-wrapper

### DIFF
--- a/meta/bio/agat_genome_statistics/meta.yaml
+++ b/meta/bio/agat_genome_statistics/meta.yaml
@@ -28,8 +28,3 @@ pathvars:
     - resources
     - results
     - logs
-  custom:
-    contigs: List of contigs to keep, e.g. cannonical chromosomes
-    species: Ensembl species name
-    release: Ensembl release tag
-    build: Ensembl genome build identifier

--- a/meta/bio/agat_genome_statistics/meta.yaml
+++ b/meta/bio/agat_genome_statistics/meta.yaml
@@ -1,0 +1,35 @@
+name: Agat complete genome statistics
+url: https://agat.readthedocs.io/en/latest/tools/agat_sp_statistics.html
+description: >
+  Downlaod, fix, and filter Ensembl genomes, then compute genome size and
+  provide genome-wide statistics with Agat.
+  
+    +-------------+-----------+-----------------------------------------------------+
+    | Step        | Tool      | Reason                                              |
+    +=============+===========+=====================================================+
+    | Download    | curl      | Download genome sequence from Ensembl               |
+    +-------------+-----------+-----------------------------------------------------+
+    | Download    | curl      | Download genome annotation from Ensembl             |
+    +-------------+-----------+-----------------------------------------------------+
+    | Fix         | agat      | Fix common Ensembl format issues on GFF files       |
+    +-------------+-----------+-----------------------------------------------------+
+    | Filter      | pyfaidx   | Optionally remove contigs from genome sequences     |
+    +-------------+-----------+-----------------------------------------------------+
+    | Filter      | agat      | Remove features with TSL=NA from annotations        |
+    +-------------+-----------+-----------------------------------------------------+
+    | Filter      | agat      | Ensure same contigs are present in Fasta/GFF files  |
+    +-------------+-----------+-----------------------------------------------------+
+    | Statistics  | agat      | Compute genome-wide statistics                      |
+    +-------------+-----------+-----------------------------------------------------+
+authors:
+  - Thibault Dayris
+pathvars:
+  default:
+    - resources
+    - results
+    - logs
+  custom:
+    contigs: List of contigs to keep, e.g. cannonical chromosomes
+    species: Ensembl species name
+    release: Ensembl release tag
+    build: Ensembl genome build identifier

--- a/meta/bio/agat_genome_statistics/meta_wrapper.smk
+++ b/meta/bio/agat_genome_statistics/meta_wrapper.smk
@@ -1,14 +1,14 @@
 rule download_ensembl_genome_sequence:
     output:
         temp("<resources>/{species}.{build}.{release}/{build}.ensembl.fasta"),
+    log:
+        "<logs>/download_ensembl_genome_sequence/{species}.{build}.{release}.log",
+    cache: "omit-software"
     params:
         species="{species}",
         build="{build}",
         release="{release}",
         datatype="dna",
-    log:
-        "<logs>/download_ensembl_genome_sequence/{species}.{build}.{release}.log",
-    cache: "omit-software"
     wrapper:
         "v5.10.0/bio/reference/ensembl-sequence"
 
@@ -18,11 +18,11 @@ rule filter_genome_sequence_contigs:
         fasta="<resources>/{species}.{build}.{release}/{build}.ensembl.fasta",
     output:
         temp("<resources>/{species}.{build}.{release}/{build}.contigs_filtered.fasta"),
+    log:
+        "<logs>/filter_genome_sequence_contigs/{species}.{build}.{release}.log",
     params:
         extra="",
         regions=config.get("contigs", ""),
-    log:
-        "<logs>/filter_genome_sequence_contigs/{species}.{build}.{release}.log",
     wrapper:
         "v9.4.2/bio/pyfaidx"
 
@@ -30,14 +30,14 @@ rule filter_genome_sequence_contigs:
 rule download_ensembl_genome_annotations:
     output:
         temp("<resources>/{species}.{build}.{release}/{build}.ensembl.gff3"),
+    log:
+        "<logs>/download_ensembl_genome_annotations/{species}.{build}.{release}.log",
+    cache: "omit-software"
     params:
         species="{species}",
         build="{build}",
         release="{release}",
         flavor="",
-    log:
-        "<logs>/download_ensembl_genome_annotations/{species}.{build}.{release}.log",
-    cache: "omit-software"
     wrapper:
         "v9.4.2/bio/reference/ensembl-annotation"
 
@@ -47,11 +47,11 @@ rule fix_known_format_issues_with_ensembl_gff:
         gff="<resources>/{species}.{build}.{release}/{build}.ensembl.gff3",
     output:
         o=temp("<resources>/{species}.{build}.{release}/{build}.format_fixed.gff3"),
+    log:
+        "<logs>/fix_known_format_issues_with_ensembl_gff/{species}.{build}.{release}.log",
     params:
         command="agat_convert_sp_gxf2gxf.pl",
         extra="",
-    log:
-        "<logs>/fix_known_format_issues_with_ensembl_gff/{species}.{build}.{release}.log",
     wrapper:
         "v9.6.0/bio/agat"
 
@@ -61,11 +61,11 @@ rule remove_tsl_na_from_gff_annotations:
         gff="<resources>/{species}.{build}.{release}/{build}.format_fixed.gff3",
     output:
         o=temp("<resources>/{species}.{build}.{release}/{build}.no_tsl_na.gff3"),
+    log:
+        "<logs>/remove_tsl_na_from_gff_annotations/{species}.{build}.{release}.log",
     params:
         command="agat_sp_filter_feature_by_attribute_value.pl",
         extra="--attribute 'transcript_support_level' --value '\"NA\"' --test '='",
-    log:
-        "<logs>/remove_tsl_na_from_gff_annotations/{species}.{build}.{release}.log",
     wrapper:
         "v9.6.0/bio/agat"
 
@@ -76,11 +76,11 @@ rule ensure_annotations_and_sequences_have_same_contigs:
         fasta="<resources>/{species}.{build}.{release}/{build}.contigs_filtered.fasta",
     output:
         o="<resources>/{species}.{build}.{release}/{build}.contigs_filtered.gff3",
+    log:
+        "<logs>/ensure_annotations_and_sequences_have_same_contigs/{species}.{build}.{release}.log",
     params:
         extra="",
         command="agat_sq_filter_feature_from_fasta.pl",
-    log:
-        "<logs>/ensure_annotations_and_sequences_have_same_contigs/{species}.{build}.{release}.log",
     wrapper:
         "v9.6.0/bio/agat"
 

--- a/meta/bio/agat_genome_statistics/meta_wrapper.smk
+++ b/meta/bio/agat_genome_statistics/meta_wrapper.smk
@@ -65,7 +65,7 @@ rule remove_tsl_na_from_gff_annotations:
         "<logs>/remove_tsl_na_from_gff_annotations/{species}.{build}.{release}.log",
     params:
         command="agat_sp_filter_feature_by_attribute_value.pl",
-        extra="--attribute 'transcript_support_level' --value '\"NA\"' --test '='",
+        extra="--attribute 'transcript_support_level' --value 'NA' --test '='",
     wrapper:
         "v9.6.0/bio/agat"
 

--- a/meta/bio/agat_genome_statistics/meta_wrapper.smk
+++ b/meta/bio/agat_genome_statistics/meta_wrapper.smk
@@ -87,12 +87,13 @@ rule ensure_annotations_and_sequences_have_same_contigs:
 
 rule compute_genome_wide_statistics:
     input:
-        # Avoid useless pyfaidx filter in case user do not want to filter on contigs
+        # Avoid useless agat filter in case user do not want to filter on contigs
         gff=branch(
             condition=config.get("contigs"),
             then="<resources>/{species}.{build}.{release}/{build}.contigs_filtered.gff3",
             otherwise="<resources>/{species}.{build}.{release}/{build}.no_tsl_na.gff3",
         ),
+        # Avoid useless pyfaidx filter in case user do not want to filter on contigs
         gs=branch(
             condition=config.get("contigs"),
             then="<resources>/{species}.{build}.{release}/{build}.contigs_filtered.fasta",

--- a/meta/bio/agat_genome_statistics/meta_wrapper.smk
+++ b/meta/bio/agat_genome_statistics/meta_wrapper.smk
@@ -1,0 +1,113 @@
+rule download_ensembl_genome_sequence:
+    output:
+        temp("<resources>/{species}.{build}.{release}/{build}.ensembl.fasta"),
+    params:
+        species="{species}",
+        build="{build}",
+        release="{release}",
+        datatype="dna",
+    log:
+        "<logs>/download_ensembl_genome_sequence/{species}.{build}.{release}.log",
+    cache: "omit-software"
+    wrapper:
+        "v5.10.0/bio/reference/ensembl-sequence"
+
+
+rule filter_genome_sequence_contigs:
+    input:
+        fasta="<resources>/{species}.{build}.{release}/{build}.ensembl.fasta",
+    output:
+        temp("<resources>/{species}.{build}.{release}/{build}.contigs_filtered.fasta"),
+    params:
+        extra="",
+        regions=config.get("contigs", ""),
+    log:
+        "<logs>/filter_genome_sequence_contigs/{species}.{build}.{release}.log",
+    wrapper:
+        "v9.4.2/bio/pyfaidx"
+
+
+rule download_ensembl_genome_annotations:
+    output:
+        temp("<resources>/{species}.{build}.{release}/{build}.ensembl.gff3"),
+    params:
+        species="{species}",
+        build="{build}",
+        release="{release}",
+        flavor="",
+    log:
+        "<logs>/download_ensembl_genome_annotations/{species}.{build}.{release}.log",
+    cache: "omit-software"
+    wrapper:
+        "v9.4.2/bio/reference/ensembl-annotation"
+
+
+rule fix_known_format_issues_with_ensembl_gff:
+    input:
+        gff="<resources>/{species}.{build}.{release}/{build}.ensembl.gff3",
+    output:
+        o=temp("<resources>/{species}.{build}.{release}/{build}.format_fixed.gff3"),
+    params:
+        command="agat_convert_sp_gxf2gxf.pl",
+        extra="",
+    log:
+        "<logs>/fix_known_format_issues_with_ensembl_gff/{species}.{build}.{release}.log",
+    wrapper:
+        "v9.6.0/bio/agat"
+
+
+rule remove_tsl_na_from_gff_annotations:
+    input:
+        gff="<resources>/{species}.{build}.{release}/{build}.format_fixed.gff3",
+    output:
+        o=temp("<resources>/{species}.{build}.{release}/{build}.no_tsl_na.gff3"),
+    params:
+        command="agat_sp_filter_feature_by_attribute_value.pl",
+        extra="--attribute 'transcript_support_level' --value '\"NA\"' --test '='",
+    log:
+        "<logs>/remove_tsl_na_from_gff_annotations/{species}.{build}.{release}.log",
+    wrapper:
+        "v9.6.0/bio/agat"
+
+
+rule ensure_annotations_and_sequences_have_same_contigs:
+    input:
+        gff="<resources>/{species}.{build}.{release}/{build}.no_tsl_na.gff3",
+        fasta="<resources>/{species}.{build}.{release}/{build}.contigs_filtered.fasta",
+    output:
+        o="<resources>/{species}.{build}.{release}/{build}.contigs_filtered.gff3",
+    params:
+        extra="",
+        command="agat_sq_filter_feature_from_fasta.pl",
+    log:
+        "<logs>/ensure_annotations_and_sequences_have_same_contigs/{species}.{build}.{release}.log",
+    wrapper:
+        "v9.6.0/bio/agat"
+
+
+rule compute_genome_wide_statistics:
+    input:
+        # Avoid useless pyfaidx filter in case user do not want to filter on contigs
+        gff=branch(
+            condition=config.get("contigs"),
+            then="<resources>/{species}.{build}.{release}/{build}.contigs_filtered.gff3",
+            otherwise="<resources>/{species}.{build}.{release}/{build}.no_tsl_na.gff3",
+        ),
+        gs=branch(
+            condition=config.get("contigs"),
+            then="<resources>/{species}.{build}.{release}/{build}.contigs_filtered.fasta",
+            otherwise="<resources>/{species}.{build}.{release}/{build}.ensembl.fasta",
+        ),
+    output:
+        report="<results>/{species}.{build}.{release}/agat_genome_statistics.txt",
+        yaml="<results>/{species}.{build}.{release}/agat_genome_statistics.yaml",
+        plot=directory(
+            "<results>/{species}.{build}.{release}/agat_genome_statistics_plots"
+        ),
+    log:
+        "<logs>/compute_genome_wide_statistics/{species}.{build}.{release}.log",
+    params:
+        extra="",
+        command="agat_sp_statistics.pl",
+    wrapper:
+        "v9.6.0/bio/agat"

--- a/meta/bio/agat_genome_statistics/test/Snakefile
+++ b/meta/bio/agat_genome_statistics/test/Snakefile
@@ -1,0 +1,16 @@
+from snakemake.utils import min_version
+
+min_version("9.13.1")
+
+
+configfile: "config.yaml"
+
+
+module agat_genome_statistics:
+    meta_wrapper:
+        "file:.."
+    config:
+        config
+
+
+use rule * from agat_genome_statistics as agat_genome_statistics_*

--- a/meta/bio/agat_genome_statistics/test/Snakefile
+++ b/meta/bio/agat_genome_statistics/test/Snakefile
@@ -7,10 +7,10 @@ configfile: "config.yaml"
 
 
 module agat_genome_statistics:
-    meta_wrapper:
-        "file:.."
     config:
         config
+    meta_wrapper:
+        "file:.."
 
 
 use rule * from agat_genome_statistics as agat_genome_statistics_*

--- a/meta/bio/agat_genome_statistics/test/config.yaml
+++ b/meta/bio/agat_genome_statistics/test/config.yaml
@@ -1,0 +1,3 @@
+contigs:
+  - "I"
+  - "II"

--- a/meta/bio/agat_genome_statistics/used_wrappers.yaml
+++ b/meta/bio/agat_genome_statistics/used_wrappers.yaml
@@ -1,0 +1,5 @@
+wrappers:
+  - bio/reference/ensembl-sequence
+  - bio/reference/ensembl-annotation
+  - bio/pyfaidx
+  - bio/agat

--- a/test_wrappers.py
+++ b/test_wrappers.py
@@ -4839,6 +4839,15 @@ def test_rbt_collapse_reads_to_fragments(run):
     )
 
 
+def test_meta_agat_genome_statistics(run):
+    run(
+        "meta/bio/agat_genome_statistics",
+        [
+            "snakemake",
+            "results/saccharomyces_cerevisiae.R64-1-1.105/agat_genome_statistics.yaml",
+        ],
+    )
+
 def test_meta_gatk_mutect2_calling(run):
     run(
         "meta/bio/gatk_mutect2_calling",


### PR DESCRIPTION
<!-- Ensure that the PR title follows conventional commit style (<type>: <description>)-->
<!-- Possible types are here: https://github.com/commitizen/conventional-commit-types/blob/master/index.json -->

<!-- Add a description of your PR here-->
This PR is here as an attempt to answer a coworker's issue with `pathvars`. `pathvar` evaluations are postponed after the wrapper evaluation. This lead to two kind of errors : 

1. A wrapper expects numbers and `pathvars` can only be strings. e.g. `"v5.10.0/bio/reference/ensembl-sequence"` expects numbers in its `release` parameter.
```
WorkflowError in file "/tmp/tmpvvs9wown/tmpk101_r_n/test/Snakefile", line 6:
Pathvars have to be a mapping of str to str, with keys being valid pathvar names (i.e. alphanumeric + _, lower-case, no leading number). The following entries are invalid: release='105'
```

2. A wrapper can try to process `pathvars` before they're being replaced by Snakemake. e.g. `"v5.10.0/bio/reference/ensembl-sequence"` fails to cast `release` to int.
```
[Mon Jul  6 12:53:43 2026]
localrule agat_genome_statistics_download_ensembl_genome_annotations:
    output: resources/saccharomyces_cerevisiae.R64-1-1.105/R64-1-1.ensembl.gff3
    log: logs/download_ensembl_genome_annotations/saccharomyces_cerevisiae.R64-1-1.105.log
    jobid: 4
    reason: Missing output files: resources/saccharomyces_cerevisiae.R64-1-1.105/R64-1-1.ensembl.gff3
    resources: tmpdir=/tmp
Shell command: None
Activating conda environment: .snakemake/conda/7d2d8499f7bbaec1feb944bfa4ac99b8_
Traceback (most recent call last):
  File "/tmp/tmp82s2l863/tmpn55elvoc/test/.snakemake/scripts/tmps3eznouy.wrapper.py", line 19, in <module>
    release = int(snakemake.params.release)
ValueError: invalid literal for int() with base 10: '<release>'
```

Here, we use `pathvars` and `wildcards` alongside. But replacing the `wildcards` with `pathvars` will reproduce the above issues.

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] I confirm that I have followed the [documentation for contributing to `snakemake-wrappers`](https://snakemake-wrappers.readthedocs.io/en/stable/contributing.html).

While the contributions guidelines are more extensive, please particularly ensure that:
* [x] `test.py` was updated to call any added or updated example rules in a `Snakefile`
* [x] `input:` and `output:` file paths in the rules can be chosen arbitrarily
* [x] wherever possible, command line arguments are inferred and set automatically (e.g. based on file extensions in `input:` or `output:`)
* [x] temporary files are either written to a unique hidden folder in the working directory, or (better) stored where the Python function `tempfile.gettempdir()` points to 
* [x] the `meta.yaml` contains a link to the documentation of the respective tool or command under `url:`
* [x] conda environments use a minimal amount of channels and packages, in recommended ordering

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new genome statistics workflow that downloads genome data, filters contigs, applies annotation fixes, and produces summary reports with plots.
  * Introduced a test configuration for running the workflow on selected contigs.
  * Added automated coverage for the new workflow to verify expected outputs are generated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->