### PR TITLE
feat: add runiq

### DIFF
--- a/test_wrappers.py
+++ b/test_wrappers.py
@@ -3574,6 +3574,17 @@ def test_cairosvg(run):
     run("utils/cairosvg", ["snakemake", "pca.pdf"])
 
 
+
+def test_runiq(run):
+    run(
+        "utils/runiq",
+        ["snakemake"],
+        compare_results_with_expected={
+            "deduplicated.txt": "expected_dedup.txt",
+        },
+    )
+
+
 def test_ripgrep(run):
     run(
         "utils/ripgrep",

--- a/test_wrappers.py
+++ b/test_wrappers.py
@@ -3578,7 +3578,7 @@ def test_cairosvg(run):
 def test_runiq(run):
     run(
         "utils/runiq",
-        ["snakemake"],
+        ["snakemake", "deduplicated.txt"],
         compare_results_with_expected={
             "deduplicated.txt": "expected_dedup.txt",
         },

--- a/utils/runiq/environment.linux-64.pin.txt
+++ b/utils/runiq/environment.linux-64.pin.txt
@@ -1,0 +1,9 @@
+# This file may be used to create an environment using:
+# $ conda create --name <env> --file <this file>
+# platform: linux-64
+# created-by: conda 26.3.2
+@EXPLICIT
+https://conda.anaconda.org/conda-forge/linux-64/libgomp-15.2.0-he0feb66_19.conda#faac990cb7aedc7f3a2224f2c9b0c26c
+https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda#a9f577daf3de00bca7c3c76c0ecbd1de
+https://conda.anaconda.org/conda-forge/linux-64/libgcc-15.2.0-he0feb66_19.conda#57736f29cc2b0ec0b6c2952d3f101b6a
+https://conda.anaconda.org/conda-forge/linux-64/runiq-2.1.0-hdab8a38_0.conda#99b1b55efcbfe72a34a6d253d35bff29

--- a/utils/runiq/environment.yaml
+++ b/utils/runiq/environment.yaml
@@ -1,0 +1,5 @@
+channels:
+  - conda-forge
+  - nodefaults
+dependencies:
+  - runiq =2.1.0

--- a/utils/runiq/meta.yaml
+++ b/utils/runiq/meta.yaml
@@ -1,0 +1,15 @@
+name: runiq
+url: https://github.com/whitfin/runiq
+description: |
+  An efficient way to filter duplicate lines from input. GNU uniq, but faster.
+authors:
+  - Thibault Dayris
+input:
+  - Path to file with duplicates
+output:
+  - Path to (de)duplicated data
+params:
+  - extra: Optional parameters
+notes: |
+  This tool handles unsorted files, and finds duplicates faster and with lesser RAM
+  than classic ` sort | uniq `.

--- a/utils/runiq/test/Snakefile
+++ b/utils/runiq/test/Snakefile
@@ -1,0 +1,12 @@
+rule test_runiq:
+    input:
+        "unsorted_duplicates.txt",
+    output:
+        "deduplicated.txt",
+    log:
+        "test_runiq.log",
+    threads: 1
+    params:
+        extra="",
+    wrapper:
+        "master/utils/runiq"

--- a/utils/runiq/test/expected_dedup.txt
+++ b/utils/runiq/test/expected_dedup.txt
@@ -1,0 +1,3 @@
+this is a unique line
+this is a duplicate line
+this is another unique line

--- a/utils/runiq/test/unsorted_duplicates.txt
+++ b/utils/runiq/test/unsorted_duplicates.txt
@@ -1,0 +1,5 @@
+this is a unique line
+this is a duplicate line
+this is another unique line
+this is a duplicate line
+this is a duplicate line

--- a/utils/runiq/wrapper.py
+++ b/utils/runiq/wrapper.py
@@ -1,0 +1,15 @@
+# coding: utf-8
+
+"""Snakemake wrapper for runiq"""
+
+__author__ = "Thibault Dayris"
+__copyright__ = "Copyright 2026, Thibault Dayris"
+__email__ = "thibault.dayris@gustaveroussy.fr"
+__license__ = "MIT"
+
+from snakemake.shell import shell
+
+log = snakemake.log_fmt_shell(stdout=False, stderr=True)
+extra = snakemake.params.get("extra", "")
+
+shell("runiq {extra} {snakemake.input} > {snakemake.output} {log}")


### PR DESCRIPTION
<!-- Ensure that the PR title follows conventional commit style (<type>: <description>)-->
<!-- Possible types are here: https://github.com/commitizen/conventional-commit-types/blob/master/index.json -->

<!-- Add a description of your PR here-->
This PR add [`runiq`](https://github.com/whitfin/runiq) to the list of available wrappers.

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] I confirm that I have followed the [documentation for contributing to `snakemake-wrappers`](https://snakemake-wrappers.readthedocs.io/en/stable/contributing.html).

While the contributions guidelines are more extensive, please particularly ensure that:
* [x] `test.py` was updated to call any added or updated example rules in a `Snakefile`
* [x] `input:` and `output:` file paths in the rules can be chosen arbitrarily
* [x] wherever possible, command line arguments are inferred and set automatically (e.g. based on file extensions in `input:` or `output:`)
* [x] temporary files are either written to a unique hidden folder in the working directory, or (better) stored where the Python function `tempfile.gettempdir()` points to 
* [x] the `meta.yaml` contains a link to the documentation of the respective tool or command under `url:`
* [x] conda environments use a minimal amount of channels and packages, in recommended ordering


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Snakemake wrapper task for `runiq` to deduplicate text inputs.
  * Added Conda environment and package metadata for `runiq`, including a pinned environment specification.

* **Tests**
  * Added automated test coverage for `runiq` deduplication via workflow execution and direct wrapper testing.
  * Introduced new test fixtures for unsorted duplicate input and the expected deduplicated output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->