### PR TITLE
feat: add DotMatch CRISPR count wrapper

### DIFF
--- a/bio/dotmatch/crispr-count/environment.linux-64.pin.txt
+++ b/bio/dotmatch/crispr-count/environment.linux-64.pin.txt
@@ -1,0 +1,30 @@
+# This file may be used to create an environment using:
+# $ conda create --name <env> --file <this file>
+# platform: linux-64
+# created-by: mamba with CONDA_OVERRIDE_GLIBC=2.28
+@EXPLICIT
+https://conda.anaconda.org/conda-forge/noarch/python_abi-3.14-8_cp314.conda#ad6d2e9ac39751cc0529dd1566a26751a0bf2542adb0c232533d32e176e21db5
+https://conda.anaconda.org/conda-forge/noarch/tzdata-2026c-h151e31d_0.conda#b928c30ddcb0e3f544c6eade8352737e6e610e263276b90232db6a578ef899d8
+https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.7.22-hbd8a1cb_0.conda#0a0544cf95f64394fe4959286f5c71f5444ad58feb0602e53becb27448d24da6
+https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_3.conda#eb8a0db0aa570124f7d2a93d7c7f596e3390df5e047818d873baad32985fc736
+https://conda.anaconda.org/conda-forge/linux-64/libgomp-16.1.0-he0feb66_3.conda#5998d3e2ef3ffcae6cd794c87f12acdd7220e69f7685a8ccef3cd2c5f6252831
+https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_7.conda#47d682b9f6d6ec9eb1a6e6c3e75ea6273e899e78fb7fc59f81d39745009fbc60
+https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda#1dd3fffd892081df9726d7eb7e0dea6198962ba775bd88842135a4ddb4deb3c9
+https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.46.1-default_hbd61a6d_102.conda#27d83f1188cd19bcb7754a078b3fa7f4cfb8527f8eb2fde54dd01fc529d1adec
+https://conda.anaconda.org/conda-forge/linux-64/libgcc-16.1.0-ha9f2e26_3.conda#af35751596409fc1a1a81a32b7f1e195bca7f648dfe7c64f8ec4848b3a5003f8
+https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-16.1.0-h934c35e_3.conda#6e98c0283244b5f8bbc0e86f7cba4d4921136bfbabf8da42b898a7a1f10be949
+https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h1df4ec4_4.conda#a1a241d172c1ccab067ba245206dd048bc3c2d1b84504b53c9468e99adfc16a1
+https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.3-h35e630c_1.conda#012096056b97abf1f68c46b7146bd2cbd68c1be762340b4f5dad4fbbe99177bc
+https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.6-hdb14827_1.conda#5d46557214ed184381dafe835b7c94a474a1c3b307a08a250b1ea4779b44ffb3
+https://conda.anaconda.org/conda-forge/linux-64/libmpdec-4.0.0-hb03c661_2.conda#46820b4a835e175940ae20bec00fdddaff804cda27a1408ab1b95e77a2196437
+https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.3-hb03c661_1.conda#9787df8c22a59c9a70d3e5a10db9ad663485e75e9ccc3f09bd092cb7b95e0dab
+https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.8.1-hecca717_1.conda#16feffd9ddbbe5b718515d38ee376c685ba95491cd901244e24671d20b952a77
+https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_10.conda#1a0d382c515ebf55f8ee1f38c8b81bc95af5c2acc42ad53b66bc5df932032f96
+https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.42.2-h5347b49_0.conda#9b1bdce27a7e31f7d241aeecff67a1f3101d52a2b1e33ccc2cdf2613072bf81f
+https://conda.anaconda.org/conda-forge/linux-64/libffi-3.7.0-h3435931_0.conda#ac38603008bf1e99b8ed379b1a656a67a70e2841f2b6a069c630cdf6316012d2
+https://conda.anaconda.org/conda-forge/linux-64/icu-78.3-py310h44b86e0_2.conda#9f07834f0c546ab14d885ce0366285f61f44e326c0edd1fc63b8294e113ae432
+https://conda.anaconda.org/conda-forge/linux-64/readline-8.3-hd6e31c0_1.conda#01b3fe073a66e321970d09e04b388708f8cbdca5cdfbfcb7c9eeb470ad10383d
+https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.53.4-h13e7031_1.conda#f20d70da54e5b31dd4a51fb1efeaafafd5ab6dd8d7ac9d1438eaa2526ac4ed3d
+https://conda.anaconda.org/conda-forge/linux-64/python-3.14.7-h399a421_100_cp314.conda#ee59fa05898243b9a068476f4bed9461abef4487ebcdc094f569c4c47dc4a732
+https://conda.anaconda.org/conda-forge/noarch/pip-26.2.1-pyh145f28c_0.conda#0f7021cfb3ff454c91a5e28e1f5060906a52c6d1cde3f879a7d03ac33c28b1c3
+https://conda.anaconda.org/bioconda/linux-64/dotmatch-0.2.2-py314h118bc1c_0.conda#d40a6f01fffaa99a4d78c4dfca4352af5737f3a94760dbb36951a62d4516263f

--- a/bio/dotmatch/crispr-count/environment.yaml
+++ b/bio/dotmatch/crispr-count/environment.yaml
@@ -1,0 +1,6 @@
+channels:
+  - conda-forge
+  - bioconda
+  - nodefaults
+dependencies:
+  - dotmatch =0.2.2

--- a/bio/dotmatch/crispr-count/meta.yaml
+++ b/bio/dotmatch/crispr-count/meta.yaml
@@ -13,22 +13,6 @@ output:
   - counts: MAGeCK-compatible guide count matrix.
   - summary: Optional run summary JSON.
   - sample_qc: Optional per-sample QC TSV.
-params:
-  - guide_start: Zero-based guide window start in each read.
-  - guide_length: Guide window length.
-  - k: Maximum correction radius.
-  - metric: hamming or levenshtein distance.
-  - ambiguity_policy: radius or best assignment policy.
-  - ambiguous: discard or include ambiguous counts.
-  - indel_window: Optional extraction slack for levenshtein indel rescue.
-  - extra: Optional additional DotMatch arguments.
 notes: |
   * Audit the guide library before using a correction radius greater than zero.
-  * The `extra` param can be used for options such as `--hamming-index` or
-    `--no-progress`.
-channels:
-  - conda-forge
-  - bioconda
-  - nodefaults
-dependencies:
-  - dotmatch =0.2.2
+  * The `extra` param allows for additional DotMatch arguments.

--- a/bio/dotmatch/crispr-count/meta.yaml
+++ b/bio/dotmatch/crispr-count/meta.yaml
@@ -1,0 +1,34 @@
+name: "DotMatch CRISPR count"
+description: |
+  Count known CRISPR guide sequences in FASTQ samples with deterministic
+  fixed-window assignment. The wrapper emits a MAGeCK-compatible count matrix
+  and optional run and sample QC tables.
+url: https://github.com/dnncha/dotmatch
+authors:
+  - Donncha O'Toole
+input:
+  - library: Guide library CSV or TSV with guide identifiers, sequences, and optional genes.
+  - samples: Sample sheet CSV or TSV with sample identifiers and FASTQ paths.
+output:
+  - counts: MAGeCK-compatible guide count matrix.
+  - summary: Optional run summary JSON.
+  - sample_qc: Optional per-sample QC TSV.
+params:
+  - guide_start: Zero-based guide window start in each read.
+  - guide_length: Guide window length.
+  - k: Maximum correction radius.
+  - metric: hamming or levenshtein distance.
+  - ambiguity_policy: radius or best assignment policy.
+  - ambiguous: discard or include ambiguous counts.
+  - indel_window: Optional extraction slack for levenshtein indel rescue.
+  - extra: Optional additional DotMatch arguments.
+notes: |
+  * Audit the guide library before using a correction radius greater than zero.
+  * The `extra` param can be used for options such as `--hamming-index` or
+    `--no-progress`.
+channels:
+  - conda-forge
+  - bioconda
+  - nodefaults
+dependencies:
+  - dotmatch =0.2.2

--- a/bio/dotmatch/crispr-count/meta.yaml
+++ b/bio/dotmatch/crispr-count/meta.yaml
@@ -13,6 +13,7 @@ output:
   - counts: MAGeCK-compatible guide count matrix.
   - summary: Optional run summary JSON.
   - sample_qc: Optional per-sample QC TSV.
+params:
+  - extra: additional DotMatch arguments
 notes: |
   * Audit the guide library before using a correction radius greater than zero.
-  * The `extra` param allows for additional DotMatch arguments.

--- a/bio/dotmatch/crispr-count/test/Snakefile
+++ b/bio/dotmatch/crispr-count/test/Snakefile
@@ -10,13 +10,6 @@ rule dotmatch_crispr_count:
         "dotmatch.log",
     threads: 1
     params:
-        extra=(
-            "--guide-start 0 "
-            "--guide-length 4 "
-            "--k 0 "
-            "--metric hamming "
-            "--ambiguity-policy radius "
-            "--ambiguous discard"
-        ),
+        extra="--guide-start 0 --guide-length 4 --k 0 --metric hamming --ambiguity-policy radius --ambiguous discard",
     wrapper:
         "master/bio/dotmatch/crispr-count"

--- a/bio/dotmatch/crispr-count/test/Snakefile
+++ b/bio/dotmatch/crispr-count/test/Snakefile
@@ -1,0 +1,20 @@
+rule dotmatch_crispr_count:
+    input:
+        library="guides.csv",
+        samples="samples.tsv",
+    output:
+        counts="counts.mageck.tsv",
+        summary="summary.json",
+        sample_qc="sample_qc.tsv",
+    log:
+        "dotmatch.log",
+    threads: 1
+    params:
+        guide_start=0,
+        guide_length=4,
+        k=0,
+        metric="hamming",
+        ambiguity_policy="radius",
+        ambiguous="discard",
+    wrapper:
+        "master/bio/dotmatch/crispr-count"

--- a/bio/dotmatch/crispr-count/test/Snakefile
+++ b/bio/dotmatch/crispr-count/test/Snakefile
@@ -10,11 +10,13 @@ rule dotmatch_crispr_count:
         "dotmatch.log",
     threads: 1
     params:
-        guide_start=0,
-        guide_length=4,
-        k=0,
-        metric="hamming",
-        ambiguity_policy="radius",
-        ambiguous="discard",
+        extra=(
+            "--guide-start 0 "
+            "--guide-length 4 "
+            "--k 0 "
+            "--metric hamming "
+            "--ambiguity-policy radius "
+            "--ambiguous discard"
+        ),
     wrapper:
         "master/bio/dotmatch/crispr-count"

--- a/bio/dotmatch/crispr-count/test/expected_counts.mageck.tsv
+++ b/bio/dotmatch/crispr-count/test/expected_counts.mageck.tsv
@@ -1,0 +1,3 @@
+sgRNA	Gene	sample_a
+guide_a	GENE_A	1
+guide_b	GENE_B	1

--- a/bio/dotmatch/crispr-count/test/guides.csv
+++ b/bio/dotmatch/crispr-count/test/guides.csv
@@ -1,0 +1,3 @@
+id,gRNA.sequence,Gene
+guide_a,ACGT,GENE_A
+guide_b,TGCA,GENE_B

--- a/bio/dotmatch/crispr-count/test/reads/sample_a.fastq
+++ b/bio/dotmatch/crispr-count/test/reads/sample_a.fastq
@@ -1,0 +1,12 @@
+@read_a
+ACGT
++
+IIII
+@read_b
+TGCA
++
+IIII
+@read_none
+CCCC
++
+IIII

--- a/bio/dotmatch/crispr-count/test/samples.tsv
+++ b/bio/dotmatch/crispr-count/test/samples.tsv
@@ -1,0 +1,2 @@
+sample_id	fastq
+sample_a	reads/sample_a.fastq

--- a/bio/dotmatch/crispr-count/wrapper.py
+++ b/bio/dotmatch/crispr-count/wrapper.py
@@ -17,7 +17,8 @@ sample_qc = snakemake.output.get("sample_qc", "")
 if sample_qc:
     sample_qc = f"--sample-qc {quote(sample_qc)}"
 
-shell("dotmatch crispr-count "
+shell(
+    "dotmatch crispr-count "
     "--library {snakemake.input.library:q} "
     "--samples {snakemake.input.samples:q} "
     "--threads {snakemake.threads} "

--- a/bio/dotmatch/crispr-count/wrapper.py
+++ b/bio/dotmatch/crispr-count/wrapper.py
@@ -18,13 +18,12 @@ sample_qc = snakemake.output.get("sample_qc")
 if sample_qc:
     sample_qc = f"--sample-qc {quote(sample_qc)}"
 
-shell(
-    "(dotmatch crispr-count "
+shell("dotmatch crispr-count "
     "--library {snakemake.input.library:q} "
     "--samples {snakemake.input.samples:q} "
     "--threads {snakemake.threads} "
     "--out {snakemake.output.counts:q} "
     "{summary} "
     "{sample_qc} "
-    "{extra}) {log}"
+    "{extra} {log}"
 )

--- a/bio/dotmatch/crispr-count/wrapper.py
+++ b/bio/dotmatch/crispr-count/wrapper.py
@@ -4,7 +4,6 @@ __author__ = "Donncha O'Toole"
 __license__ = "MIT"
 
 from shlex import quote
-
 from snakemake.shell import shell
 
 extra = snakemake.params.get("extra", "")

--- a/bio/dotmatch/crispr-count/wrapper.py
+++ b/bio/dotmatch/crispr-count/wrapper.py
@@ -25,5 +25,6 @@ shell("dotmatch crispr-count "
     "--out {snakemake.output.counts:q} "
     "{summary} "
     "{sample_qc} "
-    "{extra} {log}"
+    "{extra}"
+    " {log}"
 )

--- a/bio/dotmatch/crispr-count/wrapper.py
+++ b/bio/dotmatch/crispr-count/wrapper.py
@@ -9,11 +9,11 @@ from snakemake.shell import shell
 extra = snakemake.params.get("extra", "")
 log = snakemake.log_fmt_shell(stdout=False, stderr=True)
 
-summary = snakemake.output.get("summary")
+summary = snakemake.output.get("summary", "")
 if summary:
     summary = f"--summary {quote(summary)}"
 
-sample_qc = snakemake.output.get("sample_qc")
+sample_qc = snakemake.output.get("sample_qc", "")
 if sample_qc:
     sample_qc = f"--sample-qc {quote(sample_qc)}"
 

--- a/bio/dotmatch/crispr-count/wrapper.py
+++ b/bio/dotmatch/crispr-count/wrapper.py
@@ -8,7 +8,6 @@ from shlex import quote
 from snakemake.shell import shell
 
 extra = snakemake.params.get("extra", "")
-threads = snakemake.threads
 log = snakemake.log_fmt_shell(stdout=False, stderr=True)
 
 summary = snakemake.output.get("summary")
@@ -23,7 +22,7 @@ shell(
     "(dotmatch crispr-count "
     "--library {snakemake.input.library:q} "
     "--samples {snakemake.input.samples:q} "
-    "--threads {threads} "
+    "--threads {snakemake.threads} "
     "--out {snakemake.output.counts:q} "
     "{summary} "
     "{sample_qc} "

--- a/bio/dotmatch/crispr-count/wrapper.py
+++ b/bio/dotmatch/crispr-count/wrapper.py
@@ -11,15 +11,13 @@ extra = snakemake.params.get("extra", "")
 threads = snakemake.threads
 log = snakemake.log_fmt_shell(stdout=False, stderr=True)
 
-summary_arg = ""
 summary = snakemake.output.get("summary")
 if summary:
-    summary_arg = f"--summary {quote(summary)}"
+    summary = f"--summary {quote(summary)}"
 
-sample_qc_arg = ""
 sample_qc = snakemake.output.get("sample_qc")
 if sample_qc:
-    sample_qc_arg = f"--sample-qc {quote(sample_qc)}"
+    sample_qc = f"--sample-qc {quote(sample_qc)}"
 
 shell(
     "(dotmatch crispr-count "
@@ -27,7 +25,7 @@ shell(
     "--samples {snakemake.input.samples:q} "
     "--threads {threads} "
     "--out {snakemake.output.counts:q} "
-    "{summary_arg} "
-    "{sample_qc_arg} "
+    "{summary} "
+    "{sample_qc} "
     "{extra}) {log}"
 )

--- a/bio/dotmatch/crispr-count/wrapper.py
+++ b/bio/dotmatch/crispr-count/wrapper.py
@@ -8,19 +8,8 @@ from shlex import quote
 from snakemake.shell import shell
 
 extra = snakemake.params.get("extra", "")
-guide_start = snakemake.params.guide_start
-guide_length = snakemake.params.guide_length
-k = snakemake.params.get("k", 1)
-metric = snakemake.params.get("metric", "hamming")
-ambiguity_policy = snakemake.params.get("ambiguity_policy", "radius")
-ambiguous = snakemake.params.get("ambiguous", "discard")
 threads = snakemake.threads
 log = snakemake.log_fmt_shell(stdout=False, stderr=True)
-
-indel_window = snakemake.params.get("indel_window")
-indel_window_arg = ""
-if indel_window is not None:
-    indel_window_arg = f"--indel-window {indel_window}"
 
 summary_arg = ""
 summary = snakemake.output.get("summary")
@@ -36,16 +25,9 @@ shell(
     "(dotmatch crispr-count "
     "--library {snakemake.input.library:q} "
     "--samples {snakemake.input.samples:q} "
-    "--guide-start {guide_start} "
-    "--guide-length {guide_length} "
-    "--k {k} "
-    "--metric {metric} "
-    "--ambiguity-policy {ambiguity_policy} "
-    "--ambiguous {ambiguous} "
     "--threads {threads} "
     "--out {snakemake.output.counts:q} "
     "{summary_arg} "
     "{sample_qc_arg} "
-    "{indel_window_arg} "
     "{extra}) {log}"
 )

--- a/bio/dotmatch/crispr-count/wrapper.py
+++ b/bio/dotmatch/crispr-count/wrapper.py
@@ -1,0 +1,51 @@
+"""Snakemake wrapper for DotMatch CRISPR guide counting."""
+
+__author__ = "Donncha O'Toole"
+__license__ = "MIT"
+
+from shlex import quote
+
+from snakemake.shell import shell
+
+extra = snakemake.params.get("extra", "")
+guide_start = snakemake.params.guide_start
+guide_length = snakemake.params.guide_length
+k = snakemake.params.get("k", 1)
+metric = snakemake.params.get("metric", "hamming")
+ambiguity_policy = snakemake.params.get("ambiguity_policy", "radius")
+ambiguous = snakemake.params.get("ambiguous", "discard")
+threads = snakemake.threads
+log = snakemake.log_fmt_shell(stdout=False, stderr=True)
+
+indel_window = snakemake.params.get("indel_window")
+indel_window_arg = ""
+if indel_window is not None:
+    indel_window_arg = f"--indel-window {indel_window}"
+
+summary_arg = ""
+summary = snakemake.output.get("summary")
+if summary:
+    summary_arg = f"--summary {quote(summary)}"
+
+sample_qc_arg = ""
+sample_qc = snakemake.output.get("sample_qc")
+if sample_qc:
+    sample_qc_arg = f"--sample-qc {quote(sample_qc)}"
+
+shell(
+    "(dotmatch crispr-count "
+    "--library {snakemake.input.library:q} "
+    "--samples {snakemake.input.samples:q} "
+    "--guide-start {guide_start} "
+    "--guide-length {guide_length} "
+    "--k {k} "
+    "--metric {metric} "
+    "--ambiguity-policy {ambiguity_policy} "
+    "--ambiguous {ambiguous} "
+    "--threads {threads} "
+    "--out {snakemake.output.counts:q} "
+    "{summary_arg} "
+    "{sample_qc_arg} "
+    "{indel_window_arg} "
+    "{extra}) {log}"
+)

--- a/test_wrappers.py
+++ b/test_wrappers.py
@@ -2803,6 +2803,13 @@ def test_mageck_test(run):
     )
 
 
+def test_dotmatch_crispr_count(run):
+    run(
+        "bio/dotmatch/crispr-count",
+        ["snakemake", "counts.mageck.tsv"],
+    )
+
+
 def test_mageck_flute_rra(run):
     run(
         "bio/mageckflute/fluterra",

--- a/test_wrappers.py
+++ b/test_wrappers.py
@@ -2807,6 +2807,9 @@ def test_dotmatch_crispr_count(run):
     run(
         "bio/dotmatch/crispr-count",
         ["snakemake", "counts.mageck.tsv"],
+        compare_results_with_expected={
+            "counts.mageck.tsv": "expected_counts.mageck.tsv",
+        },
     )
 
 


### PR DESCRIPTION
## Purpose

Add a reusable Snakemake wrapper for the DotMatch `crispr-count` command. It accepts a guide library and sample sheet, emits a MAGeCK-compatible count matrix, and optionally writes run and per-sample QC summaries.

## Included

- wrapper implementation with explicit guide-window, distance, ambiguity, threading, and optional indel settings;
- Conda environment pinned to `dotmatch=0.2.2`;
- minimal fixture and wrapper test;
- metadata and documentation fields for the wrapper catalogue.

## Validation

- `snakemake --lint` passed;
- Black and Snakefmt checks passed;
- local Conda-backed Snakemake execution passed with the three-read fixture and produced the expected two guide counts.

This contribution exposes the existing public DotMatch package to Snakemake workflows; it does not claim downstream adoption.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added DotMatch support for CRISPR guide-counting workflows.
  - Produces count tables, optional summaries, and sample quality-control results.
  - Added reproducible Conda environment configuration with pinned tool versions.
  - Supports configurable threading, logging, and additional command options.

- **Bug Fixes**
  - Improved handling of matching and ambiguity options during workflow execution.

- **Tests**
  - Added an end-to-end test using representative sequencing reads and expected count output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->