### PR TITLE
feat: add xan run wrapper

### DIFF
--- a/test_wrappers.py
+++ b/test_wrappers.py
@@ -1226,7 +1226,7 @@ def test_csvtk(run):
 
 def test_xan(run):
     run(
-        "utils/xan",
+        "utils/xan/run",
         [
             "snakemake",
             "processed_through_script.csv",

--- a/test_wrappers.py
+++ b/test_wrappers.py
@@ -1224,7 +1224,20 @@ def test_csvtk(run):
         },
     )
 
-
+def test_xan(run):
+    run(
+        "utils/xan",
+        [
+            "snakemake",
+            "processed_through_script.csv",
+            "processed_through_expression.csv",
+        ],
+        compare_results_with_expected={
+            "processed_through_script.csv": "expected/total_reads.csv",
+            "processed_through_expression.csv": "expected/total_fragments.csv",
+        },
+    )
+            
 def test_xsv(run):
     run(
         "utils/xsv",

--- a/utils/xan/run/environment.linux-64.pin.txt
+++ b/utils/xan/run/environment.linux-64.pin.txt
@@ -1,0 +1,9 @@
+# This file may be used to create an environment using:
+# $ conda create --name <env> --file <this file>
+# platform: linux-64
+# created-by: conda 26.5.3
+@EXPLICIT
+https://conda.anaconda.org/conda-forge/linux-64/libgomp-16.1.0-he0feb66_1.conda#88f2d91cb1533194c323534253094d23
+https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda#a9f577daf3de00bca7c3c76c0ecbd1de
+https://conda.anaconda.org/conda-forge/linux-64/libgcc-16.1.0-ha9f2e26_1.conda#5a7d954665c707c93311657cd779c705
+https://conda.anaconda.org/conda-forge/linux-64/xan-0.60.0-hb17b654_0.conda#0ffd6c201c32b4d0bc921abb3e521f2f

--- a/utils/xan/run/environment.yaml
+++ b/utils/xan/run/environment.yaml
@@ -1,0 +1,5 @@
+channels:
+  - conda-forge
+  - nodefaults
+dependencies:
+  - xan =0.60.0

--- a/utils/xan/run/meta.yaml
+++ b/utils/xan/run/meta.yaml
@@ -5,11 +5,12 @@ authors:
   - Thibault Dayris
 input:
   - Path to a table. See `xan input`,  `xan from` and `xan scrape` to have a list of accepted formats
-  - xan: Path to a xan script
+  - xan_script: Path to a xan script. Ignore it if an expression is provided in `params.expression`
 output:
   - Path to output table, report, etc. See `xan to`, `xan matrix`, `xan network` to have a list of accepted formats
 params:
   - extra: Optional parameter besides `-f | --file`
+  - expression: Expression for xan pipeline. Ignore it if a script is provided in `input.xan_script`
 notes: |
   Use `xan help functions` and `xan help cheatsheet` to see examples of pipelines and
   expressions avilable in this wrapper.

--- a/utils/xan/run/meta.yaml
+++ b/utils/xan/run/meta.yaml
@@ -5,12 +5,14 @@ authors:
   - Thibault Dayris
 input:
   - Path to a table. See `xan input`,  `xan from` and `xan scrape` to have a list of accepted formats
-  - xan_script: Path to a xan script. Ignore it if an expression is provided in `params.expression`
+  - xan_script: Path to a xan script. Avoid it if an expression is provided in `params.expression`
 output:
   - Path to output table, report, etc. See `xan to`, `xan matrix`, `xan network` to have a list of accepted formats
 params:
   - extra: Optional parameter besides `-f | --file`
-  - expression: Expression for xan pipeline. Ignore it if a script is provided in `input.xan_script`
+  - expression: Expression for xan pipeline. Avoid it if a script is provided in `input.xan_script`
 notes: |
   Use `xan help functions` and `xan help cheatsheet` to see examples of pipelines and
   expressions avilable in this wrapper.
+
+  Parameters `input.xan_script` and `params.expression` are mutually exclusive.

--- a/utils/xan/run/meta.yaml
+++ b/utils/xan/run/meta.yaml
@@ -1,0 +1,15 @@
+name: xan run
+url: https://github.com/medialab/xan
+description: Run the given xan pipeline or execute a xan script
+authors:
+  - Thibault Dayris
+input:
+  - Path to a table. See `xan input`,  `xan from` and `xan scrape` to have a list of accepted formats
+  - xan: Path to a xan script
+output:
+  - Path to output table, report, etc. See `xan to`, `xan matrix`, `xan network` to have a list of accepted formats
+params:
+  - extra: Optional parameter besides `-f | --file`
+notes: |
+  Use `xan help functions` and `xan help cheatsheet` to see examples of pipelines and
+  expressions avilable in this wrapper.

--- a/utils/xan/run/meta.yaml
+++ b/utils/xan/run/meta.yaml
@@ -12,7 +12,6 @@ params:
   - extra: Optional parameter besides `-f | --file`
   - expression: Expression for xan pipeline. Avoid it if a script is provided in `input.xan_script`
 notes: |
-  Use `xan help functions` and `xan help cheatsheet` to see examples of pipelines and
+  - Use `xan help functions` and `xan help cheatsheet` to see examples of pipelines and
   expressions avilable in this wrapper.
-
-  Parameters `input.xan_script` and `params.expression` are mutually exclusive.
+  - Parameters `input.xan_script` and `params.expression` are mutually exclusive.

--- a/utils/xan/run/meta.yaml
+++ b/utils/xan/run/meta.yaml
@@ -4,8 +4,8 @@ description: Run the given xan pipeline or execute a xan script
 authors:
   - Thibault Dayris
 input:
-  - Path to a table. See `xan input`,  `xan from` and `xan scrape` to have a list of accepted formats
-  - xan_script: Path to a xan script. Avoid it if an expression is provided in `params.expression`
+  - data: Path to a table. See `xan input`,  `xan from` and `xan scrape` to have a list of accepted formats
+  - script: Path to a xan script. Avoid it if an expression is provided in `params.expression`
 output:
   - Path to output table, report, etc. See `xan to`, `xan matrix`, `xan network` to have a list of accepted formats
 params:

--- a/utils/xan/run/meta.yaml
+++ b/utils/xan/run/meta.yaml
@@ -10,7 +10,7 @@ output:
   - Path to output table, report, etc. See `xan to`, `xan matrix`, `xan network` to have a list of accepted formats
 params:
   - extra: Optional parameter besides `-f | --file`
-  - expression: Expression for xan pipeline. Avoid it if a script is provided in `input.xan_script`
+  - expression: Expression for xan pipeline. Avoid it if a script is provided in `input.script`
 notes: |
   - Use `xan help functions` and `xan help cheatsheet` to see examples of pipelines and
   expressions avilable in this wrapper.

--- a/utils/xan/run/meta.yaml
+++ b/utils/xan/run/meta.yaml
@@ -14,4 +14,4 @@ params:
 notes: |
   - Use `xan help functions` and `xan help cheatsheet` to see examples of pipelines and
   expressions avilable in this wrapper.
-  - Parameters `input.xan_script` and `params.expression` are mutually exclusive.
+  - Parameters `input.script` and `params.expression` are mutually exclusive.

--- a/utils/xan/run/meta.yaml
+++ b/utils/xan/run/meta.yaml
@@ -4,13 +4,13 @@ description: Run the given xan pipeline or execute a xan script
 authors:
   - Thibault Dayris
 input:
-  - data: Path to a table. See `xan input`,  `xan from` and `xan scrape` to have a list of accepted formats
-  - script: Path to a xan script. Avoid it if an expression is provided in `params.expression`
+  - data: Path to a table (see `xan input`,  `xan from` and `xan scrape` for a list of accepted formats).
+  - script: Path to a xan script.
 output:
-  - Path to output table, report, etc. See `xan to`, `xan matrix`, `xan network` to have a list of accepted formats
+  - Path to output table, report, etc (see `xan to`, `xan matrix`, `xan network` for a list of accepted formats).
 params:
-  - extra: Optional parameter besides `-f | --file`
-  - expression: Expression for xan pipeline. Avoid it if a script is provided in `input.script`
+  - extra: Optional parameter (not `-f | --file`)
+  - expression: Expression for xan pipeline.
 notes: |
   - Use `xan help functions` and `xan help cheatsheet` to see examples of pipelines and
   expressions avilable in this wrapper.

--- a/utils/xan/run/test/Snakefile
+++ b/utils/xan/run/test/Snakefile
@@ -1,6 +1,6 @@
 rule test_xan_script:
     input:
-        "data.csv",
+        data="data.csv",
         # Path to xan script.
         # Provide it if and only if no expression is given in params
         xan_script="script.xan",
@@ -23,7 +23,7 @@ rule test_xan_expression:
         # Path to xan script.
         # Provide it if and only if no expression is given in params
         # xan="",
-        "data.csv",
+        data="data.csv",
     output:
         "processed_through_expression.csv",
     log:

--- a/utils/xan/run/test/Snakefile
+++ b/utils/xan/run/test/Snakefile
@@ -36,6 +36,3 @@ rule test_xan_expression:
         extra="",
     wrapper:
         "master/utils/xan/run"
-
-
-

--- a/utils/xan/run/test/Snakefile
+++ b/utils/xan/run/test/Snakefile
@@ -1,0 +1,41 @@
+rule test_xan_script:
+    input:
+        "data.csv",
+        # Path to xan script.
+        # Provide it if and only if no expression is given in params
+        xan_script="script.xan",
+    output:
+        "processed_through_script.csv",
+    log:
+        "test_xan_script.log",
+    threads: 1
+    params:
+        # xan pipelin expression,
+        # Provide it if and only if no script if given in input
+        # expression="",
+        extra="",
+    wrapper:
+        "master/utils/xan/run"
+
+
+rule test_xan_expression:
+    input:
+        # Path to xan script.
+        # Provide it if and only if no expression is given in params
+        # xan="",
+        "data.csv",
+    output:
+        "processed_through_expression.csv",
+    log:
+        "test_xan_expression.log",
+    threads: 1
+    params:
+        # xan pipelin expression,
+        # Provide it if and only if no script if given in input
+        expression="progress | groupby sample,pair 'sum(nb_read) as total_fragments'",
+        extra="",
+    wrapper:
+        "master/utils/xan/run"
+
+
+

--- a/utils/xan/run/test/Snakefile
+++ b/utils/xan/run/test/Snakefile
@@ -3,7 +3,7 @@ rule test_xan_script:
         data="data.csv",
         # Path to xan script.
         # Provide it if and only if no expression is given in params
-        xan_script="script.xan",
+        script="script.xan",
     output:
         "processed_through_script.csv",
     log:
@@ -22,7 +22,7 @@ rule test_xan_expression:
     input:
         # Path to xan script.
         # Provide it if and only if no expression is given in params
-        # xan="",
+        # script="",
         data="data.csv",
     output:
         "processed_through_expression.csv",

--- a/utils/xan/run/test/Snakefile
+++ b/utils/xan/run/test/Snakefile
@@ -31,7 +31,7 @@ rule test_xan_expression:
     threads: 1
     params:
         # xan pipelin expression,
-        # Provide it if and only if no script if given in input
+        # Provide it if, and only if, no script is given in input
         expression="progress | groupby sample,pair 'sum(nb_read) as total_fragments'",
         extra="",
     wrapper:

--- a/utils/xan/run/test/Snakefile
+++ b/utils/xan/run/test/Snakefile
@@ -1,8 +1,6 @@
 rule test_xan_script:
     input:
         data="data.csv",
-        # Path to xan script.
-        # Provide it if and only if no expression is given in params
         script="script.xan",
     output:
         "processed_through_script.csv",
@@ -10,8 +8,7 @@ rule test_xan_script:
         "test_xan_script.log",
     threads: 1
     params:
-        # xan pipelin expression,
-        # Provide it if and only if no script if given in input
+        # xan pipelin expression (only if no script given in input)
         # expression="",
         extra="",
     wrapper:
@@ -20,8 +17,7 @@ rule test_xan_script:
 
 rule test_xan_expression:
     input:
-        # Path to xan script.
-        # Provide it if and only if no expression is given in params
+        # Path to xan script (only if no expression given in params)
         # script="",
         data="data.csv",
     output:
@@ -30,8 +26,6 @@ rule test_xan_expression:
         "test_xan_expression.log",
     threads: 1
     params:
-        # xan pipelin expression,
-        # Provide it if, and only if, no script is given in input
         expression="progress | groupby sample,pair 'sum(nb_read) as total_fragments'",
         extra="",
     wrapper:

--- a/utils/xan/run/test/data.csv
+++ b/utils/xan/run/test/data.csv
@@ -1,0 +1,5 @@
+sample,pair,nb_read,date
+S1,R1,1275,yesterday
+S1,R2,1275,yesterday
+S1,R1,786,today
+S1,R2,786,today

--- a/utils/xan/run/test/expected/total_fragments.csv
+++ b/utils/xan/run/test/expected/total_fragments.csv
@@ -1,0 +1,3 @@
+sample,pair,total_fragments
+S1,R1,2061
+S1,R2,2061

--- a/utils/xan/run/test/expected/total_reads.csv
+++ b/utils/xan/run/test/expected/total_reads.csv
@@ -1,0 +1,2 @@
+sample,total_reads
+S1,4122

--- a/utils/xan/run/test/script.xan
+++ b/utils/xan/run/test/script.xan
@@ -1,0 +1,1 @@
+progress | groupby sample 'sum(nb_read) as total_reads'

--- a/utils/xan/run/wrapper.py
+++ b/utils/xan/run/wrapper.py
@@ -1,0 +1,23 @@
+# coding: utf-8
+
+"""This snakemake wrapper handle xan pipelines run"""
+
+from snakemake.shell import shell
+
+extra = snakemake.params.get("extra", "")
+log = snakemake.log_fmt_shell(stdout=False, stderr=True)
+
+script = snakemake.input.get("xan_script")
+if script:
+    extra += f" --file '{script}'"
+
+expression = snakemake.params.get("expression", "")
+if script and expression:
+    raise ValueError("Either provide a xan script, or a xan run expression. Not both.")
+elif not (script or expression):
+    raise ValueError("Please provide either a xan script or a xan run expression.")
+
+shell(
+    "xan run {extra} {expression:q} {snakemake.input[0]:q} "
+    "> {snakemake.output[0]:q} {log}"
+)

--- a/utils/xan/run/wrapper.py
+++ b/utils/xan/run/wrapper.py
@@ -7,7 +7,7 @@ from snakemake.shell import shell
 extra = snakemake.params.get("extra", "")
 log = snakemake.log_fmt_shell(stdout=False, stderr=True)
 
-script = snakemake.input.get("xan_script")
+script = snakemake.input.get("script")
 if script:
     extra += f" --file '{script}'"
 
@@ -18,6 +18,6 @@ elif not (script or expression):
     raise ValueError("Please provide either a xan script or a xan run expression.")
 
 shell(
-    "xan run {extra} {expression:q} {snakemake.input[0]:q} "
+    "xan run {extra} {expression:q} {snakemake.input.data:q} "
     "> {snakemake.output[0]:q} {log}"
 )


### PR DESCRIPTION
<!-- Ensure that the PR title follows conventional commit style (<type>: <description>)-->
<!-- Possible types are here: https://github.com/commitizen/conventional-commit-types/blob/master/index.json -->

<!-- Add a description of your PR here-->
This PR brings [`xan run`](https://github.com/medialab/xan) to the list of available wrappers.

### QC
<!-- Make sure that you can tick the boxes below. -->

* [X] I confirm that I have followed the [documentation for contributing to `snakemake-wrappers`](https://snakemake-wrappers.readthedocs.io/en/stable/contributing.html).

While the contributions guidelines are more extensive, please particularly ensure that:
* [x] `test.py` was updated to call any added or updated example rules in a `Snakefile`
* [x] `input:` and `output:` file paths in the rules can be chosen arbitrarily
* [x] wherever possible, command line arguments are inferred and set automatically (e.g. based on file extensions in `input:` or `output:`)
* [x] temporary files are either written to a unique hidden folder in the working directory, or (better) stored where the Python function `tempfile.gettempdir()` points to 
* [x] the `meta.yaml` contains a link to the documentation of the respective tool or command under `url:`
* [x] conda environments use a minimal amount of channels and packages, in recommended ordering


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a Snakemake wrapper for running Xan pipelines from either a script or inline expression.
  - Added support for configurable inputs, outputs, optional parameters, logging, and input validation.
  - Added a reproducible Conda environment pinned to Xan 0.60.0.
  - Added metadata and usage information for the Xan utility.

- **Tests**
  - Added coverage for running Xan scripts and inline expressions, including grouped read-count processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->