### PR TITLE
perf: update fastaguard to 0.7.0

### DIFF
--- a/bio/fastaguard/environment.linux-64.pin.txt
+++ b/bio/fastaguard/environment.linux-64.pin.txt
@@ -1,9 +1,9 @@
 # This file may be used to create an environment using:
 # $ conda create --name <env> --file <this file>
 # platform: linux-64
-# created-by: conda 24.9.2
+# created-by: conda 26.3.2
 @EXPLICIT
-https://conda.anaconda.org/conda-forge/linux-64/libgomp-16.1.0-he0feb66_1.conda#88f2d91cb1533194c323534253094d23
+https://conda.anaconda.org/conda-forge/linux-64/libgomp-16.1.0-he0feb66_3.conda#593dc8ed1ed687d4ffff6b8d2fce9d9f
 https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda#a9f577daf3de00bca7c3c76c0ecbd1de
-https://conda.anaconda.org/conda-forge/linux-64/libgcc-16.1.0-ha9f2e26_1.conda#5a7d954665c707c93311657cd779c705
-https://conda.anaconda.org/bioconda/linux-64/fastaguard-0.6.0-hfa8f182_0.conda#d19a3733e08a394af1921501c9dbccad
+https://conda.anaconda.org/conda-forge/linux-64/libgcc-16.1.0-ha9f2e26_3.conda#c471b242d299f8bc1e2b3e0f6e9f4b77
+https://conda.anaconda.org/bioconda/linux-64/fastaguard-0.7.0-hfa8f182_0.conda#350e5bdc2240744ac9d1fb007c5c2f05

--- a/bio/fastaguard/environment.yaml
+++ b/bio/fastaguard/environment.yaml
@@ -3,4 +3,4 @@ channels:
   - bioconda
   - nodefaults
 dependencies:
-  - fastaguard =0.6.0
+  - fastaguard =0.7.0


### PR DESCRIPTION
Updates FastaGuard from 0.6.0 to 0.7.0 and refreshes the generated Linux pin. The wrapper command, four report outputs, parameters, and conventional exit behaviour remain unchanged.

### QC

* [x] I confirm that I have followed the contribution documentation.
* [x] The existing wrapper test exercises all four example rules; no test change was needed.
* [x] Input and output paths remain user-defined.
* [x] Arguments continue to use the named input and outputs, with optional `extra` parameters.
* [x] The wrapper creates no temporary files.
* [x] The existing metadata documentation link remains valid.
* [x] The Conda environment keeps the recommended channel order and one package dependency.

Testing:

* `pytest -v test_wrappers.py -k fastaguard`
* `snakemake --lint --snakefile bio/fastaguard/test/Snakefile`
* Black and Snakefmt checks
* Direct installation of the generated Linux pin reports `fastaguard 0.7.0`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the FastAGuard environment to version 0.7.0.
  * Refreshed related runtime package builds and environment metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->