### PR TITLE
fix: fix mem spec in samtools/sort wrapper

### DIFF
--- a/bio/samtools/sort/test/Snakefile
+++ b/bio/samtools/sort/test/Snakefile
@@ -6,8 +6,9 @@ rule samtools_sort:
     log:
         "logs/{sample}.log",
     params:
-        mem="64G", # choose as required, the more the better
         extra="",
     threads: 8
+    resources:
+        mem="64G",  # choose as required, the more the better
     wrapper:
         "master/bio/samtools/sort"


### PR DESCRIPTION
<!-- Ensure that the PR title follows conventional commit style (<type>: <description>)-->
<!-- Possible types are here: https://github.com/commitizen/conventional-commit-types/blob/master/index.json -->

<!-- Add a description of your PR here-->

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] I confirm that I have followed the [documentation for contributing to `snakemake-wrappers`](https://snakemake-wrappers.readthedocs.io/en/stable/contributing.html).

While the contributions guidelines are more extensive, please particularly ensure that:
* [x] `test.py` was updated to call any added or updated example rules in a `Snakefile`
* [x] `input:` and `output:` file paths in the rules can be chosen arbitrarily
* [x] wherever possible, command line arguments are inferred and set automatically (e.g. based on file extensions in `input:` or `output:`)
* [x] temporary files are either written to a unique hidden folder in the working directory, or (better) stored where the Python function `tempfile.gettempdir()` points to 
* [x] the `meta.yaml` contains a link to the documentation of the respective tool or command under `url:`
* [x] conda environments use a minimal amount of channels and packages, in recommended ordering


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved memory resource handling for the Samtools sorting workflow.
  * Preserved configurable extra arguments while ensuring memory limits are applied through the workflow’s resource settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->